### PR TITLE
Gimpact-based trimesh heightfield implementation

### DIFF
--- a/core/src/main/java/org/ode4j/ode/DContactGeom.java
+++ b/core/src/main/java/org/ode4j/ode/DContactGeom.java
@@ -41,10 +41,6 @@ import org.ode4j.math.DVector3;
  */
 public class DContactGeom {
 	
-	DContactGeom() {
-		// Non-public
-	}
-	
 	/** contact position */
 	public final DVector3 pos = new DVector3();          
     /** normal vector */

--- a/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshCCylinder.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshCCylinder.java
@@ -24,6 +24,9 @@
  *************************************************************************/
 package org.ode4j.ode.internal;
 
+import java.util.Arrays;
+import java.util.Comparator;
+
 import org.ode4j.math.DMatrix3C;
 import org.ode4j.math.DVector3C;
 import org.ode4j.ode.DColliderFn;
@@ -1221,6 +1224,12 @@ public class CollideTrimeshCCylinder implements DColliderFn {
 		int contactmax = (flags & DxGeom.NUMC_MASK);
 		if (contactcount > contactmax)
 		{
+			Arrays.sort((Object[])trimeshcontacts.GIM_DYNARRAY_POINTER(), 0, contactcount, new Comparator<Object>() {
+				@Override
+				public int compare(Object o1, Object o2) {
+					return Float.compare(((GimContact) o2).getDepth(), ((GimContact) o1).getDepth());
+				}
+			});
 			contactcount = contactmax;
 		}
 

--- a/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshPlane.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshPlane.java
@@ -24,6 +24,9 @@
  *************************************************************************/
 package org.ode4j.ode.internal;
 
+import java.util.Arrays;
+import java.util.Comparator;
+
 import org.ode4j.math.DVector4;
 import org.ode4j.ode.DColliderFn;
 import org.ode4j.ode.DContactGeom;
@@ -197,6 +200,12 @@ public class CollideTrimeshPlane implements DColliderFn {
 		int contactmax = (flags & DxGeom.NUMC_MASK);
 		if (contactcount > contactmax)
 		{
+			Arrays.sort((Object[])collision_result.GIM_DYNARRAY_POINTER(), 0, contactcount, new Comparator<Object>() {
+				@Override
+				public int compare(Object o1, Object o2) {
+					return Float.compare(((vec4f) o2).f[3], ((vec4f) o1).f[3]);
+				}
+			});
 			contactcount = contactmax;
 		}
 

--- a/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshSphere.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshSphere.java
@@ -24,6 +24,9 @@
  *************************************************************************/
 package org.ode4j.ode.internal;
 
+import java.util.Arrays;
+import java.util.Comparator;
+
 import org.ode4j.math.DVector3C;
 import org.ode4j.ode.DColliderFn;
 import org.ode4j.ode.DContactGeom;
@@ -572,6 +575,12 @@ public class CollideTrimeshSphere implements DColliderFn {
 		int maxcontacts = (Flags & DxGeom.NUMC_MASK);
 		if (contactcount > maxcontacts)
 		{
+			Arrays.sort((Object[])trimeshcontacts.GIM_DYNARRAY_POINTER(), 0, contactcount, new Comparator<Object>() {
+				@Override
+				public int compare(Object o1, Object o2) {
+					return Float.compare(((GimContact) o2).getDepth(), ((GimContact) o1).getDepth());
+				}
+			});
 			contactcount = maxcontacts;
 		}
 

--- a/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshTrimesh.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshTrimesh.java
@@ -24,6 +24,9 @@
  *************************************************************************/
 package org.ode4j.ode.internal;
 
+import java.util.Arrays;
+import java.util.Comparator;
+
 import org.ode4j.ode.DColliderFn;
 import org.ode4j.ode.DContactGeom;
 import org.ode4j.ode.DContactGeomBuffer;
@@ -82,6 +85,12 @@ public class CollideTrimeshTrimesh implements DColliderFn {
 		int maxcontacts = Flags & DxGeom.NUMC_MASK;
 		if (contactcount > maxcontacts)
 		{
+			Arrays.sort((Object[])trimeshcontacts.GIM_DYNARRAY_POINTER(), 0, contactcount, new Comparator<Object>() {
+				@Override
+				public int compare(Object o1, Object o2) {
+					return Float.compare(((GimContact) o2).getDepth(), ((GimContact) o1).getDepth());
+				}
+			});
 			contactcount = maxcontacts;
 		}
 

--- a/core/src/main/java/org/ode4j/ode/internal/DxAbstractHeightfield.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxAbstractHeightfield.java
@@ -1,0 +1,42 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal;
+
+import org.ode4j.ode.DContactGeomBuffer;
+import org.ode4j.ode.DHeightfield;
+
+public abstract class DxAbstractHeightfield extends DxGeom implements DHeightfield {
+
+	//dxHeightfieldData* m_p_data;
+	protected DxHeightfieldData m_p_data;
+
+	protected DxAbstractHeightfield(DxSpace space, boolean isPlaceable) {
+		super(space, isPlaceable);
+	}
+
+	abstract int dCollideHeightfieldZone(int nMinX, int nMaxX, int nMinZ, int nMaxZ, DxGeom o2, int i, int flags,
+			DContactGeomBuffer createView, int skip);
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/DxHeightfield.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxHeightfield.java
@@ -42,7 +42,6 @@ import org.ode4j.ode.DColliderFn;
 import org.ode4j.ode.DContactGeom;
 import org.ode4j.ode.DContactGeomBuffer;
 import org.ode4j.ode.DGeom;
-import org.ode4j.ode.DHeightfield;
 import org.ode4j.ode.DHeightfieldData;
 import org.ode4j.ode.internal.cpp4j.java.ObjArray;
 
@@ -50,7 +49,7 @@ import org.ode4j.ode.internal.cpp4j.java.ObjArray;
  *
  * @author Tilmann Zaeschke
  */
-public class DxHeightfield extends DxGeom implements DHeightfield {
+public class DxHeightfield extends DxAbstractHeightfield {
 
 	static final int HEIGHTFIELDMAXCONTACTPERCELL = 10;
 
@@ -130,8 +129,6 @@ public class DxHeightfield extends DxGeom implements DHeightfield {
 
 	////////dxHeightfield /////////////////////////////////////////////////////////////////
 
-	//dxHeightfieldData* m_p_data;
-	private DxHeightfieldData m_p_data;
 
 	//	    dxHeightfield( dSpaceID space, dHeightfieldDataID data, int bPlaceable );
 	//	    ~dxHeightfield();
@@ -1476,7 +1473,7 @@ public class DxHeightfield extends DxGeom implements DHeightfield {
 	}
 
 	static class CollideHeightfield implements DColliderFn {
-		int dCollideHeightfield( DxHeightfield o1, DxGeom o2, int flags, DContactGeomBuffer contacts, int skip )
+		int dCollideHeightfield( DxAbstractHeightfield o1, DxGeom o2, int flags, DContactGeomBuffer contacts, int skip )
 		{
 			dIASSERT( skip >= 1);//(int)sizeof(dContactGeom) );
 			//dIASSERT( o1.type == dHeightfieldClass );
@@ -1489,7 +1486,7 @@ public class DxHeightfield extends DxGeom implements DHeightfield {
 
 			int numMaxTerrainContacts = (flags & NUMC_MASK);
 
-			DxHeightfield terrain = o1;
+			DxAbstractHeightfield terrain = o1;
 
 			DVector3 posbak = new DVector3();
 			DMatrix3 Rbak = new DMatrix3();
@@ -1686,7 +1683,7 @@ public class DxHeightfield extends DxGeom implements DHeightfield {
 		@Override
 		public int dColliderFn(DGeom o1, DGeom o2, int flags,
 				DContactGeomBuffer contacts) {
-			return dCollideHeightfield((DxHeightfield)o1, (DxGeom)o2, flags, contacts, 1);
+			return dCollideHeightfield((DxAbstractHeightfield)o1, (DxGeom)o2, flags, contacts, 1);
 		}
 	}
 

--- a/core/src/main/java/org/ode4j/ode/internal/DxTrimeshHeightfield.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxTrimeshHeightfield.java
@@ -1,0 +1,819 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal;
+
+import static org.ode4j.ode.OdeConstants.dInfinity;
+import static org.ode4j.ode.OdeMath.dMultiply0_331;
+import static org.ode4j.ode.OdeMath.dMultiply1_331;
+import static org.ode4j.ode.OdeMath.dMultiply1_333;
+import static org.ode4j.ode.internal.Common.dCeil;
+import static org.ode4j.ode.internal.Common.dEpsilon;
+import static org.ode4j.ode.internal.Common.dFloor;
+import static org.ode4j.ode.internal.Common.dIASSERT;
+
+import org.ode4j.math.DMatrix3;
+import org.ode4j.math.DVector3;
+import org.ode4j.ode.DAABB;
+import org.ode4j.ode.DColliderFn;
+import org.ode4j.ode.DContactGeom;
+import org.ode4j.ode.DContactGeomBuffer;
+import org.ode4j.ode.DGeom;
+import org.ode4j.ode.DHeightfieldData;
+import org.ode4j.ode.DSpace;
+import org.ode4j.ode.internal.cpp4j.java.ObjArray;
+
+/**
+ *
+ * @author Tilmann Zaeschke
+ */
+public class DxTrimeshHeightfield extends DxAbstractHeightfield {
+
+    //#define dMIN(A,B)  ((A)>(B) ? (B) : (A))
+    private static final double dMIN(double A, double B) { return ((A)>(B) ? (B) : (A)); }
+    //#define dMAX(A,B)  ((A)>(B) ? (A) : (B))
+    private static final double dMAX(double A, double B) { return ((A)>(B) ? (A) : (B)); }
+    //
+    //
+    ////Three-way MIN and MAX
+    //#define dMIN3(A,B,C)  ( (A)<(B) ? dMIN((A),(C)) : dMIN((B),(C)) )
+    private final double dMIN3(double A, double B, double C) { return A<B ? dMIN(A,C) : dMIN(B,C); }
+    //#define dMAX3(A,B,C)  ( (A)>(B) ? dMAX((A),(C)) : dMAX((B),(C)) )
+    private final double dMAX3(double A, double B, double C) { return A>B ? dMAX(A,C) : dMAX(B,C); }
+    //
+    //#define dOPESIGN(a, op1, op2,b) \
+    //(a)[0] op1 op2 ((b)[0]); \
+    //(a)[1] op1 op2 ((b)[1]); \
+    //(a)[2] op1 op2 ((b)[2]);
+    //
+    //#define dGeomRaySetNoNormalize(myRay, MyPoint, MyVector) {  \
+    //\
+    //dVector3Copy (MyPoint, (myRay).final_posr.pos);   \
+    //(myRay).final_posr.R[2] = (MyVector)[0];       \
+    //(myRay).final_posr.R[6] = (MyVector)[1];       \
+    //(myRay).final_posr.R[10] = (MyVector)[2];      \
+    //dGeomMoved (&myRay);                        \
+    //        }
+
+
+
+    ////////Local Build Option ////////////////////////////////////////////////////
+
+    //Uncomment this #define to use the (0,0) corner of the geom as the origin,
+    //rather than the center. This was the way the original heightfield worked,
+    //but as it does not match the way all other geometries work, so for constancy it
+    //was changed to work like this.
+
+    //#define DHEIGHTFIELD_CORNER_ORIGIN
+    private static final boolean DHEIGHTFIELD_CORNER_ORIGIN = false;  //DO NOT ENABLE without uncommenting code!!
+
+
+    //Uncomment this #define to add heightfield triangles edge colliding
+    //Code is not guaranteed and I didn't find the need to add that as 
+    //colliding planes triangles and edge triangles seems enough.
+    //#define _HEIGHTFIELDEDGECOLLIDING
+    //private static final boolean _HEIGHTFIELDEDGECOLLIDING = false;  //DO NOT ENABLE without uncommenting code!!
+
+
+    ////////dxHeightfield /////////////////////////////////////////////////////////////////
+
+    //      dxHeightfield( dSpaceID space, dHeightfieldDataID data, int bPlaceable );
+    //      ~dxHeightfield();
+    //
+    //      void computeAABB();
+    //
+    //      int dCollideHeightfieldZone( const int minX, const int maxX, const int minZ, const int maxZ,  
+    //          dxGeom *o2, const int numMaxContacts,
+    //          int flags, dContactGeom *contact, int skip );
+
+    //      private enum TEMP
+    //      {
+    private static final int TEMP_HEIGHT_BUFFER_ELEMENT_COUNT_ALIGNMENT_X = 4;
+    private static final int TEMP_HEIGHT_BUFFER_ELEMENT_COUNT_ALIGNMENT_Z = 4;
+    private static final int TEMP_TRIANGLE_BUFFER_ELEMENT_COUNT_ALIGNMENT = 1; // Triangles are easy to reallocate and hard to predict
+    //      };
+
+    //static inline size_t AlignBufferSize(size_t value, size_t alignment) { dIASSERT((alignment & (alignment - 1)) == 0); return (value + (alignment - 1)) & ~(alignment - 1); }
+    private static int AlignBufferSize(int value, int alignment) { 
+        dIASSERT((alignment & (alignment - 1)) == 0); 
+        return (value + (alignment - 1)) & ~(alignment - 1); 
+    }
+
+
+    private HeightFieldTriangle[] tempTriangleBuffer;
+    private int              tempTriangleBufferSize;
+
+    //private HeightFieldVertex[]  tempHeightBuffer;
+    private ObjArray<HeightFieldVertex>[]  tempHeightBuffer;
+    private HeightFieldVertex[]   tempHeightInstances;
+    private int              tempHeightBufferSizeX;
+    private int              tempHeightBufferSizeZ;
+
+
+
+    // dxHeightfield constructor
+    public DxTrimeshHeightfield(DSpace space, DHeightfieldData data, boolean bPlaceable) {            //:
+        //      dxGeom( space, bPlaceable ),
+        //      tempPlaneBuffer(0),
+        //      tempPlaneInstances(0),
+        //      tempPlaneBufferSize(0),
+        //      tempTriangleBuffer(0),
+        //      tempTriangleBufferSize(0),
+        //      tempHeightBuffer(0),
+        //      tempHeightInstances(0),
+        //      tempHeightBufferSizeX(0),
+        //      tempHeightBufferSizeZ(0)
+        super( (DxSpace) space, bPlaceable );
+        tempTriangleBuffer = null;
+        tempTriangleBufferSize = 0;
+        tempHeightBuffer = null;
+        tempHeightInstances = null;
+        tempHeightBufferSizeX = 0;
+        tempHeightBufferSizeZ = 0;
+
+        type = dHeightfieldClass;
+        m_p_data = (DxHeightfieldData) data;
+    }
+
+
+    // compute axis aligned bounding box
+    @Override
+    void computeAABB()
+    {
+        final DxHeightfieldData d = m_p_data;
+
+        if ( d.m_bWrapMode == false )
+        {
+            // Finite
+            //if ( (_gflags & GEOM_PLACEABLE)!=0 )
+            if (hasFlagPlaceable())
+            {
+                double[] dx=new double[6], dy=new double[6], dz=new double[6];
+
+                // Y-axis
+                if (d.m_fMinHeight != -dInfinity)
+                {
+                    dy[0] = ( final_posr().R().get01() * d.m_fMinHeight );
+                    dy[1] = ( final_posr().R().get11() * d.m_fMinHeight );
+                    dy[2] = ( final_posr().R().get21() * d.m_fMinHeight );
+                } else {
+                    // Multiplication is performed to obtain infinity of correct sign
+                    dy[0] = ( final_posr().R().get01()!=0 ? final_posr().R().get01() * -dInfinity : (0.0) );
+                    dy[1] = ( final_posr().R().get11()!=0 ? final_posr().R().get11() * -dInfinity : (0.0) );
+                    dy[2] = ( final_posr().R().get21()!=0 ? final_posr().R().get21() * -dInfinity : (0.0) );
+                }
+
+                if (d.m_fMaxHeight != dInfinity)
+                {
+                dy[3] = ( final_posr().R().get01() * d.m_fMaxHeight );
+                dy[4] = ( final_posr().R().get11() * d.m_fMaxHeight );
+                dy[5] = ( final_posr().R().get21() * d.m_fMaxHeight );
+                } else {
+                    dy[3] = ( final_posr().R().get01()!=0 ? final_posr().R().get01() * dInfinity : (0.0) );
+                    dy[4] = ( final_posr().R().get11()!=0 ? final_posr().R().get11() * dInfinity : (0.0) );
+                    dy[5] = ( final_posr().R().get21()!=0 ? final_posr().R().get21() * dInfinity : (0.0) );
+                }
+
+
+                //  #ifdef DHEIGHTFIELD_CORNER_ORIGIN
+                //
+                //              // X-axis
+                //              dx[0] = 0;  dx[3] = ( _final_posr.R[ 0] * d.m_fWidth );
+                //              dx[1] = 0;  dx[4] = ( _final_posr.R[ 4] * d.m_fWidth );
+                //              dx[2] = 0;  dx[5] = ( _final_posr.R[ 8] * d.m_fWidth );
+                //
+                //              // Z-axis
+                //              dz[0] = 0;  dz[3] = ( _final_posr.R[ 2] * d.m_fDepth );
+                //              dz[1] = 0;  dz[4] = ( _final_posr.R[ 6] * d.m_fDepth );
+                //              dz[2] = 0;  dz[5] = ( _final_posr.R[10] * d.m_fDepth );
+                //
+                //  #else // DHEIGHTFIELD_CORNER_ORIGIN
+
+                // X-axis
+                dx[0] = ( final_posr().R().get00() * -d.m_fHalfWidth );
+                dx[1] = ( final_posr().R().get10() * -d.m_fHalfWidth );
+                dx[2] = ( final_posr().R().get20() * -d.m_fHalfWidth );
+                dx[3] = ( final_posr().R().get00() * d.m_fHalfWidth );
+                dx[4] = ( final_posr().R().get10() * d.m_fHalfWidth );
+                dx[5] = ( final_posr().R().get20() * d.m_fHalfWidth );
+
+                // Z-axis
+                dz[0] = ( final_posr().R().get02() * -d.m_fHalfDepth );
+                dz[1] = ( final_posr().R().get12() * -d.m_fHalfDepth );
+                dz[2] = ( final_posr().R().get22() * -d.m_fHalfDepth );
+                dz[3] = ( final_posr().R().get02() * d.m_fHalfDepth );
+                dz[4] = ( final_posr().R().get12() * d.m_fHalfDepth );
+                dz[5] = ( final_posr().R().get22() * d.m_fHalfDepth );
+
+                //  #endif // DHEIGHTFIELD_CORNER_ORIGIN
+
+                // X extents
+                _aabb.setMin0(final_posr().pos().get0() +
+                        dMIN3( dMIN( dx[0], dx[3] ), dMIN( dy[0], dy[3] ), dMIN( dz[0], dz[3] ) ) );
+                _aabb.setMax0(final_posr().pos().get0() +
+                        dMAX3( dMAX( dx[0], dx[3] ), dMAX( dy[0], dy[3] ), dMAX( dz[0], dz[3] ) ) );
+
+                // Y extents
+                _aabb.setMin1(final_posr().pos().get1() +
+                        dMIN3( dMIN( dx[1], dx[4] ), dMIN( dy[1], dy[4] ), dMIN( dz[1], dz[4] ) ) );
+                _aabb.setMax1(final_posr().pos().get1() +
+                        dMAX3( dMAX( dx[1], dx[4] ), dMAX( dy[1], dy[4] ), dMAX( dz[1], dz[4] ) ) );
+
+                // Z extents
+                _aabb.setMin2(final_posr().pos().get2() +
+                        dMIN3( dMIN( dx[2], dx[5] ), dMIN( dy[2], dy[5] ), dMIN( dz[2], dz[5] ) ) );
+                _aabb.setMax2(final_posr().pos().get2() +
+                        dMAX3( dMAX( dx[2], dx[5] ), dMAX( dy[2], dy[5] ), dMAX( dz[2], dz[5] ) ) );
+            }
+            else
+            {
+
+                //  #ifdef DHEIGHTFIELD_CORNER_ORIGIN
+                //
+                //              aabb[0] = 0;                    aabb[1] = d.m_fWidth;
+                //              aabb[2] = d.m_fMinHeight;       aabb[3] = d.m_fMaxHeight;
+                //              aabb[4] = 0;                    aabb[5] = d.m_fDepth;
+                //
+                //  #else // DHEIGHTFIELD_CORNER_ORIGIN
+
+                //              aabb[0] = -d.m_fHalfWidth;      aabb[1] = +d.m_fHalfWidth;
+                //              aabb[2] = d.m_fMinHeight;       aabb[3] = d.m_fMaxHeight;
+                //              aabb[4] = -d.m_fHalfDepth;      aabb[5] = +d.m_fHalfDepth;
+                _aabb.set(-d.m_fHalfWidth, +d.m_fHalfWidth,
+                        d.m_fMinHeight, d.m_fMaxHeight, 
+                        -d.m_fHalfDepth, +d.m_fHalfDepth);
+
+                //  #endif // DHEIGHTFIELD_CORNER_ORIGIN
+
+            }
+        }
+        else
+        {
+            // Infinite
+            //if ( (_gflags & GEOM_PLACEABLE)!=0 )
+            if (hasFlagPlaceable())
+            {
+                //              aabb[0] = -dInfinity;           aabb[1] = +dInfinity;
+                //              aabb[2] = -dInfinity;           aabb[3] = +dInfinity;
+                //              aabb[4] = -dInfinity;           aabb[5] = +dInfinity;
+                _aabb.set(-dInfinity, +dInfinity,
+                        -dInfinity, +dInfinity,
+                        -dInfinity, +dInfinity);
+
+            }
+            else
+            {
+                //              aabb[0] = -dInfinity;           aabb[1] = +dInfinity;
+                //              aabb[2] = d.m_fMinHeight;       aabb[3] = d.m_fMaxHeight;
+                //              aabb[4] = -dInfinity;           aabb[5] = +dInfinity;
+                _aabb.set(-dInfinity, +dInfinity,
+                        d.m_fMinHeight, d.m_fMaxHeight,
+                        -dInfinity, +dInfinity);
+            }
+        }
+
+    }
+
+
+    // dxHeightfield destructor
+    //dxHeightfield::~dxHeightfield()
+    @Override
+    public void DESTRUCTOR()
+    {
+        resetTriangleBuffer();
+        resetHeightBuffer();
+        super.DESTRUCTOR();
+    }
+
+    private void allocateTriangleBuffer(int numTri)
+    {
+        int alignedNumTri = AlignBufferSize(numTri, TEMP_TRIANGLE_BUFFER_ELEMENT_COUNT_ALIGNMENT);
+        tempTriangleBufferSize = alignedNumTri;
+        tempTriangleBuffer = new HeightFieldTriangle[alignedNumTri];
+        for (int i = 0; i < tempTriangleBuffer.length; i++) tempTriangleBuffer[i] = new HeightFieldTriangle();
+    }
+
+    private void resetTriangleBuffer()
+    {
+        //delete[] tempTriangleBuffer;
+        tempTriangleBuffer = null;
+        //TODO set size == 0? TZ
+    }
+
+    @SuppressWarnings("unchecked")
+    private void allocateHeightBuffer(int numX, int numZ)
+    {
+        int alignedNumX = AlignBufferSize(numX, TEMP_HEIGHT_BUFFER_ELEMENT_COUNT_ALIGNMENT_X);
+        int alignedNumZ = AlignBufferSize(numZ, TEMP_HEIGHT_BUFFER_ELEMENT_COUNT_ALIGNMENT_Z);
+        tempHeightBufferSizeX = alignedNumX;
+        tempHeightBufferSizeZ = alignedNumZ;
+        //tempHeightBuffer = new HeightFieldVertex *[alignedNumX];
+        tempHeightBuffer = new ObjArray[alignedNumX];
+        int numCells = alignedNumX * alignedNumZ;
+        tempHeightInstances = new HeightFieldVertex [numCells];
+        for (int i = 0; i < tempHeightInstances.length; i++) {
+            tempHeightInstances[i] = new HeightFieldVertex();
+        }
+
+        //HeightFieldVertex *ptrHeightMatrix = tempHeightInstances;
+        for (int indexX = 0; indexX != alignedNumX; indexX++)
+        {
+            //          tempHeightBuffer[indexX] = ptrHeightMatrix;
+            //          ptrHeightMatrix += alignedNumZ;
+            //tempHeightBuffer[indexX] = tempHeightInstances[indexX];
+            tempHeightBuffer[indexX] = new ObjArray<HeightFieldVertex>(tempHeightInstances, indexX*alignedNumZ);
+        }
+    }
+
+    void resetHeightBuffer()
+    {
+        //delete[] tempHeightInstances;
+        //delete[] tempHeightBuffer;
+        tempHeightInstances = null;
+        tempHeightBuffer = null;
+    }
+
+    //////// Heightfield geom interface ////////////////////////////////////////////////////
+
+    /**
+     * @param space 
+     * @param data 
+     * @param bPlaceable 
+     * @return New DHeightfield
+     */
+    public static DxTrimeshHeightfield dCreateHeightfield( DxSpace space, DxHeightfieldData data, boolean bPlaceable )
+    {
+        return new DxTrimeshHeightfield( space, data, bPlaceable );
+    }
+
+
+    //  void dGeomHeightfieldSetHeightfieldData( dGeom g, dHeightfieldData d )
+    void dGeomHeightfieldSetHeightfieldData( DHeightfieldData d )
+    {
+        //dxHeightfield* geom = (dxHeightfield*) g;
+        //TODO change type of m_p_data?
+        m_p_data = (DxHeightfieldData) d;
+    }
+
+
+    //  dHeightfieldData dGeomHeightfieldGetHeightfieldData( dGeom g )
+    DHeightfieldData dGeomHeightfieldGetHeightfieldData( )
+    {
+        //dxHeightfield* geom = (dxHeightfield*) g;
+        return m_p_data;
+    }
+
+    // from heightfield.h
+
+    //typedef int HeightFieldVertexCoords[2];
+
+    class HeightFieldVertex
+    {
+        //  public:
+        HeightFieldVertex(){};
+
+        DVector3 vertex = new DVector3();
+        //HeightFieldVertexCoords coords;
+        //int[] coords = new int[2]; //use c1 & c2 (TZ)
+        int coords0, coords1;
+    };
+
+    //TODO TZ not used
+//  private class HeightFieldEdge
+//  {
+//      //public:
+//      HeightFieldEdge(){};
+//
+//      //HeightFieldVertex   *vertices[2];
+//      HeightFieldVertex[]   vertices = new HeightFieldVertex[2];  //TODO v1/v1 (TZ)
+//  };
+
+    private class HeightFieldTriangle
+    {
+        //public:
+        HeightFieldTriangle(){};
+
+        //HeightFieldVertex   *vertices[3];
+        HeightFieldVertex[]   vertices = new HeightFieldVertex[3]; //TODO c1, c2, c3 (TZ)
+        //double[]               planeDef=new double[4];
+    };
+
+
+    //////// dxHeightfield /////////////////////////////////////////////////////////////////
+
+
+    //  int dxHeightfield::dCollideHeightfieldZone( final int minX, final int maxX, final int minZ, final int maxZ,
+    //            dxGeom* o2, final int numMaxContactsPossible,
+    //            int flags, dContactGeom* contact,
+    //            int skip )
+    int dCollideHeightfieldZone( final int minX, final int maxX, final int minZ, final int maxZ,
+            DxGeom o2, final int numMaxContactsPossible,
+            int flags, DContactGeomBuffer contacts,
+            int skip )
+    {
+        DContactGeom pContact = null;
+        int  x, z;
+        // check if not above or inside terrain first
+        // while filling a heightmap partial temporary buffer
+        //      final unsigned int numX = (maxX - minX) + 1;
+        //      final unsigned int numZ = (maxZ - minZ) + 1;
+        final int numX = (maxX - minX) + 1;
+        final int numZ = (maxZ - minZ) + 1;
+        final double minO2Height = o2._aabb.getMin1();
+        final double maxO2Height = o2._aabb.getMax1();
+        //unsigned 
+        int x_local, z_local;
+        double maxY = - dInfinity;
+        double minY = dInfinity;
+        // localize and final for faster access
+        final double cfSampleWidth = m_p_data.m_fSampleWidth;
+        final double cfSampleDepth = m_p_data.m_fSampleDepth;
+        {
+            if (tempHeightBufferSizeX < numX || tempHeightBufferSizeZ < numZ)
+            {
+                resetHeightBuffer();
+                allocateHeightBuffer(numX, numZ);
+            }
+
+            double Xpos, Ypos;
+
+            for ( x = minX, x_local = 0; x_local < numX; x++, x_local++)
+            {
+                Xpos = x * cfSampleWidth; // Always calculate pos via multiplication to avoid computational error accumulation during multiple additions
+
+                final double c_Xpos = Xpos;
+                //HeightFieldVertex HeightFieldRow = tempHeightBuffer[x_local];
+                //ObjArray<HeightFieldVertex> HeightFieldRow = new ObjArray<HeightFieldVertex>(tempHeightBuffer, x_local);
+                ObjArray<HeightFieldVertex> HeightFieldRow = tempHeightBuffer[x_local];
+                for ( z = minZ, z_local = 0; z_local < numZ; z++, z_local++)
+                {
+                    Ypos = z * cfSampleDepth; // Always calculate pos via multiplication to avoid computational error accumulation during multiple additions
+
+                    final double h = m_p_data.GetHeight(x, z);
+                    //                  HeightFieldRow.at(z_local).vertex[0] = c_Xpos;
+                    //                  HeightFieldRow.at(z_local).vertex[1] = h;
+                    //                  HeightFieldRow.at(z_local).vertex[2] = Ypos;
+                    HeightFieldRow.at(z_local).vertex.set( c_Xpos, h, Ypos);
+                    HeightFieldRow.at(z_local).coords0 = x;
+                    HeightFieldRow.at(z_local).coords1 = z;
+
+                    maxY = dMAX(maxY, h);
+                    minY = dMIN(minY, h);
+                }
+            }
+            if (minO2Height - maxY > -dEpsilon )
+            {
+                //totally above heightfield
+                return 0;
+            }
+            if (minY - maxO2Height > -dEpsilon )
+            {
+                // totally under heightfield
+                //pContact = CONTACT(contact, 0);
+                pContact = contacts.get(0); 
+                pContact.pos.set( o2.final_posr().pos().get0(), minY, o2.final_posr().pos().get2() );
+                pContact.normal.set( 0, -1, 0 );
+
+                pContact.depth =  minY - maxO2Height;
+
+                pContact.side1 = -1;
+                pContact.side2 = -1;
+
+                return 1;
+            }
+        }
+
+        int numTerrainContacts = 0;
+        //dContactGeom *PlaneContact = m_p_data.m_contacts;
+
+        //final unsigned 
+        final int numTriMax = (maxX - minX) * (maxZ - minZ) * 2;
+        if (tempTriangleBufferSize < numTriMax)
+        {
+            resetTriangleBuffer();
+            allocateTriangleBuffer(numTriMax);
+        }
+
+        // Sorting triangle/plane  resulting from heightfield zone
+        // Perhaps that would be necessary in case of too much limited
+        // maximum contact point...
+        // or in complex mesh case (trimesh and convex)
+        // need some test or insights on this before enabling this.
+        int numTri = 0;
+        HeightFieldVertex A, B, C, D;
+        // keep only triangle that does intersect geom
+
+        //final unsigned 
+        final int maxX_local = maxX - minX;
+        //final unsigned 
+        final int maxZ_local = maxZ - minZ;
+
+        for ( x_local = 0; x_local < maxX_local; x_local++)
+        {
+            ObjArray<HeightFieldVertex> HeightFieldRow      = tempHeightBuffer[x_local];
+            ObjArray<HeightFieldVertex> HeightFieldNextRow  = tempHeightBuffer[x_local + 1];
+
+            C = HeightFieldRow.at(0);
+            D = HeightFieldNextRow.at(0);
+
+            for ( z_local = 0; z_local < maxZ_local; z_local++)
+            {
+                A = C;
+                B = D;
+                C = HeightFieldRow.at(z_local + 1);//  [z_local + 1];
+                D = HeightFieldNextRow.at(z_local + 1);//[z_local + 1];
+
+                final double AHeight = A.vertex.get1();
+                final double BHeight = B.vertex.get1();
+                final double CHeight = C.vertex.get1();
+                final double DHeight = D.vertex.get1();
+
+                final boolean isACollide = AHeight > minO2Height;
+                final boolean isBCollide = BHeight > minO2Height;
+                final boolean isCCollide = CHeight > minO2Height;
+                final boolean isDCollide = DHeight > minO2Height;
+
+                if (isACollide || isBCollide || isCCollide)
+                {
+                    HeightFieldTriangle CurrTriUp = tempTriangleBuffer[numTri++];// final ?? TZ
+                    CurrTriUp.vertices[0] = A;
+                    CurrTriUp.vertices[1] = C;
+                    CurrTriUp.vertices[2] = B;
+                }
+                if (isBCollide || isCCollide || isDCollide)
+                {
+                    HeightFieldTriangle CurrTriDown = tempTriangleBuffer[numTri++];//final ?? TZ
+                    CurrTriDown.vertices[0] = D;
+                    CurrTriDown.vertices[1] = B;
+                    CurrTriDown.vertices[2] = C;
+                }
+            }
+        }
+        float[] vertices = new float[numTri * 9];
+        int[] faces = new int[numTri * 3];
+        for (int k = 0; k < numTri; k++) {
+            HeightFieldTriangle itTriangle = tempTriangleBuffer[k];
+            for (int j = 0; j < 3; j ++) {
+                for (int i = 0; i < 3; i ++) {
+                    vertices[k * 9 + j * 3 + i] = (float) itTriangle.vertices[j].vertex.get(i);
+                }
+                faces[k * 3 + j] = k * 3 + j;
+            }
+        }
+        DxGimpactData data = new DxGimpactData();
+        data.build(vertices, faces);
+        DxGimpact trimesh = new DxGimpact(null, data);
+        trimesh.recomputeAABB();
+        numTerrainContacts = DxGeom.dCollide(trimesh, o2, flags, contacts, skip);
+        trimesh.destroy();
+        return numTerrainContacts;
+    }
+
+    public static class CollideHeightfield implements DColliderFn {
+        int dCollideHeightfield( DxTrimeshHeightfield o1, DxGeom o2, int flags, DContactGeomBuffer contacts, int skip )
+        {
+            dIASSERT( skip >= 1);//(int)sizeof(dContactGeom) );
+            //dIASSERT( o1.type == dHeightfieldClass );
+            dIASSERT((flags & NUMC_MASK) >= 1);
+
+            int i;
+
+            // if ((flags & NUMC_MASK) == 0) -- An assertion check is made on entry
+            //  { flags = (flags & ~NUMC_MASK) | 1; dIASSERT((1 & ~NUMC_MASK) == 0); }
+
+            int numMaxTerrainContacts = (flags & NUMC_MASK);
+
+            DxTrimeshHeightfield terrain = o1;
+
+            DVector3 posbak = new DVector3();
+            DMatrix3 Rbak = new DMatrix3();
+            DAABB aabbbak = new DAABB();
+            int gflagsbak = 0;
+            DVector3 pos0 = new DVector3(), pos1 = new DVector3();
+            DMatrix3 R1 = new DMatrix3();
+
+            int numTerrainContacts = 0;
+            int numTerrainOrigContacts = 0;
+
+            //@@ Should find a way to set reComputeAABB to false in default case
+            // aka DHEIGHTFIELD_CORNER_ORIGIN not defined and terrain not PLACEABLE
+            // so that we can free some memory and speed up things a bit
+            // while saving some precision loss
+            boolean reComputeAABB;
+            if (!DHEIGHTFIELD_CORNER_ORIGIN) {//#ifndef DHEIGHTFIELD_CORNER_ORIGIN
+                //final boolean reComputeAABB = true;
+                reComputeAABB = true;
+            } else {//#else
+                //final boolean reComputeAABB = ( (terrain._gflags & GEOM_PLACEABLE)!=0 ) ? true : false;
+                //reComputeAABB = ( (terrain._gflags & GEOM_PLACEABLE)!=0 ) ? true : false;
+                reComputeAABB = terrain.hasFlagPlaceable();
+            }//#endif //DHEIGHTFIELD_CORNER_ORIGIN
+
+            //
+            // Transform O2 into Heightfield Space
+            //
+            if (reComputeAABB)
+            {
+                // Backup original o2 position, rotation and AABB.
+                posbak.set(o2.final_posr().pos());//dVector3Copy( o2._final_posr.pos, posbak );
+                Rbak.set(o2.final_posr().R());//dMatrix3Copy( o2._final_posr.R, Rbak );
+                aabbbak.set(o2._aabb);//memcpy( aabbbak, o2.aabb, sizeof( double ) * 6 );
+                gflagsbak = o2.getFlags();//_gflags;
+            }
+
+            //if ( (terrain._gflags & GEOM_PLACEABLE)!=0 )
+            if (terrain.hasFlagPlaceable())
+            {
+                // Transform o2 into heightfield space.
+                //dOP( pos0, OP.SUB, o2._final_posr.pos, terrain._final_posr.pos );
+                pos0.eqDiff( o2.final_posr().pos(), terrain.final_posr().pos() );
+                dMultiply1_331( pos1, terrain.final_posr().R(), pos0 );
+                dMultiply1_333( R1, terrain.final_posr().R(), o2.final_posr().R() );
+
+                // Update o2 with transformed position and rotation.
+                o2._final_posr.pos.set(pos1);//dVector3Copy( pos1, o2._final_posr.pos );
+                o2._final_posr.Rw().set(R1);//dMatrix3Copy( R1, o2._final_posr.R );
+            }
+
+            if (!DHEIGHTFIELD_CORNER_ORIGIN) {//#ifndef DHEIGHTFIELD_CORNER_ORIGIN
+                o2._final_posr.pos.add( 0, +terrain.m_p_data.m_fHalfWidth );
+                o2._final_posr.pos.add( 2, +terrain.m_p_data.m_fHalfDepth );
+            }////#endif // DHEIGHTFIELD_CORNER_ORIGIN
+
+            // Rebuild AABB for O2
+            if (reComputeAABB) {
+                //o2.computePosr();
+                o2.computeAABB();
+            }
+
+            //
+            // Collide
+            //
+
+            //check if inside boundaries
+            // using O2 aabb
+            //  aabb[6] is (minx, maxx, miny, maxy, minz, maxz)
+            final boolean wrapped = terrain.m_p_data.m_bWrapMode != false;
+
+            //TZ
+            boolean dCollideHeightfieldExit = false;
+
+            if ( !wrapped )
+            {
+                if (    o2._aabb.getMin0() > terrain.m_p_data.m_fWidth //MinX
+                        ||  o2._aabb.getMin2() > terrain.m_p_data.m_fDepth) { //MinZ
+                    //goto dCollideHeightfieldExit;
+                    dCollideHeightfieldExit = true;
+                }
+
+                if (    o2._aabb.getMax0() < 0 //MaxX
+                        ||  o2._aabb.getMax2() < 0) { //MaxZ
+                    //goto dCollideHeightfieldExit;
+                    dCollideHeightfieldExit = true;
+                }
+
+            }
+
+            DContactGeom pContact;
+            if (!dCollideHeightfieldExit) {
+                {
+                    // To narrow scope of following variables
+                    final double fInvSampleWidth = terrain.m_p_data.m_fInvSampleWidth;
+                    int nMinX = (int)dFloor(Common.dNextAfter(o2._aabb.getMin0() * fInvSampleWidth, -dInfinity));
+                    int nMaxX = (int)dCeil(Common.dNextAfter(o2._aabb.getMax0() * fInvSampleWidth, dInfinity));
+                    final double fInvSampleDepth = terrain.m_p_data.m_fInvSampleDepth;
+                    int nMinZ = (int)dFloor(Common.dNextAfter(o2._aabb.getMin2() * fInvSampleDepth, -dInfinity));
+                    int nMaxZ = (int)dCeil(Common.dNextAfter(o2._aabb.getMax2() * fInvSampleDepth, dInfinity));
+
+                    if ( !wrapped )
+                    {
+                        nMinX = (int) dMAX( nMinX, 0 );
+                        nMaxX = (int) dMIN( nMaxX, terrain.m_p_data.m_nWidthSamples - 1 );
+                        nMinZ = (int) dMAX( nMinZ, 0 );
+                        nMaxZ = (int) dMIN( nMaxZ, terrain.m_p_data.m_nDepthSamples - 1 );
+
+                        dIASSERT ((nMinX < nMaxX) && (nMinZ < nMaxZ));
+                    }
+
+
+                    numTerrainOrigContacts = numTerrainContacts;
+                    numTerrainContacts += terrain.dCollideHeightfieldZone(
+                            nMinX,nMaxX,nMinZ,nMaxZ,o2,numMaxTerrainContacts - numTerrainContacts,
+                            flags,
+                            //CONTACT(contact,numTerrainContacts*skip),
+                            contacts.createView(numTerrainContacts*skip),
+                            skip );
+                    dIASSERT( numTerrainContacts <= numMaxTerrainContacts );
+                }
+                
+                for ( i = numTerrainOrigContacts; i != numTerrainContacts; ++i )
+                {
+                    pContact = contacts.get(i*skip);//CONTACT(contact,i*skip);
+                    pContact.g1 = o1;
+                    pContact.g2 = o2;
+                    // pContact->side1 = -1; -- Oleh_Derevenko: sides must not
+                    // be erased here as they are set by respective colliders during ray/plane tests 
+                    // pContact->side2 = -1;
+                }
+            }
+
+            //------------------------------------------------------------------------------
+
+            //dCollideHeightfieldExit:
+            //if (dCollideHeightfieldExit)
+                if (reComputeAABB)
+                {
+                    // Restore o2 position, rotation and AABB
+                    //dVector3Copy( posbak, o2._final_posr.pos );
+                    o2._final_posr.pos.set(posbak);
+                    //dMatrix3Copy( Rbak, o2._final_posr.R );
+                    o2._final_posr.Rw().set(Rbak);
+                    //memcpy( o2.aabb, aabbbak, sizeof(double)*6 );
+                    o2._aabb.set(aabbbak);
+                    o2.setFlags(gflagsbak);//_gflags = gflagsbak;
+                    if (o2 instanceof DxGimpact)
+                        o2.computeAABB();  //TODO TZ
+
+                    //
+                    // Transform Contacts to World Space
+                    //
+                    //if ( (terrain._gflags & GEOM_PLACEABLE)!=0 )
+                    if ( terrain.hasFlagPlaceable() )
+                    {
+                        for ( i = 0; i < numTerrainContacts; ++i )
+                        {
+                            pContact = contacts.get(i*skip);//CONTACT(contact,i*skip);
+                            //dOPE( pos0, =, pContact.pos );
+                            pos0.set( pContact.pos );
+
+                            if (!DHEIGHTFIELD_CORNER_ORIGIN) {//#ifndef DHEIGHTFIELD_CORNER_ORIGIN
+                                pos0.add( 0, -terrain.m_p_data.m_fHalfWidth );
+                                pos0.add( 2, -terrain.m_p_data.m_fHalfDepth );
+                            }//#endif // !DHEIGHTFIELD_CORNER_ORIGIN
+
+                            dMultiply0_331( pContact.pos, terrain.final_posr().R(), pos0 );
+
+                            //dOP( pContact.pos, +, pContact.pos, terrain._final_posr.pos );
+                            pContact.pos.add(terrain.final_posr().pos());
+                            //dOPE( pos0, =, pContact.normal );
+                            pos0.set(pContact.normal);
+
+                            dMultiply0_331( pContact.normal, terrain.final_posr().R(), pos0 );
+                        }
+                    } 
+                    else
+                    {
+                        if (!DHEIGHTFIELD_CORNER_ORIGIN) {//#ifndef DHEIGHTFIELD_CORNER_ORIGIN
+                            for ( i = 0; i < numTerrainContacts; ++i )
+                            {
+                                pContact = contacts.get(i*skip);//CONTACT(contact,i*skip);
+                                pContact.pos.add( 0, -terrain.m_p_data.m_fHalfWidth );
+                                pContact.pos.add( 2, -terrain.m_p_data.m_fHalfDepth );
+                            }
+                        }//#endif // !DHEIGHTFIELD_CORNER_ORIGIN
+                    }
+                }
+            // Return contact count.
+            return numTerrainContacts;
+        }
+
+        @Override
+        public int dColliderFn(DGeom o1, DGeom o2, int flags,
+                DContactGeomBuffer contacts) {
+            return dCollideHeightfield((DxTrimeshHeightfield)o1, (DxGeom)o2, flags, contacts, 1);
+        }
+    }
+
+
+    @Override
+    public DHeightfieldData getHeightfieldData() {
+        return dGeomHeightfieldGetHeightfieldData();
+    }
+    
+    
+    @Override
+    public void setHeightfieldData(DHeightfieldData d) {
+        dGeomHeightfieldSetHeightfieldData(d);
+    }
+}

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimeshHeightfield.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimeshHeightfield.java
@@ -1,0 +1,700 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.demo;
+
+import static org.ode4j.demo.BunnyGeom.IndexCount;
+import static org.ode4j.demo.BunnyGeom.Indices;
+import static org.ode4j.demo.BunnyGeom.Vertices;
+import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
+import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
+import static org.ode4j.drawstuff.DrawStuff.dsDrawConvex;
+import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
+import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
+import static org.ode4j.drawstuff.DrawStuff.dsDrawTriangle;
+import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
+import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
+import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
+import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
+import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.ode.DMisc.dRandReal;
+import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
+import static org.ode4j.ode.OdeConstants.dContactBounce;
+import static org.ode4j.ode.OdeConstants.dContactSoftCFM;
+import static org.ode4j.ode.OdeConstants.dInfinity;
+import static org.ode4j.ode.OdeHelper.areConnectedExcluding;
+
+import org.ode4j.drawstuff.DrawStuff.DS_TEXTURE_NUMBER;
+import org.ode4j.drawstuff.DrawStuff.dsFunctions;
+import org.ode4j.math.DMatrix3;
+import org.ode4j.math.DMatrix3C;
+import org.ode4j.math.DVector3;
+import org.ode4j.math.DVector3C;
+import org.ode4j.ode.DAABBC;
+import org.ode4j.ode.DBody;
+import org.ode4j.ode.DBox;
+import org.ode4j.ode.DCapsule;
+import org.ode4j.ode.DContact;
+import org.ode4j.ode.DContactBuffer;
+import org.ode4j.ode.DContactJoint;
+import org.ode4j.ode.DConvex;
+import org.ode4j.ode.DCylinder;
+import org.ode4j.ode.DGeom;
+import org.ode4j.ode.DHeightfield;
+import org.ode4j.ode.DHeightfield.DHeightfieldGetHeight;
+import org.ode4j.ode.DHeightfieldData;
+import org.ode4j.ode.DJoint;
+import org.ode4j.ode.DJointGroup;
+import org.ode4j.ode.DMass;
+import org.ode4j.ode.DSpace;
+import org.ode4j.ode.DSphere;
+import org.ode4j.ode.DTriMesh;
+import org.ode4j.ode.DTriMeshData;
+import org.ode4j.ode.DWorld;
+import org.ode4j.ode.OdeHelper;
+import org.ode4j.ode.internal.DxGeom;
+import org.ode4j.ode.internal.DxTrimeshHeightfield;
+
+
+class DemoTrimeshHeightfield extends dsFunctions {
+
+	private static final float DEGTORAD = 0.01745329251994329577f	; //!< PI / 180.0, convert degrees to radians
+
+	// Our heightfield geom
+	private DGeom gheight;
+
+	// Heightfield dimensions
+
+	private static final int HFIELD_WSTEP =			15;			// Vertex count along edge >= 2
+	private static final int HFIELD_DSTEP =			31;
+
+	private static final float HFIELD_WIDTH =			4.0f;
+	private static final float HFIELD_DEPTH =			8.0f;
+
+	private static final float HFIELD_WSAMP =			( HFIELD_WIDTH / ( HFIELD_WSTEP-1 ) );
+	private static final float HFIELD_DSAMP =			( HFIELD_DEPTH / ( HFIELD_DSTEP-1 ) );
+
+
+
+	//<---- Convex Object
+	private double[] planes= // planes for a cube
+	{
+			1.0f ,0.0f ,0.0f ,0.25f,
+			0.0f ,1.0f ,0.0f ,0.25f,
+			0.0f ,0.0f ,1.0f ,0.25f,
+			0.0f ,0.0f ,-1.0f,0.25f,
+			0.0f ,-1.0f,0.0f ,0.25f,
+			-1.0f,0.0f ,0.0f ,0.25f
+	};
+	private final int planecount=6;
+
+	private double points[]= // points for a cube
+	{
+			0.25f,0.25f,0.25f,  //  point 0
+			-0.25f,0.25f,0.25f, //  point 1
+
+			0.25f,-0.25f,0.25f, //  point 2
+			-0.25f,-0.25f,0.25f,//  point 3
+
+			0.25f,0.25f,-0.25f, //  point 4
+			-0.25f,0.25f,-0.25f,//  point 5
+
+			0.25f,-0.25f,-0.25f,//  point 6
+			-0.25f,-0.25f,-0.25f,// point 7
+	};
+	private final int pointcount=8;
+	private int polygons[] = //Polygons for a cube (6 squares)
+	{
+			4,0,2,6,4, // positive X
+			4,1,0,4,5, // positive Y
+			4,0,1,3,2, // positive Z
+			4,3,1,5,7, // negative X
+			4,2,3,7,6, // negative Y
+			4,5,4,6,7, // negative Z
+	};
+	//----> Convex Object
+
+
+	// some constants
+
+	private static final int NUM = 100;			// max number of objects
+	private static final float DENSITY = 5.0f	;	// density of all objects
+	private static final int  GPB = 3;			// maximum number of geometries per body
+	private static final int  MAX_CONTACTS = 64;		// maximum number of contact points per body
+
+
+	// dynamics and collision objects
+
+	private class MyObject {
+		DBody body;			// the body
+		DGeom[] geom = new DGeom[GPB];		// geometries representing this body
+
+		// Trimesh only - double buffered matrices for 'last transform' setup
+		//double[] matrix_dblbuff = new double[ 16 * 2 ];
+		//int last_matrix_index;
+	};
+
+	private int num=0;		// number of objects in simulation
+	private int nextobj=0;		// next object to recycle if num==NUM
+	private DWorld world;
+	private DSpace space;
+	private MyObject[] obj = new MyObject[NUM];
+	private DJointGroup contactgroup;
+	private int selected = -1;	// selected object
+	private boolean show_aabb = false;	// show geom AABBs?
+	private boolean show_contacts = false;	// show contact points?
+	private boolean random_pos = true;	// drop objects from random position?
+
+
+	//============================
+
+	//private DGeom TriMesh1;
+	//private DGeom TriMesh2;
+	//static dTriMeshDataID TriData1, TriData2;  // reusable static trimesh data
+
+	//============================
+
+	private DHeightfieldGetHeight heightfield_callback = new DHeightfieldGetHeight(){
+		@Override
+		public double call(Object pUserData, int x, int z) {
+			return heightfield_callback(pUserData, x, z);
+		}
+	};
+
+	private double heightfield_callback( Object pUserData, int x, int z ) {
+		double fx = ( ((double)x) - ( HFIELD_WSTEP-1 )/2 ) / ( HFIELD_WSTEP-1 );
+		double fz = ( ((double)z) - ( HFIELD_DSTEP-1 )/2 ) / ( HFIELD_DSTEP-1 );
+
+		// Create an interesting 'hump' shape
+		double h = ( 1.0 ) + ( ( -16.0 ) * ( fx*fx*fx + fz*fz*fz ) );
+
+		return h;
+	}
+
+
+	private DGeom.DNearCallback nearCallback = new DGeom.DNearCallback() {
+		@Override
+		public void call(Object data, DGeom o1, DGeom o2) {
+			nearCallback(data, o1, o2);
+		}
+	};
+
+
+	// this is called by dSpaceCollide when two objects in space are
+	// potentially colliding.
+
+	private void nearCallback (Object data, DGeom o1, DGeom o2) {
+		int i;
+		// if (o1->body && o2->body) return;
+
+		// exit without doing anything if the two bodies are connected by a joint
+		DBody b1 = o1.getBody();
+		DBody b2 = o2.getBody();
+		if (b1!=null && b2!=null && areConnectedExcluding (b1,b2,DContactJoint.class)) {
+			return;
+		}
+
+		DContactBuffer contacts = new DContactBuffer(MAX_CONTACTS);   // up to MAX_CONTACTS contacts per box-box
+		for (i=0; i<MAX_CONTACTS; i++) {
+			DContact contact = contacts.get(i);
+			contact.surface.mode = dContactBounce | dContactSoftCFM;
+			contact.surface.mu = dInfinity;
+			contact.surface.mu2 = 0;
+			contact.surface.bounce = 0.1;
+			contact.surface.bounce_vel = 0.1;
+			contact.surface.soft_cfm = 0.01;
+		}
+		int numc = OdeHelper.collide (o1,o2,MAX_CONTACTS,contacts.getGeomBuffer());
+		if (numc!=0) {
+			DMatrix3 RI = new DMatrix3();
+			RI.setIdentity();
+			final DVector3 ss = new DVector3(0.02,0.02,0.02);
+			for (i=0; i<numc; i++) {
+				DJoint c = OdeHelper.createContactJoint (world,contactgroup,contacts.get(i));
+				c.attach (b1,b2);
+				if (show_contacts) {
+					dsSetColor(0, 0, 1);
+					dsDrawBox (contacts.get(i).geom.pos,RI,ss);
+				}
+			}
+		}
+	}
+
+	private static float[] xyz = {2.1640f,-1.3079f,1.7600f};
+	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+
+	// start simulation - set viewpoint
+	@Override
+	public void start() {
+		dsSetViewpoint (xyz,hpr);
+		System.out.println ("To drop another object, press:\n");
+		System.out.println ("   b for box.");
+		System.out.println ("   s for sphere.");
+		System.out.println ("   c for capsule.");
+		System.out.println ("   y for cylinder.");
+		System.out.println ("   v for a convex object.");
+		System.out.println ("   x for a composite object.");
+		System.out.println ("   m for a trimesh.");
+		System.out.println ("To select an object, press space.");
+		System.out.println ("To disable the selected object, press d.");
+		System.out.println ("To enable the selected object, press e.");
+		System.out.println ("To toggle showing the geom AABBs, press a.");
+		System.out.println ("To toggle showing the contact points, press t.");
+		System.out.println ("To toggle dropping from random position/orientation, press r.");
+	}
+
+
+	// called when a key pressed
+
+	@Override
+	public void command (char cmd) {
+		int i;
+		int j,k;
+		double[] sides = new double[3];
+		DMass m = OdeHelper.createMass();
+	    boolean setBody = false;
+
+		cmd = Character.toLowerCase(cmd);
+
+
+		//
+		// Geom Creation
+		//
+
+		if ( cmd == 'b' || cmd == 's' || cmd == 'c' || ( cmd == 'm' ) ||
+				cmd == 'x' || cmd == 'y' || cmd == 'v' ) {
+			if ( num < NUM ) {
+				i = num;
+				num++;
+			} else {
+				i = nextobj;
+				nextobj++;
+				nextobj %= num;
+
+				// destroy the body and geoms for slot i
+				obj[i].body.destroy();
+				obj[i].body = null;
+				
+				for (k=0; k < GPB; k++)	{
+					if (obj[i].geom[k]!=null) {
+						obj[i].geom[k].destroy();
+						obj[i].geom[k] = null;
+					}
+				}
+				//memset (&obj[i],0,sizeof(obj[i]));
+				obj[i] = new MyObject();
+			}
+
+			obj[i].body = OdeHelper.createBody (world);
+			for (k=0; k<3; k++) {
+				sides[k] = dRandReal()*0.5+0.1;
+			}
+
+			DMatrix3 R = new DMatrix3();
+			if (random_pos) {
+				obj[i].body.setPosition(
+						(dRandReal()-0.5)*HFIELD_WIDTH*0.75,
+						(dRandReal()-0.5)*HFIELD_DEPTH*0.75,
+						dRandReal() + 2 );
+				dRFromAxisAndAngle (R,dRandReal()*2.0-1.0,dRandReal()*2.0-1.0,
+						dRandReal()*2.0-1.0,dRandReal()*10.0-5.0);
+			} else {
+				double maxheight = 0;
+				for (k=0; k<num; k++) {
+					final DVector3C pos = obj[k].body.getPosition();
+					if (pos.get2() > maxheight) {
+						maxheight = pos.get2();
+					}
+				}
+				obj[i].body.setPosition(0,maxheight+1,0);
+				dRFromAxisAndAngle (R,0,0,1,dRandReal()*10.0-5.0);
+			}
+			obj[i].body.setRotation (R);
+			obj[i].body.setData (i);
+
+			if (cmd == 'b') {
+				m.setBox (DENSITY,sides[0],sides[1],sides[2]);
+				obj[i].geom[0] = OdeHelper.createBox (space,sides[0],sides[1],sides[2]);
+			} else if (cmd == 'c') {
+				sides[0] *= 0.5;
+				m.setCapsule (DENSITY,3,sides[0],sides[1]);
+				obj[i].geom[0] = OdeHelper.createCapsule (space,sides[0],sides[1]);
+			} else if (cmd == 'v') {
+				m.setBox (DENSITY,0.25,0.25,0.25);
+				obj[i].geom[0] = OdeHelper.createConvex (space,
+						planes,
+						planecount,
+						points,
+						pointcount,
+						polygons);
+			} else if (cmd == 'y') {
+				m.setCylinder (DENSITY,3,sides[0],sides[1]);
+				obj[i].geom[0] = OdeHelper.createCylinder (space,sides[0],sides[1]);
+			} else if (cmd == 's') {
+				sides[0] *= 0.5;
+				m.setSphere (DENSITY,sides[0]);
+				obj[i].geom[0] = OdeHelper.createSphere (space,sides[0]);
+			} else if (cmd == 'm') {
+				DTriMeshData new_tmdata = OdeHelper.createTriMeshData();
+				new_tmdata.build(Vertices, Indices);
+
+				obj[i].geom[0] = OdeHelper.createTriMesh(space, new_tmdata, null, null, null);
+
+				m.setTrimesh( DENSITY, (DTriMesh)obj[i].geom[0] );
+				DVector3 c = new DVector3(m.getC());
+				c.scale(-1);
+				obj[i].geom[0].setPosition(c);
+				m.translate(c);
+			} else if (cmd == 'x') {
+				setBody = true;
+				// start accumulating masses for the encapsulated geometries
+				DMass m2 = OdeHelper.createMass();
+				m.setZero ();
+
+				DVector3[] dpos = DVector3.newArray(GPB);	// delta-positions for encapsulated geometries
+				DMatrix3[] drot = DMatrix3.newArray(GPB);
+
+				// set random delta positions
+				for (j=0; j<GPB; j++) {
+					for (k=0; k<3; k++) dpos[j].set(k, dRandReal()*0.3-0.15);
+				}
+
+				for (k=0; k<GPB; k++) {
+					if (k==0) {
+						double radius = dRandReal()*0.25+0.05;
+						obj[i].geom[k] = OdeHelper.createSphere (space, radius);
+						m2.setSphere (DENSITY,radius);
+					} else if (k==1) {
+						obj[i].geom[k] = OdeHelper.createBox (space,sides[0],sides[1],sides[2]);
+						m2.setBox (DENSITY,sides[0],sides[1],sides[2]);
+					} else {
+						double radius = dRandReal()*0.1+0.05;
+						double length = dRandReal()*1.0+0.1;
+						obj[i].geom[k] = OdeHelper.createCapsule (space,radius,length);
+						m2.setCapsule (DENSITY,3,radius,length);
+					}
+
+					dRFromAxisAndAngle(drot[k], dRandReal()*2.0-1.0,dRandReal()*2.0-1.0,
+                                   dRandReal()*2.0-1.0,dRandReal()*10.0-5.0);
+					m2.rotate (drot[k]);
+
+	                m2.translate(dpos[k]);
+
+					// add to the total mass
+					m.add (m2);
+				}
+
+				// move all encapsulated objects so that the center of mass is (0,0,0)
+				DVector3 c = new DVector3().set(m.getC());
+				c.scale(-1);
+				for (k=0; k<GPB; k++) {
+					obj[i].geom[k].setBody(obj[i].body);
+//					dGeomSetOffsetPosition (obj[i].geom[k],
+//							dpos[k][0]-m.c[0],
+//							dpos[k][1]-m.c[1],
+//							dpos[k][2]-m.c[2]);
+					obj[i].geom[k].setOffsetPosition(dpos[k].reAdd(c));
+					obj[i].geom[k].setOffsetRotation(drot[k]);
+				}
+//				dMassTranslate (m,-m.c[0],-m.c[1],-m.c[2]);
+				m.translate(c);
+				obj[i].body.setMass(m);
+			}
+
+			if (!setBody) {
+				for (k=0; k < GPB; k++) {
+					if (obj[i].geom[k]!=null) {
+						obj[i].geom[k].setBody(obj[i].body);
+					}
+				}
+
+				obj[i].body.setMass(m);
+			}
+		}
+
+
+		//
+		// Control Commands
+		//
+
+		if (cmd == ' ') {
+			selected++;
+			if (selected >= num) 
+				selected = 0;
+			if (selected < -1) 
+				selected = 0;
+		} else if (cmd == 'd' && selected >= 0 && selected < num) {
+			obj[selected].body.disable();
+		} else if (cmd == 'e' && selected >= 0 && selected < num) {
+			obj[selected].body.enable();
+		} else if (cmd == 'a') {
+			show_aabb = !show_aabb;
+		} else if (cmd == 't') {
+			show_contacts = !show_contacts;
+		} else if (cmd == 'r') {
+			random_pos = !random_pos;
+		}
+	}
+
+
+	// draw a geom
+
+	private void drawGeom (DGeom g, DVector3C pos, DMatrix3C R, boolean show_aabb) {
+		if (g==null) 
+			return;
+		if (pos==null) 
+			pos = g.getPosition ();
+		if (R==null) 
+			R = g.getRotation ();
+
+		if (g instanceof DBox) {
+			DVector3C sides = ((DBox)g).getLengths();
+			dsDrawBox (pos,R,sides);
+			
+		} else if (g instanceof DSphere) {
+			dsDrawSphere (pos, R, ((DSphere)g).getRadius());
+			
+		} else if (g instanceof DCapsule) {
+			DCapsule cap = (DCapsule) g; 
+			dsDrawCapsule (pos, R, cap.getLength(), cap.getRadius());
+			
+		} else if (g instanceof DConvex) {
+			//dVector3 sides={0.50,0.50,0.50};
+			dsDrawConvex(pos,R,planes,
+					planecount,
+					points,
+					pointcount,
+					polygons);
+			
+		} else if (g instanceof DCylinder) {
+			DCylinder cyl = (DCylinder) g;
+			dsDrawCylinder (pos, R, cyl.getLength(), cyl.getRadius());
+			
+		} else if (g instanceof DTriMesh) {
+	        int[] Indices = BunnyGeom.Indices;
+
+	        // assume all trimeshes are drawn as bunnies
+	        for (int ii = 0; ii < IndexCount / 3; ii++) {
+	            float[] v0 = { // explicit conversion from float to dReal
+	                Vertices[Indices[ii * 3 + 0] * 3 + 0],
+	                Vertices[Indices[ii * 3 + 0] * 3 + 1],
+	                Vertices[Indices[ii * 3 + 0] * 3 + 2]};
+	            float[] v3 = {
+	                Vertices[Indices[ii * 3 + 1] * 3 + 0],
+	                Vertices[Indices[ii * 3 + 1] * 3 + 1],
+	                Vertices[Indices[ii * 3 + 1] * 3 + 2]};
+	            float[] v6 = {
+	                Vertices[Indices[ii * 3 + 2] * 3 + 0],
+	                Vertices[Indices[ii * 3 + 2] * 3 + 1],
+	                Vertices[Indices[ii * 3 + 2] * 3 + 2]
+	            };
+	            dsDrawTriangle(pos, R, v0, v3, v6, true);
+	        }
+
+	    } else if (g instanceof DHeightfield) {
+
+	        // Set ox and oz to zero for DHEIGHTFIELD_CORNER_ORIGIN mode.
+	        int ox = (int) ( -HFIELD_WIDTH/2 );
+	        int oz = (int) ( -HFIELD_DEPTH/2 );
+
+	        //	for ( int tx = -1; tx < 2; ++tx )
+	        //	for ( int tz = -1; tz < 2; ++tz )
+	        dsSetColorAlpha (0.5,1,0.5,0.5);
+	        dsSetTexture( DS_TEXTURE_NUMBER.DS_WOOD );
+
+	        for ( int i = 0; i < HFIELD_WSTEP - 1; ++i )
+	            for ( int j = 0; j < HFIELD_DSTEP - 1; ++j ) {
+	                float[] a = new float[3], b = new float[3];
+	                float[] c = new float[3], d = new float[3];
+
+	                a[ 0 ] = ox + ( i ) * HFIELD_WSAMP;
+	                a[ 1 ] = (float) heightfield_callback( null, i, j );
+	                a[ 2 ] = oz + ( j ) * HFIELD_DSAMP;
+
+	                b[ 0 ] = ox + ( i + 1 ) * HFIELD_WSAMP;
+	                b[ 1 ] = (float) heightfield_callback( null, i + 1, j );
+	                b[ 2 ] = oz + ( j ) * HFIELD_DSAMP;
+
+	                c[ 0 ] = ox + ( i ) * HFIELD_WSAMP;
+	                c[ 1 ] = (float) heightfield_callback( null, i, j + 1 );
+	                c[ 2 ] = oz + ( j + 1 ) * HFIELD_DSAMP;
+	                
+	                d[ 0 ] = ox + ( i + 1 ) * HFIELD_WSAMP;
+	                d[ 1 ] = (float) heightfield_callback( null, i + 1, j + 1 );
+	                d[ 2 ] = oz + ( j + 1 ) * HFIELD_DSAMP;
+
+	                dsDrawTriangle( pos, R, a, c, b, true );
+	                dsDrawTriangle( pos, R, b, c, d, true );
+	            }
+
+		}
+
+		drawAABB(g);
+	}
+	
+	private void drawAABB(DGeom g) {
+		if (show_aabb) {
+			// draw the bounding box for this geom
+			DAABBC aabb = g.getAABB();
+			DVector3 bbpos = aabb.getCenter();
+			DVector3 bbsides = aabb.getLengths();
+			DMatrix3 RI = new DMatrix3();
+			RI.setIdentity ();
+			dsSetColorAlpha (1,0,0,0.5f);
+			dsDrawBox (bbpos,RI,bbsides);
+		}
+	}
+
+	// simulation loop
+
+	@Override
+	public void step (boolean pause) {
+
+		space.collide (null,nearCallback);
+
+		if (!pause) {
+			world.quickStep (0.05);
+		}
+		
+		// remove all contact joints
+		contactgroup.empty();
+
+
+		//
+		// Draw Heightfield
+		//
+		
+		drawGeom(gheight, null, null, false);
+
+		dsSetColorAlpha (0.5f,1,0.5f,0.5f);
+		dsSetTexture( DS_TEXTURE_NUMBER.DS_WOOD );
+		for ( int i = 0; i < num; ++i ) {
+			for ( int j = 0; j < GPB; ++j ) {
+				if (i==selected) {
+					dsSetColor (0,0.7,1);
+				} else if (! obj[i].body.isEnabled ()) {
+					dsSetColor (1,0.8,0);
+				} else {
+					dsSetColor (1,1,0);
+				}
+
+				drawGeom (obj[i].geom[j],null,null,show_aabb);
+			}
+		}
+	}
+
+
+	public static void main(String[] args) {
+		new DemoTrimeshHeightfield().demo(args);
+	}
+
+	private void demo(String[] args) {
+		System.out.println("ODE configuration: " + OdeHelper.getConfiguration());
+
+		// create world
+		OdeHelper.initODE2(0);
+		world = OdeHelper.createWorld ();
+		space = OdeHelper.createHashSpace (null);
+		contactgroup = OdeHelper.createJointGroup ();
+		world.setGravity (0,0,-0.05);
+		world.setCFM (1e-5);
+		world.setAutoDisableFlag (true);
+		world.setContactMaxCorrectingVel (0.1);
+		world.setContactSurfaceLayer (0.001);
+		for (int i = 0; i < obj.length; i++) {
+			obj[i] = new MyObject();
+		}
+
+		world.setAutoDisableAverageSamplesCount( 1 );
+
+		// base plane to catch overspill
+		OdeHelper.createPlane( space, 0, 0, 1, 0 );
+
+
+		// our heightfield floor
+
+		DHeightfieldData height = OdeHelper.createHeightfieldData();
+
+		// Create an finite heightfield.
+		height.buildCallback( null, heightfield_callback,
+				HFIELD_WIDTH, HFIELD_DEPTH, HFIELD_WSTEP, HFIELD_DSTEP,
+				1.0, 0.0, 0.0, false );
+		// alternative: create heightfield from array
+//		double[] data = new double[HFIELD_WSTEP*HFIELD_DSTEP];
+//		for (int x = 0; x < HFIELD_WSTEP; x++) {
+//			for (int z = 0; z < HFIELD_DSTEP; z++) {
+//				data[x+HFIELD_WSTEP*z] = heightfield_callback(null, x, z);
+//			}
+//		}
+//		heightid.build(data, false, HFIELD_WIDTH, HFIELD_DEPTH, 
+//				HFIELD_WSTEP, HFIELD_DSTEP, 1.0, 0.0, 0.0, false );
+
+		// Give some very bounds which, while conservative,
+		// makes AABB computation more accurate than +/-INF.
+		height.setBounds( ( -4.0 ), ( +6.0 ) );
+
+		gheight = new DxTrimeshHeightfield(space, height, true);// OdeHelper.createHeightfield( space, height, true );
+
+		DVector3 pos = new DVector3();
+
+		// Rotate so Z is up, not Y (which is the default orientation)
+		DMatrix3 R = new DMatrix3();
+		R.setIdentity();
+		dRFromAxisAndAngle( R, 1, 0, 0, DEGTORAD * 90 );
+
+		// Place it.
+		gheight.setRotation( R );
+		gheight.setPosition( pos );
+
+		//TODO
+//	    DThreadingImplementation threading = OdeHelper.allocateMultiThreaded();
+//	    DThreadingThreadPool pool = OdeHelper.allocateThreadPool(4, 0, /*dAllocateFlagBasicData,*/ null);
+//	    pool.serveMultiThreadedImplementation(threading);
+//	    // dWorldSetStepIslandsProcessingMaxThreadCount(world, 1);
+//	    world.setStepThreadingImplementation(threading.dThreadingImplementationGetFunctions(), threading);
+
+		// run simulation
+		dsSimulationLoop (args,352,288,this);
+
+//	    threading.shutdownProcessing();//dThreadingImplementationShutdownProcessing(threading);
+//	    pool.freeThreadPool();
+//	    world.setStepThreadingImplementation(null, null);
+//	    threading.free();
+ 
+		contactgroup.destroy();
+		space.destroy();
+		world.destroy();
+
+		// destroy heightfield data, because _we_ own it not ODE
+		height.destroy();
+
+		OdeHelper.closeODE();
+	}
+
+
+	@Override
+	public void stop() {
+		// Nothing
+	}
+}


### PR DESCRIPTION
This patch contains an alternative implementation of the heightfield based on Gimpact. It also contains related changes to trimesh colliders to sort contacts based on their depth before discarding the ones beyond the given limit. There is no switch to disable the new behaviour, but it can be easily added - the invocations of Collections.sort can be enclosed with a single if statement.
There is also a corresponding demo, please note that ODE does not support convex-trimesh collisions and so convex hulls will simply fall through the heightfield in the demo.
Moreover, a the DxAbstractHeightfield class was extracted in order to make it easy to add DHeightfield implementations with no need to override colliders.