### PR TITLE
Simple support for rag dolls

### DIFF
--- a/core/src/main/java/org/ode4j/ode/internal/joints/DxJointConstrainedBall.java
+++ b/core/src/main/java/org/ode4j/ode/internal/joints/DxJointConstrainedBall.java
@@ -1,0 +1,141 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.joints;
+
+import static org.ode4j.ode.OdeMath.dCalcVectorCross3;
+import static org.ode4j.ode.internal.Common.M_PI;
+import static org.ode4j.ode.internal.Rotation.dRFromAxisAndAngle;
+
+import org.ode4j.math.DMatrix3;
+import org.ode4j.math.DVector3;
+import org.ode4j.ode.DWorld;
+import org.ode4j.ode.OdeMath;
+import org.ode4j.ode.internal.DxWorld;
+
+/**
+ * Ball and socket joint with constraints as described here http://www.monsterden.net/software/ragdoll-pyode-tutorial
+ */
+public class DxJointConstrainedBall extends DxJointBall {
+
+	private final DVector3 baseAxis;
+	private final DVector3 body2Axis;
+	private final DVector3 twistUpAxis1;
+	private final DVector3 twistUpAxis2;
+	private final DVector3 axis1;
+	private final DVector3 axis2;
+	private final DxJointLimitMotor limotFlex;
+	private final DxJointLimitMotor limotTwist;
+
+	public DxJointConstrainedBall(DWorld w) {
+		super((DxWorld) w);
+		baseAxis = new DVector3();
+		body2Axis = new DVector3();
+		twistUpAxis1 = new DVector3();
+		twistUpAxis2 = new DVector3();
+		limotFlex = new DxJointLimitMotor();
+		limotFlex.init((DxWorld) w);
+		limotTwist = new DxJointLimitMotor();
+		limotTwist.init((DxWorld) w);
+		axis1 = new DVector3();
+		axis2 = new DVector3();
+	}
+
+	@Override
+	public void getInfo1(DxJoint.Info1 info) {
+		info.setNub(3);
+		info.setM(3);
+		boolean limitingFlex = (limotFlex.lostop >= -M_PI || limotFlex.histop <= M_PI)
+				&& limotFlex.lostop <= limotFlex.histop;
+		boolean limitingTwist = (limotTwist.lostop >= -M_PI || limotTwist.histop <= M_PI)
+				&& limotTwist.lostop <= limotTwist.histop;
+		DVector3 flex = new DVector3();
+		getAxis(flex, baseAxis);
+		DVector3 twist = new DVector3();
+		getAxis2(twist, body2Axis);
+		dCalcVectorCross3(axis1, twist, flex);
+		axis1.safeNormalize();
+		double angle = limitingFlex ? Math.acos(flex.dot(twist)) : 0;
+		if (limotFlex.testRotationalLimit(angle)) {
+			info.incM();
+		}
+		if (limitingTwist) {
+			DVector3 twistUpB1 = new DVector3();
+			getAxis(twistUpB1, twistUpAxis1);
+			DVector3 twistUpB2 = new DVector3();
+			getAxis2(twistUpB2, twistUpAxis2);
+			DMatrix3 R = new DMatrix3();
+			dRFromAxisAndAngle(R, axis1, angle);
+			DVector3 projected = new DVector3();
+			OdeMath.dMultiply0_133(projected, twistUpB1, R);
+			double angle2 = Math.acos(projected.dot(twistUpB2));
+			if (limotTwist.testRotationalLimit(angle2)) {
+				dCalcVectorCross3(axis2, twistUpB2, projected);
+				axis2.safeNormalize();
+				info.incM();
+			}
+		} else {
+			limotTwist.testRotationalLimit(0.0);
+		}
+	}
+
+	@Override
+	public void getInfo2(double worldFPS, double worldERP, DxJoint.Info2Descr info) {
+		setBall(this, worldFPS, erp, info, anchor1, anchor2);
+		int m = 3;
+		m += limotFlex.addLimot(this, worldFPS, info, m, axis1, true);
+		m += limotTwist.addLimot(this, worldFPS, info, m, axis2, true);
+	}
+
+	/**
+	 * @param baseAxis - base axis for constraints
+	 * @param body2Axis - main axis of the 2nd body
+	 */
+	public void setAxes(DVector3 baseAxis, DVector3 body2Axis) {
+		baseAxis.safeNormalize();
+		body2Axis.safeNormalize();
+		DVector3 twistUpAxis = new DVector3();
+		if (Math.abs(body2Axis.dot(new DVector3(0.0, 1.0, 0.0))) < 0.7) {
+			twistUpAxis.set(0, 1, 0);
+		} else {
+			twistUpAxis.set(0, 0, 1);
+		}
+		DVector3 cross = new DVector3();
+		cross.eqCross(body2Axis, twistUpAxis);
+		cross.safeNormalize();
+		twistUpAxis.eqCross(cross, body2Axis);
+		twistUpAxis.safeNormalize();
+		setAxes(baseAxis, this.baseAxis, null);
+		setAxes(body2Axis, null, this.body2Axis);
+		setAxes(twistUpAxis, twistUpAxis1, twistUpAxis2);
+	}
+
+	public void setLimits(double flexLimit, double twistLimit) {
+		limotFlex.set(PARAM.dParamLoStop, -flexLimit);
+		limotFlex.set(PARAM.dParamHiStop, flexLimit);
+		limotTwist.set(PARAM.dParamLoStop, -twistLimit);
+		limotTwist.set(PARAM.dParamHiStop, twistLimit);
+	}
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/ragdoll/DxRagdoll.java
+++ b/core/src/main/java/org/ode4j/ode/internal/ragdoll/DxRagdoll.java
@@ -1,0 +1,331 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.ragdoll;
+
+import static org.ode4j.ode.internal.Rotation.dQMultiply1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.ode4j.math.DMatrix3;
+import org.ode4j.math.DQuaternion;
+import org.ode4j.math.DQuaternionC;
+import org.ode4j.math.DVector3;
+import org.ode4j.math.DVector3C;
+import org.ode4j.ode.DBody;
+import org.ode4j.ode.DCapsule;
+import org.ode4j.ode.DFixedJoint;
+import org.ode4j.ode.DHingeJoint;
+import org.ode4j.ode.DJoint;
+import org.ode4j.ode.DJoint.PARAM_N;
+import org.ode4j.ode.DMass;
+import org.ode4j.ode.DSpace;
+import org.ode4j.ode.DUniversalJoint;
+import org.ode4j.ode.DWorld;
+import org.ode4j.ode.OdeHelper;
+import org.ode4j.ode.internal.joints.DxJointConstrainedBall;
+import org.ode4j.ode.ragdoll.DRagdollBoneConfig;
+import org.ode4j.ode.ragdoll.DRagdollConfig;
+import org.ode4j.ode.ragdoll.DRagdollJointConfig;
+
+public class DxRagdoll {
+
+    public class DxRagdollBody {
+        private final DBody body;
+        private final double length;
+        private final double radius;
+        private final DVector3 position;
+        private final DQuaternion quaternion;
+        private DVector3[] pBuffer;
+        private DQuaternion[] qBuffer;
+
+        public DxRagdollBody(DBody body, double length, double radius, DVector3C pinitial, DQuaternionC qinitial) {
+            this.body = body;
+            this.length = length;
+            this.radius = radius;
+            this.position = new DVector3(pinitial);
+            this.quaternion = new DQuaternion(qinitial.get0(), qinitial.get1(), qinitial.get2(), qinitial.get3());
+        }
+
+        public double getLength() {
+            return length;
+        }
+
+        public double getRadius() {
+            return radius;
+        }
+
+        public DVector3 getPosition() {
+            return position;
+        }
+
+        public DQuaternion getQuaternion() {
+            return quaternion;
+        }
+
+        public DBody getBody() {
+            return body;
+        }
+
+    }
+
+    private final DWorld world;
+    private final DSpace space;
+    private final List<DxRagdollBody> bones = new ArrayList<DxRagdollBody>(16);
+    private final List<DJoint> joints = new ArrayList<DJoint>();
+    private double totalMass;
+    private boolean autoDisabled;
+    private double autoDisableLinearAverageThreshold;
+    private double autoDisableAngularAverageThreshold;
+    private int autoDisableAverageSamples;
+    private int autoDisableBufferIndex;
+    private boolean autoDisableBufferReady;
+
+    public DxRagdoll(DWorld world, DSpace space, DRagdollConfig skeleton) {
+        this.world = world;
+        this.space = space;
+        autoDisableLinearAverageThreshold = 0.1;
+        autoDisableAngularAverageThreshold = 0.1;
+        for (DRagdollBoneConfig bone : skeleton.getBones()) {
+            addBody(bone.getStart(), bone.getEnd(), bone.getRadius());
+        }
+        adjustMass(skeleton);
+        for (DRagdollJointConfig joint : skeleton.getJoints()) {
+            DxRagdollBody bone1 = bones.get(joint.getBone());
+            DxRagdollBody bone2 = bones.get(joint.getBone2());
+            switch (joint.getType()) {
+            case CONSTRAINED_BALL:
+                addConstrainedBallJoint(bone1, bone2, joint.getAnchor(), joint.getAxis(), joint.getAxis2(), joint.getLimitMax(), joint.getLimitMax2());
+                break;
+            case FIXED:
+                addFixedJoint(bone1, bone2);
+                break;
+            case HINGE:
+                addHingeJoint(bone1, bone2, joint.getAnchor(), joint.getAxis(), joint.getLimitMin(), joint.getLimitMax());
+                break;
+            case UNIVERSAL:
+                addUniversalJoint(bone1, bone2, joint.getAnchor(), joint.getAxis(), joint.getAxis2(), joint.getLimitMin(), joint.getLimitMax(), joint.getLimitMin2(), joint.getLimitMax2());
+                break;
+            }
+        }
+    }
+
+    private DxRagdollBody addBody(DVector3 p1, DVector3 p2, double radius) {
+        p1 = new DVector3(p1);
+        p2 = new DVector3(p2);
+        double cyllen = p1.distance(p2) - radius;
+        DBody body = OdeHelper.createBody(world);
+        DMass m = OdeHelper.createMass();
+        m.setCapsule(1, 3, radius, cyllen);
+        body.setMass(m);
+        DCapsule geom = OdeHelper.createCapsule(space, radius, cyllen);
+        geom.setBody(body);
+        DVector3 za = new DVector3(p2);
+        (za.sub(p1)).safeNormalize();
+        DVector3 xa;
+        DVector3 ya;
+        if (Math.abs(za.dot(new DVector3(1.0, 0.0, 0.0))) < 0.7) {
+            xa = new DVector3(1.0, 0.0, 0.0);
+            ya = new DVector3();
+            ya.eqCross(za, xa);
+            ya.safeNormalize();
+            xa.eqCross(ya, za);
+        } else {
+            ya = new DVector3(0.0, 1.0, 0.0);
+            xa = new DVector3();
+            xa.eqCross(ya, za);
+            xa.safeNormalize();
+            ya.eqCross(za, xa);
+        }
+        body.setPosition(p1.add(p2).scale(0.5));
+        body.setRotation(new DMatrix3(xa.get0(), ya.get0(), za.get0(), xa.get1(), ya.get1(), za.get1(), xa.get2(), ya.get2(), za.get2()));
+        totalMass += m.getMass();
+        DxRagdollBody bone = new DxRagdollBody(body, cyllen, radius, body.getPosition(), body.getQuaternion());
+        bones.add(bone);
+        return bone;
+    }
+
+    private void adjustMass(DRagdollConfig skeleton) {
+        for (DxRagdollBody bone : bones) {
+            DMass mass = ((DMass)bone.getBody().getMass());
+            mass.adjust(bone.getBody().getMass().getMass() * skeleton.getMass() / totalMass);
+            bone.getBody().setMass(mass);
+        }
+    }
+
+    private DJoint addFixedJoint(DxRagdollBody body1, DxRagdollBody body2) {
+        DFixedJoint joint = OdeHelper.createFixedJoint(world);
+        joint.attach(body1.body, body2.body);
+        joint.setFixed();
+        joints.add(joint);
+        return joint;
+    }
+
+    private DJoint addHingeJoint(DxRagdollBody body1, DxRagdollBody body2, DVector3 anchor, DVector3 axis, double loStop, double hiStop) {
+        DHingeJoint joint = OdeHelper.createHingeJoint(world);
+        joint.attach(body1.body, body2.body);
+        joint.setAnchor(anchor);
+        joint.setAxis(axis);
+        joint.setParam(PARAM_N.dParamLoStop1, loStop);
+        joint.setParam(PARAM_N.dParamHiStop1, hiStop);
+        joints.add(joint);
+        return joint;
+    }
+
+    private DJoint addUniversalJoint(DxRagdollBody body1, DxRagdollBody body2, DVector3 anchor, DVector3 axis1, DVector3 axis2,
+            double loStop1, double hiStop1, double loStop2, double hiStop2) {
+        DUniversalJoint joint = OdeHelper.createUniversalJoint(world);
+        joint.attach(body1.body, body2.body);
+        joint.setAnchor(anchor);
+        joint.setAxis1(axis1);
+        joint.setAxis2(axis2);
+        joint.setParam(PARAM_N.dParamLoStop1, loStop1);
+        joint.setParam(PARAM_N.dParamHiStop1, hiStop1);
+        joint.setParam(PARAM_N.dParamLoStop2, loStop2);
+        joint.setParam(PARAM_N.dParamHiStop2, hiStop2);
+        joints.add(joint);
+        return joint;
+    }
+
+    private DJoint addConstrainedBallJoint(DxRagdollBody body1, DxRagdollBody body2, DVector3 anchor, DVector3 flexAxis, DVector3 twistAxis,
+            double flexLimit, double twistLimit) {
+        DxJointConstrainedBall joint = new DxJointConstrainedBall(world);
+        joint.attach(body1.body, body2.body);
+        joint.setAnchor(anchor);
+        joint.setAxes(flexAxis, twistAxis);
+        joint.setLimits(flexLimit, twistLimit);
+        joints.add(joint);
+        return joint;
+    }
+
+    public void setAngularDamping(double damping) {
+        for (DxRagdollBody bone : bones) {
+            bone.getBody().setAngularDamping(damping);
+        }
+    }
+
+    public List<DxRagdollBody> getBones() {
+        return bones;
+    }
+
+    public List<DJoint> getJoints() {
+        return joints;
+    }
+
+    public boolean isIdle() {
+        return autoDisabled;
+    }
+
+    public void setAutoDisableAverageSamplesCount(int samples) {
+        if (samples != autoDisableAverageSamples) {
+            autoDisableAverageSamples = samples;
+            for (DxRagdollBody bone : bones) {
+                bone.pBuffer = new DVector3[samples];
+                bone.qBuffer = new DQuaternion[samples];
+                for (int i = 0; i < samples; i++) {
+                    bone.pBuffer[i] = new DVector3();
+                    bone.qBuffer[i] = new DQuaternion();
+                }
+            }
+        }
+        autoDisableBufferIndex = 0;
+        autoDisableBufferReady = false;
+    }
+
+    public void setAutoDisableLinearAverageThreshold(double linearAverageThreshold) {
+        this.autoDisableLinearAverageThreshold = linearAverageThreshold;
+    }
+
+    public void setAutoDisableAngularAverageThreshold(double angularAverageThreshold) {
+        this.autoDisableAngularAverageThreshold = angularAverageThreshold;
+    }
+
+    public void autoDisable(double stepsize) {
+        if (autoDisableAverageSamples < 1) {
+            return;
+        }
+        double linearThreashold = autoDisableAverageSamples * stepsize * autoDisableLinearAverageThreshold;
+        linearThreashold *= linearThreashold;
+        double angularThreashold = autoDisableAverageSamples * stepsize * autoDisableAngularAverageThreshold;
+        angularThreashold = Math.cos(angularThreashold);
+        boolean allIdle = false;
+        if (autoDisableBufferReady) {
+            allIdle = true;
+            for (DxRagdollBody bone : bones) {
+                DBody body = bone.body;
+                DVector3 avgPos = new DVector3();
+                DQuaternion avgQuat = new DQuaternion();
+                for (int i = 0; i < autoDisableAverageSamples; i++) {
+                    DVector3C prevPos = bone.pBuffer[i];
+                    DQuaternion prevQuat = bone.qBuffer[i];
+                    avgPos.add(prevPos);
+                    avgQuat.add(prevQuat);
+                }
+                avgPos.scale(1.0 / autoDisableAverageSamples);
+                avgQuat.safeNormalize4();
+                avgPos = avgPos.sub(body.getPosition());
+                double ldiff = avgPos.dot(avgPos);
+                DQuaternion adiff = new DQuaternion();
+                dQMultiply1(adiff, avgQuat, body.getQuaternion());
+                if (ldiff > linearThreashold || adiff.get0() < angularThreashold) {
+                    allIdle = false;
+                    break;
+                }
+            }
+        }
+        autoDisabled = allIdle;
+        for (DxRagdollBody bone : bones) {
+            bone.pBuffer[autoDisableBufferIndex].set(bone.body.getPosition());
+            bone.qBuffer[autoDisableBufferIndex].set(bone.body.getQuaternion());
+            if (autoDisabled) {
+                bone.body.disable();
+                bone.body.setLinearVel(0, 0, 0);
+                bone.body.setAngularVel(0, 0, 0);
+                bone.body.setPosition(bone.position);
+                bone.body.setQuaternion(bone.quaternion);
+            } else {
+                bone.position.set(bone.body.getPosition());
+                bone.quaternion.set(bone.body.getQuaternion());
+            }
+        }
+        autoDisableBufferIndex++;
+        if (autoDisableBufferIndex == autoDisableAverageSamples) {
+            autoDisableBufferIndex = 0;
+            autoDisableBufferReady = true;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    public void destroy() {
+        for (DJoint joint : joints) {
+            joint.destroy();
+        }
+        for (DxRagdollBody bone : bones) {
+            bone.body.destroy();
+            bone.body.getFirstGeom().destroy();
+        }
+    }
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/ragdoll/DxRagdollBoneConfig.java
+++ b/core/src/main/java/org/ode4j/ode/internal/ragdoll/DxRagdollBoneConfig.java
@@ -1,0 +1,57 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.ragdoll;
+
+import org.ode4j.math.DVector3;
+import org.ode4j.ode.ragdoll.DRagdollBoneConfig;
+
+public class DxRagdollBoneConfig implements DRagdollBoneConfig {
+
+    private final DVector3 start;
+    private final DVector3 end;
+    private final double radius;
+
+    public DxRagdollBoneConfig(DVector3 start, DVector3 end, double radius) {
+        this.start = start;
+        this.end = end;
+        this.radius = radius;
+    }
+
+    @Override
+    public DVector3 getStart() {
+        return start;
+    }
+
+    @Override
+    public DVector3 getEnd() {
+        return end;
+    }
+
+    @Override
+    public double getRadius() {
+        return radius;
+    }
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/ragdoll/DxRagdollJointConfig.java
+++ b/core/src/main/java/org/ode4j/ode/internal/ragdoll/DxRagdollJointConfig.java
@@ -1,0 +1,106 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.ragdoll;
+
+import org.ode4j.math.DVector3;
+import org.ode4j.ode.ragdoll.DRagdollJointConfig;
+
+public class DxRagdollJointConfig implements DRagdollJointConfig {
+
+    private final JointType type;
+    private final int bone;
+    private final int bone2;
+    private final DVector3 anchor;
+    private final DVector3 axis;
+    private final DVector3 axis2;
+    private final double limitMin;
+    private final double limitMax;
+    private final double limitMin2;
+    private final double limitMax2;
+
+    public DxRagdollJointConfig(JointType type, int bone, int bone2, DVector3 anchor, DVector3 axis, DVector3 axis2, double limitMin,
+            double limitMax, double limitMin2, double limitMax2) {
+        this.type = type;
+        this.bone = bone;
+        this.bone2 = bone2;
+        this.anchor = anchor;
+        this.axis = axis;
+        this.axis2 = axis2;
+        this.limitMin = limitMin;
+        this.limitMax = limitMax;
+        this.limitMin2 = limitMin2;
+        this.limitMax2 = limitMax2;
+    }
+
+    @Override
+    public JointType getType() {
+        return type;
+    }
+
+    @Override
+    public int getBone() {
+        return bone;
+    }
+
+    @Override
+    public int getBone2() {
+        return bone2;
+    }
+
+    @Override
+    public DVector3 getAnchor() {
+        return anchor;
+    }
+
+    @Override
+    public DVector3 getAxis() {
+        return axis;
+    }
+
+    @Override
+    public DVector3 getAxis2() {
+        return axis2;
+    }
+
+    @Override
+    public double getLimitMin() {
+        return limitMin;
+    }
+
+    @Override
+    public double getLimitMax() {
+        return limitMax;
+    }
+
+    @Override
+    public double getLimitMin2() {
+        return limitMin2;
+    }
+
+    @Override
+    public double getLimitMax2() {
+        return limitMax2;
+    }
+}

--- a/core/src/main/java/org/ode4j/ode/ragdoll/DRagdollBoneConfig.java
+++ b/core/src/main/java/org/ode4j/ode/ragdoll/DRagdollBoneConfig.java
@@ -1,0 +1,36 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.ragdoll;
+
+import org.ode4j.math.DVector3;
+
+public interface DRagdollBoneConfig {
+
+    DVector3 getStart();
+
+    DVector3 getEnd();
+
+    double getRadius();
+}

--- a/core/src/main/java/org/ode4j/ode/ragdoll/DRagdollConfig.java
+++ b/core/src/main/java/org/ode4j/ode/ragdoll/DRagdollConfig.java
@@ -1,0 +1,34 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.ragdoll;
+
+public interface DRagdollConfig {
+
+    double getMass();
+
+    DRagdollBoneConfig[] getBones();
+
+    DRagdollJointConfig[] getJoints();
+}

--- a/core/src/main/java/org/ode4j/ode/ragdoll/DRagdollJointConfig.java
+++ b/core/src/main/java/org/ode4j/ode/ragdoll/DRagdollJointConfig.java
@@ -1,0 +1,54 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.ragdoll;
+
+import org.ode4j.math.DVector3;
+
+public interface DRagdollJointConfig {
+
+    public enum JointType {
+        FIXED, HINGE, UNIVERSAL, CONSTRAINED_BALL
+    }
+
+    JointType getType();
+
+    int getBone();
+
+    int getBone2();
+
+    DVector3 getAnchor();
+
+    DVector3 getAxis();
+
+    DVector3 getAxis2();
+
+    double getLimitMin();
+
+    double getLimitMax();
+
+    double getLimitMin2();
+
+    double getLimitMax2();
+}

--- a/demo/src/main/java/org/ode4j/demo/DemoJointConstrainedBall.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJointConstrainedBall.java
@@ -1,0 +1,191 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file LICENSE-BSD.TXT.                                       *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT and LICENSE-BSD.TXT for more details.                     *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.demo;
+
+import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
+import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
+import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
+import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
+import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
+import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+
+import org.ode4j.drawstuff.DrawStuff.DS_TEXTURE_NUMBER;
+import org.ode4j.drawstuff.DrawStuff.dsFunctions;
+import org.ode4j.math.DMatrix3C;
+import org.ode4j.math.DVector3;
+import org.ode4j.math.DVector3C;
+import org.ode4j.ode.DBody;
+import org.ode4j.ode.DBox;
+import org.ode4j.ode.DGeom;
+import org.ode4j.ode.DMass;
+import org.ode4j.ode.DSpace;
+import org.ode4j.ode.DSphere;
+import org.ode4j.ode.DWorld;
+import org.ode4j.ode.OdeHelper;
+import org.ode4j.ode.internal.joints.DxJointConstrainedBall;
+
+public class DemoJointConstrainedBall extends dsFunctions {
+
+	private DWorld world;
+	private DSpace space;
+	private DBody body1;
+	private DBody body2;
+	private DxJointConstrainedBall joint1;
+	private DxJointConstrainedBall joint2;
+
+	private static double[] xyz = {3.8966, -2.0614, 4.0300};
+	private static double[] hpr = {153.5, -16.5, 0};
+
+	@Override
+	public void start()
+	{
+		world = OdeHelper.createWorld();
+		world.setGravity(0,0,-9.8);
+
+		world.setDamping(1e-4, 1e-5);
+		//    dWorldSetERP(world, 1);
+
+		space = OdeHelper.createSimpleSpace();
+
+		body1 = OdeHelper.createBody(world);
+		body2 = OdeHelper.createBody(world);
+
+		body1.setPosition(0, 0, 3);
+		body2.setPosition(0, 0, 2);
+
+
+		DGeom g;
+		DMass mass = OdeHelper.createMass();
+
+		g = OdeHelper.createBox(space, 0.2, 0.2, 1);
+		g.setBody(body1);
+		mass.setBox(1, 0.2, 0.2, 1);
+		body1.setMass(mass);
+
+		g = OdeHelper.createBox(space, 0.2, 0.2, 1);
+		g.setBody(body2);
+		mass.setBox(1, 0.2, 0.2, 1);
+		body2.setMass(mass);
+
+		joint1 = new DxJointConstrainedBall(world);
+		joint1.attach(body1, null);
+		joint1.setAnchor(0, 0, 3.5);
+		joint1.setAxes(new DVector3(0, 0, 1), new DVector3(0, 0, 1));
+		joint1.setLimits(0.35 * Math.PI, 0.3 * Math.PI);
+
+		joint2 = new DxJointConstrainedBall(world);
+		joint2.attach(body1, body2);
+		joint2.setAnchor(0, 0, 2.5);
+		joint2.setAxes(new DVector3(0, 0, 1), new DVector3(0, 0, 1));
+		joint2.setLimits(0.3 * Math.PI, 0.4 * Math.PI);
+
+		// initial camera position
+		dsSetViewpoint (xyz,hpr);
+	}
+
+	@Override
+	public void stop()
+	{
+		space.destroy();
+
+		world.destroy();
+	}
+
+
+	private void drawGeom(DGeom g)
+	{
+		//int gclass = dGeomGetClass(g);
+		DVector3C pos = g.getPosition();
+		DMatrix3C rot = g.getRotation();
+
+		if (g instanceof DSphere) {
+			dsSetColorAlpha(0, 0.75, 0.5, 1);
+			dsSetTexture (DS_TEXTURE_NUMBER.DS_CHECKERED);
+			dsDrawSphere(pos, rot, ((DSphere)g).getRadius());
+		} else if (g instanceof DBox) {
+			dsSetColorAlpha(1, 1, 0, 1);
+			dsSetTexture (DS_TEXTURE_NUMBER.DS_WOOD);
+			DVector3C lengths = ((DBox)g).getLengths();
+			dsDrawBox(pos, rot, lengths);
+		}
+	}
+
+	private static double t = 0;
+
+
+	@Override
+	public void step(boolean pause)
+	{
+		if (!pause) {
+
+
+			final double step = 0.005;
+			final int nsteps = 4;
+
+			for (int i=0; i<nsteps; ++i) {
+
+				double f = Math.sin(t*1.2)*0.8;
+				body1.addForceAtRelPos(
+						f, 0, 0, 
+						0.1, 0.1, -0.5); // at the lower end
+
+						double g = Math.sin(t*0.7)*0.8;
+						body2.addForceAtRelPos(
+								0.2 * g, g, 0, 
+								0.1, 0, -0.5); // at the lower end
+								t += step;
+
+								world.quickStep(step);
+			}
+		}
+
+		// now we draw everything
+		int ngeoms = space.getNumGeoms();
+		for (int i=0; i<ngeoms; ++i) {
+			DGeom g = space.getGeom(i);
+
+			drawGeom(g);
+		}
+
+	}
+
+
+	public static void main(String[] args) {
+		new DemoJointConstrainedBall().demo(args);
+	}
+
+	private void demo(String[] args) {
+		// create world
+		OdeHelper.initODE();
+
+		// run demo
+		dsSimulationLoop (args, 800, 600, this);
+
+		OdeHelper.closeODE();
+	}
+
+	@Override
+	public void command(char cmd) {
+		// Auto-generated method stub
+	}
+
+}

--- a/demo/src/main/java/org/ode4j/demo/ragdoll/DemoRagdoll.java
+++ b/demo/src/main/java/org/ode4j/demo/ragdoll/DemoRagdoll.java
@@ -1,0 +1,220 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.demo.ragdoll;
+
+import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
+import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
+import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
+import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
+import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.ode.OdeConstants.dContactBounce;
+import static org.ode4j.ode.OdeConstants.dContactSoftCFM;
+import static org.ode4j.ode.OdeHelper.areConnectedExcluding;
+
+import org.ode4j.drawstuff.DrawStuff.dsFunctions;
+import org.ode4j.math.DMatrix3;
+import org.ode4j.math.DMatrix3C;
+import org.ode4j.math.DQuaternion;
+import org.ode4j.math.DVector3;
+import org.ode4j.math.DVector3C;
+import org.ode4j.ode.DBody;
+import org.ode4j.ode.DCapsule;
+import org.ode4j.ode.DContact;
+import org.ode4j.ode.DContactBuffer;
+import org.ode4j.ode.DContactJoint;
+import org.ode4j.ode.DGeom;
+import org.ode4j.ode.DJoint;
+import org.ode4j.ode.DJointGroup;
+import org.ode4j.ode.DSpace;
+import org.ode4j.ode.DWorld;
+import org.ode4j.ode.OdeHelper;
+import org.ode4j.ode.OdeMath;
+import org.ode4j.ode.internal.Rotation;
+import org.ode4j.ode.internal.ragdoll.DxRagdoll;
+import org.ode4j.ode.internal.ragdoll.DxRagdoll.DxRagdollBody;
+
+public class DemoRagdoll extends dsFunctions {
+
+	private static final int  MAX_CONTACTS = 64;		// maximum number of contact points per body
+	private DWorld world;
+	private DSpace space;
+	private DxRagdoll ragdoll;
+	private static double[] xyz = {4.3966, -2.0614, 3.4300};
+	private static double[] hpr = {153.5, -14.5, 0};
+	private DJointGroup contactgroup;
+	private boolean show_contacts = false;	// show contact points?
+
+	@Override
+	public void start()
+	{
+		//dAllocateODEDataForThread(dAllocateMaskAll);
+		dsSetViewpoint (xyz,hpr);
+		System.out.println ("Press space to apply some force to the ragdoll");
+
+		world = OdeHelper.createWorld();
+		world.setGravity(0,0,-9.8);
+		world.setDamping(1e-4, 1e-5);
+		//    dWorldSetERP(world, 1);
+		space = OdeHelper.createSimpleSpace();
+		contactgroup = OdeHelper.createJointGroup ();
+		OdeHelper.createPlane( space, 0, 0, 1, 0 );
+
+		ragdoll = new DxRagdoll(world, space, new DxDefaultHumanRagdollConfig());
+		ragdoll.setAngularDamping(0.1);
+		DQuaternion q = new DQuaternion(1, 0, 0, 0);
+		Rotation.dQFromAxisAndAngle(q, new DVector3(1, 0, 0), -0.5 * Math.PI);
+		for (int i = 0; i < ragdoll.getBones().size(); i++) {
+			DxRagdollBody bone = ragdoll.getBones().get(i);
+			DGeom g = OdeHelper.createCapsule(space, bone.getRadius(), bone.getLength());
+			DBody body = bone.getBody();
+			DQuaternion qq = new DQuaternion();
+			OdeMath.dQMultiply1(qq, q, body.getQuaternion());
+			body.setQuaternion(qq);
+			DMatrix3 R = new DMatrix3();
+			OdeMath.dRfromQ(R, q);
+			DVector3 v = new DVector3();
+			OdeMath.dMultiply0_133(v, body.getPosition(), R);
+			body.setPosition(v.get0(), v.get1(), v.get2());
+			g.setBody(body);
+		}
+		// initial camera position
+		dsSetViewpoint (xyz,hpr);
+	}
+
+	@Override
+	public void stop()
+	{
+		contactgroup.destroy();
+		space.destroy();
+		world.destroy();
+	}
+
+
+	private void drawGeom(DGeom g)
+	{
+		//int gclass = dGeomGetClass(g);
+		if (g instanceof DCapsule) {
+			DVector3C pos = g.getPosition();
+			DMatrix3C rot = g.getRotation();
+			DCapsule cap = (DCapsule) g; 
+			dsDrawCapsule (pos, rot, cap.getLength(), cap.getRadius());
+		}
+	}
+
+	private DGeom.DNearCallback nearCallback = new DGeom.DNearCallback() {
+		@Override
+		public void call(Object data, DGeom o1, DGeom o2) {
+			nearCallback(data, o1, o2);
+		}
+	};
+
+	private void nearCallback (Object data, DGeom o1, DGeom o2) {
+		int i;
+		// if (o1->body && o2->body) return;
+
+		// exit without doing anything if the two bodies are connected by a joint
+		DBody b1 = o1.getBody();
+		DBody b2 = o2.getBody();
+		if (b1!=null && b2!=null && areConnectedExcluding (b1,b2,DContactJoint.class)) {
+			return;
+		}
+
+		DContactBuffer contacts = new DContactBuffer(MAX_CONTACTS);   // up to MAX_CONTACTS contacts per box-box
+		for (i=0; i<MAX_CONTACTS; i++) {
+			DContact contact = contacts.get(i);
+			contact.surface.mode = dContactBounce | dContactSoftCFM;
+			contact.surface.mu = 100;
+			contact.surface.mu2 = 0;
+			contact.surface.bounce = 0.01;
+			contact.surface.bounce_vel = 0.01;
+			contact.surface.soft_cfm = 0.0001;
+		}
+		int numc = OdeHelper.collide (o1,o2,MAX_CONTACTS,contacts.getGeomBuffer());
+		if (numc!=0) {
+			DMatrix3 RI = new DMatrix3();
+			RI.setIdentity();
+			final DVector3 ss = new DVector3(0.02,0.02,0.02);
+			for (i=0; i<numc; i++) {
+				DJoint c = OdeHelper.createContactJoint (world,contactgroup,contacts.get(i));
+				c.attach (b1,b2);
+				if (show_contacts) {
+					dsSetColor(0, 0, 1);
+					dsDrawBox (contacts.get(i).geom.pos,RI,ss);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void step(boolean pause)
+	{
+		space.collide (null,nearCallback);
+
+		if (!pause) {
+
+
+			final double step = 0.005;
+			final int nsteps = 4;
+
+			for (int i=0; i<nsteps; ++i) {
+				world.quickStep(step);
+			}
+		}
+		contactgroup.empty();
+
+		// now we draw everything
+		int ngeoms = space.getNumGeoms();
+		for (int i=0; i<ngeoms; ++i) {
+			DGeom g = space.getGeom(i);
+
+			drawGeom(g);
+		}
+
+	}
+
+
+	public static void main(String[] args) {
+		new DemoRagdoll().demo(args);
+	}
+
+	private void demo(String[] args) {
+		// create world
+		OdeHelper.initODE();
+
+		// run demo
+		dsSimulationLoop (args, 800, 600, this);
+
+		OdeHelper.closeODE();
+	}
+
+	@Override
+	public void command(char cmd) {
+		cmd = Character.toLowerCase(cmd);
+		if (cmd == ' ') {
+			ragdoll.getBones().get(DxDefaultHumanRagdollConfig.PELVIS).getBody().setLinearVel(0, 0, 80);
+		}
+	}
+
+}

--- a/demo/src/main/java/org/ode4j/demo/ragdoll/DxDefaultHumanRagdollConfig.java
+++ b/demo/src/main/java/org/ode4j/demo/ragdoll/DxDefaultHumanRagdollConfig.java
@@ -1,0 +1,345 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.demo.ragdoll;
+
+import org.ode4j.math.DVector3;
+import org.ode4j.ode.internal.ragdoll.DxRagdollBoneConfig;
+import org.ode4j.ode.internal.ragdoll.DxRagdollJointConfig;
+import org.ode4j.ode.ragdoll.DRagdollBoneConfig;
+import org.ode4j.ode.ragdoll.DRagdollConfig;
+import org.ode4j.ode.ragdoll.DRagdollJointConfig;
+import org.ode4j.ode.ragdoll.DRagdollJointConfig.JointType;
+
+/**
+ * Human rag doll configuration based on http://www.monsterden.net/software/ragdoll-pyode-tutorial with tiny fixes.  
+ */
+public class DxDefaultHumanRagdollConfig implements DRagdollConfig {
+
+    public final static int CHEST = 0;
+    public final static int BELLY = 1;
+    public final static int PELVIS = 2;
+    public final static int HEAD = 3;
+    public final static int RIGHT_UPPER_LEG = 4;
+    public final static int RIGHT_LOWER_LEG = 5;
+    public final static int RIGHT_FOOT = 6;
+    public final static int LEFT_UPPER_LEG = 7;
+    public final static int LEFT_LOWER_LEG = 8;
+    public final static int LEFT_FOOT = 9;
+    public final static int RIGHT_UPPER_ARM = 10;
+    public final static int RIGHT_FORE_ARM = 11;
+    public final static int RIGHT_HAND = 12;
+    public final static int LEFT_UPPER_ARM = 13;
+    public final static int LEFT_FORE_ARM = 14;
+    public final static int LEFT_HAND = 15;
+
+    public final static int MID_SPINE = 0;
+    public final static int LOW_SPINE = 1;
+    public final static int NECK = 2;
+    public final static int RIGHT_HIP = 3;
+    public final static int RIGHT_KNEE = 4;
+    public final static int RIGHT_ANKLE = 5;
+    public final static int LEFT_HIP = 6;
+    public final static int LEFT_KNEE = 7;
+    public final static int LEFT_ANKLE = 8;
+    public final static int RIGHT_SHOULDER = 9;
+    public final static int RIGHT_ELBOW = 10;
+    public final static int RIGHT_WRIST = 11;
+    public final static int LEFT_SHOULDER = 12;
+    public final static int LEFT_ELBOW = 13;
+    public final static int LEFT_WRIST = 14;
+
+    public double mass = 80;
+    public double thickness = 1.0;
+    public double upperArmLen = 0.30;
+    public double foreArmLen = 0.25;
+    public double handLen = 0.13; // wrist to mid-fingers only
+    public double footLen = 0.18; // ankles to base of ball of foot only
+    public double heelLen = 0.05; // ankles to base of ball of foot only
+    public double chestW = 0.36; // actually wider, but we want narrower than shoulders (esp. with large radius)
+    public double chestH = 1.35;
+    public double chestRadius = 0.13;
+    public double bellyO = 0.1;
+    public double bellyR = 0.125;
+    public double hipH = 0.86;
+    public double hipR = 0.125;
+    public double pelvisW = 0.25; // actually wider, but we want smaller than hip width
+    public double pelvisR = 0.125;
+    public double browH = 1.68;
+    public double mouthH = 1.53;
+    public double headO = 0.03;
+    public double headR = 0.11;
+    public double legW = 0.28; // between middles of upper legs
+    public double kneeH = 0.48;
+    public double ankleH = 0.08;
+    public double upperLegR = 0.11;
+    public double lowerLegR = 0.09;
+    public double footR = 0.09;
+    public double shoulderW = 0.41;
+    public double shoulderH = 1.37;
+    public double upperArmR = 0.08;
+    public double foreArmR = 0.075;
+    public double handR = 0.075;
+    public double neckH = 1.5;
+    public final DVector3 offset = new DVector3(0, 0, 0);
+    public final DVector3 scale = new DVector3(1, 1, 1);
+
+    @Override
+    public double getMass() {
+        return mass;
+    }
+
+    @Override
+    public DRagdollBoneConfig[] getBones() {
+        DRagdollBoneConfig[] bones = new DRagdollBoneConfig[LEFT_HAND + 1];
+        bones[CHEST] = new DxRagdollBoneConfig(getRightChestPos(), getLeftChestPos(), getChestRadius());
+        bones[BELLY] = new DxRagdollBoneConfig(getBellyTopPos(), getBellyBottomPos(), getBellyRadius());
+        bones[PELVIS] = new DxRagdollBoneConfig(getRightPelvisPos(), getLeftPelvisPos(), getPelvisRadius());
+        bones[HEAD] = new DxRagdollBoneConfig(getHeadTopPos(), getHeadBottomPos(), getHeadRadius());
+        DVector3 rHipPos = getRightHipPos();
+        DVector3 rKneePos = getRightKneePos();
+        DVector3 rAnklePos = getRightAnklePos();
+        bones[RIGHT_UPPER_LEG] = new DxRagdollBoneConfig(rHipPos, rKneePos, getUpperLegRadius());
+        bones[RIGHT_LOWER_LEG] = new DxRagdollBoneConfig(rKneePos, rAnklePos, getLowerLegRadius());
+        bones[RIGHT_FOOT] = new DxRagdollBoneConfig(getRightHeelPos(), getRightToesPos(), getFootRadius());
+        DVector3 lHipPos = getLeftHipPos();
+        DVector3 lKneePos = getLeftKneePos();
+        DVector3 lAnklePos = getLeftAnklePos();
+        bones[LEFT_UPPER_LEG] = new DxRagdollBoneConfig(lHipPos, lKneePos, getUpperLegRadius());
+        bones[LEFT_LOWER_LEG] = new DxRagdollBoneConfig(lKneePos, lAnklePos, getLowerLegRadius());
+        bones[LEFT_FOOT] = new DxRagdollBoneConfig(getLeftHeelPos(), getLeftToesPos(), getFootRadius());
+        DVector3 rShoulderPos = getRightShoulderPos();
+        DVector3 rElbowPos = getRightElbowPos();
+        DVector3 rWristPos = getRightWristPos();
+        bones[RIGHT_UPPER_ARM] = new DxRagdollBoneConfig(rShoulderPos, rElbowPos, getUpperArmRadius());
+        bones[RIGHT_FORE_ARM] = new DxRagdollBoneConfig(rElbowPos, rWristPos, getForeArmRadius());
+        bones[RIGHT_HAND] = new DxRagdollBoneConfig(rWristPos, getRightFingersPos(), getHandRadius());
+        DVector3 lShoulderPos = getLeftShoulderPos();
+        DVector3 lElbowPos = getLeftElbowPos();
+        DVector3 lWristPos = getLeftWristPos();
+        bones[LEFT_UPPER_ARM] = new DxRagdollBoneConfig(lShoulderPos, lElbowPos, getUpperArmRadius());
+        bones[LEFT_FORE_ARM] = new DxRagdollBoneConfig(lElbowPos, lWristPos, getForeArmRadius());
+        bones[LEFT_HAND] = new DxRagdollBoneConfig(lWristPos, getLeftFingersPos(), getHandRadius());
+        return bones;
+    }
+
+    private final static DVector3 rightAxis = new DVector3(1.0, 0.0, 0.0);
+    private final static DVector3 leftAxis = new DVector3(-1.0, 0.0, 0.0);
+    private final static DVector3 upAxis = new DVector3(0.0, 1.0, 0.0);
+    private final static DVector3 downAxis = new DVector3(0.0, -1.0, 0.0);
+    private final static DVector3 bkwdAxis = new DVector3(0.0, 0.0, 1.0);
+    private final static DVector3 fwdAxis = new DVector3(0.0, 0.0, -1.0);
+
+    @Override
+    public DRagdollJointConfig[] getJoints() {
+        DRagdollJointConfig[] joints = new DRagdollJointConfig[LEFT_WRIST + 1];
+        joints[MID_SPINE] = new DxRagdollJointConfig(JointType.FIXED, CHEST, BELLY, null, null, null, 0, 0, 0, 0);
+        joints[LOW_SPINE] = new DxRagdollJointConfig(JointType.FIXED, BELLY, PELVIS, null, null, null, 0, 0, 0, 0);
+        joints[NECK] = new DxRagdollJointConfig(JointType.CONSTRAINED_BALL, CHEST, HEAD, getNeckPos(), upAxis, upAxis, -Math.PI * 0.25,
+                Math.PI * 0.25, -Math.PI * 0.3, Math.PI * 0.3);
+        joints[RIGHT_HIP] = new DxRagdollJointConfig(JointType.UNIVERSAL, PELVIS, RIGHT_UPPER_LEG, getRightHipPos(), bkwdAxis, rightAxis,
+                -Math.PI * 0.1, Math.PI * 0.3, -Math.PI * 0.15, Math.PI * 0.5);
+        joints[RIGHT_KNEE] = new DxRagdollJointConfig(JointType.HINGE, RIGHT_UPPER_LEG, RIGHT_LOWER_LEG, getRightKneePos(), leftAxis, null,
+                0.0, Math.PI * 0.75, 0.0, 0.0);
+        joints[RIGHT_ANKLE] = new DxRagdollJointConfig(JointType.HINGE, RIGHT_LOWER_LEG, RIGHT_FOOT, getRightAnklePos(), rightAxis, null,
+                -Math.PI * 0.1, Math.PI * 0.05, 0.0, 0.0);
+        joints[LEFT_HIP] = new DxRagdollJointConfig(JointType.UNIVERSAL, PELVIS, LEFT_UPPER_LEG, getLeftHipPos(), fwdAxis, rightAxis,
+                -Math.PI * 0.1, Math.PI * 0.3, -Math.PI * 0.15, Math.PI * 0.5);
+        joints[LEFT_KNEE] = new DxRagdollJointConfig(JointType.HINGE, LEFT_UPPER_LEG, LEFT_LOWER_LEG, getLeftKneePos(), leftAxis, null, 0.0,
+                Math.PI * 0.75, 0.0, 0.0);
+        joints[LEFT_ANKLE] = new DxRagdollJointConfig(JointType.HINGE, LEFT_LOWER_LEG, LEFT_FOOT, getLeftAnklePos(), rightAxis, null,
+                -Math.PI * 0.1, Math.PI * 0.05, 0.0, 0.0);
+
+        DVector3 axis = new DVector3(-1.0, -1.0, 4.0);
+        axis.normalize();
+        joints[RIGHT_SHOULDER] = new DxRagdollJointConfig(JointType.CONSTRAINED_BALL, CHEST, RIGHT_UPPER_ARM, getRightShoulderPos(), axis,
+                leftAxis, -Math.PI * 0.45, Math.PI * 0.45, -Math.PI * 0.25, Math.PI * 0.25);
+        joints[RIGHT_ELBOW] = new DxRagdollJointConfig(JointType.HINGE, RIGHT_UPPER_ARM, RIGHT_FORE_ARM, getRightElbowPos(), downAxis, null,
+                0.0, Math.PI * 0.6, 0.0, 0.0);
+        joints[RIGHT_WRIST] = new DxRagdollJointConfig(JointType.HINGE, RIGHT_FORE_ARM, RIGHT_HAND, getRightWristPos(), fwdAxis, null,
+                -Math.PI * 0.1, Math.PI * 0.2, 0.0, 0.0);
+        axis = new DVector3(1.0, -1.0, 4.0);
+        axis.normalize();
+        joints[LEFT_SHOULDER] = new DxRagdollJointConfig(JointType.CONSTRAINED_BALL, CHEST, LEFT_UPPER_ARM, getLeftShoulderPos(), axis,
+                rightAxis, -Math.PI * 0.45, Math.PI * 0.45, -Math.PI * 0.25, Math.PI * 0.25);
+        joints[LEFT_ELBOW] = new DxRagdollJointConfig(JointType.HINGE, LEFT_UPPER_ARM, LEFT_FORE_ARM, getLeftElbowPos(), upAxis, null, 0.0,
+                Math.PI * 0.6, 0.0, 0.0);
+        joints[LEFT_WRIST] = new DxRagdollJointConfig(JointType.HINGE, LEFT_FORE_ARM, LEFT_HAND, getLeftWristPos(), bkwdAxis, null,
+                -Math.PI * 0.1, Math.PI * 0.2, 0.0, 0.0);
+        return joints;
+    }
+
+    public DVector3 getRightChestPos() {
+        return scaleAndOffset(new DVector3(-chestW * 0.5, chestH, 0.0));
+    }
+
+    public DVector3 getLeftChestPos() {
+        return scaleAndOffset(new DVector3(chestW * 0.5, chestH, 0.0));
+    }
+
+    public DVector3 getBellyTopPos() {
+        return scaleAndOffset(new DVector3(0.0, chestH - bellyO, 0.0));
+    }
+
+    public DVector3 getBellyBottomPos() {
+        return scaleAndOffset(new DVector3(0.0, hipH + bellyO, 0.0));
+    }
+
+    public DVector3 getRightPelvisPos() {
+        return scaleAndOffset(new DVector3(-pelvisW * 0.5, hipH, 0.0));
+    }
+
+    public DVector3 getLeftPelvisPos() {
+        return scaleAndOffset(new DVector3(pelvisW * 0.5, hipH, 0.0));
+    }
+
+    public DVector3 getHeadTopPos() {
+        return scaleAndOffset(new DVector3(0.0, browH, headO));
+    }
+
+    public DVector3 getHeadBottomPos() {
+        return scaleAndOffset(new DVector3(0.0, mouthH, headO));
+    }
+
+    public DVector3 getRightHipPos() {
+        return scaleAndOffset(new DVector3(-legW * 0.5, hipH, 0.0));
+    }
+
+    public DVector3 getRightKneePos() {
+        return scaleAndOffset(new DVector3(-legW * 0.5, kneeH, 0.0));
+    }
+
+    public DVector3 getRightAnklePos() {
+        return scaleAndOffset(new DVector3(-legW * 0.5, ankleH, 0.0));
+    }
+
+    public DVector3 getRightHeelPos() {
+        return scaleAndOffset(new DVector3(-legW * 0.5, ankleH, -heelLen));
+    }
+
+    public DVector3 getRightToesPos() {
+        return scaleAndOffset(new DVector3(-legW * 0.5, ankleH, footLen));
+    }
+
+    public DVector3 getLeftHipPos() {
+        return scaleAndOffset(new DVector3(legW * 0.5, hipH, 0.0));
+    }
+
+    public DVector3 getLeftKneePos() {
+        return scaleAndOffset(new DVector3(legW * 0.5, kneeH, 0.0));
+    }
+
+    public DVector3 getLeftAnklePos() {
+        return scaleAndOffset(new DVector3(legW * 0.5, ankleH, 0.0));
+    }
+
+    public DVector3 getLeftHeelPos() {
+        return scaleAndOffset(new DVector3(legW * 0.5, ankleH, -heelLen));
+    }
+
+    public DVector3 getLeftToesPos() {
+        return scaleAndOffset(new DVector3(legW * 0.5, ankleH, footLen));
+    }
+
+    public DVector3 getNeckPos() {
+        return scaleAndOffset(new DVector3(0.0, neckH, 0.0));
+    }
+
+    public DVector3 getRightShoulderPos() {
+        return scaleAndOffset(new DVector3(-shoulderW * 0.5, shoulderH, 0.0));
+    }
+
+    public DVector3 getRightElbowPos() {
+        return scaleAndOffset(new DVector3(-shoulderW * 0.5 - upperArmLen, shoulderH, 0.0));
+    }
+
+    public DVector3 getRightWristPos() {
+        return scaleAndOffset(new DVector3(-shoulderW * 0.5 - upperArmLen - foreArmLen, shoulderH, 0.0));
+    }
+
+    public DVector3 getRightFingersPos() {
+        return scaleAndOffset(new DVector3(-shoulderW * 0.5 - upperArmLen - foreArmLen - handLen, shoulderH, 0.0));
+    }
+
+    public DVector3 getLeftShoulderPos() {
+        return scaleAndOffset(new DVector3(shoulderW * 0.5, shoulderH, 0.0));
+    }
+
+    public DVector3 getLeftElbowPos() {
+        return scaleAndOffset(new DVector3(shoulderW * 0.5 + upperArmLen, shoulderH, 0.0));
+    }
+
+    public DVector3 getLeftWristPos() {
+        return scaleAndOffset(new DVector3(shoulderW * 0.5 + upperArmLen + foreArmLen, shoulderH, 0.0));
+    }
+
+    public DVector3 getLeftFingersPos() {
+        return scaleAndOffset(new DVector3(shoulderW * 0.5 + upperArmLen + foreArmLen + handLen, shoulderH, 0.0));
+    }
+
+    private DVector3 scaleAndOffset(DVector3 anchor) {
+        return new DVector3(anchor).scale(scale).add(offset);
+    }
+
+    public double getChestRadius() {
+        return chestRadius * thickness;
+    }
+
+    public double getBellyRadius() {
+        return bellyR * thickness;
+    }
+
+    public double getPelvisRadius() {
+        return pelvisR * thickness;
+    }
+
+    public double getHeadRadius() {
+        return headR * thickness;
+    }
+
+    public double getUpperLegRadius() {
+        return upperLegR * thickness;
+    }
+
+    public double getLowerLegRadius() {
+        return lowerLegR * thickness;
+    }
+
+    public double getFootRadius() {
+        return footR * thickness;
+    }
+
+    public double getUpperArmRadius() {
+        return upperArmR * thickness;
+    }
+
+    public double getHandRadius() {
+        return handR * thickness;
+    }
+
+    public double getForeArmRadius() {
+        return foreArmR * thickness;
+    }
+
+}


### PR DESCRIPTION
Here is my attempt at adding generic support for rag dolls (or any other entities made of multiple bodies connected with joints). The patch adds a new type of joint - DxJointConstrainedBall, it is an extension to the regular ball and socket joint and additionally provides a way to constrain the movement as described at http://www.monsterden.net/software/ragdoll-pyode-tutorial. It is useful to implement more realistic shoulders of a human rag doll for instance.
DxRagdoll class builds the actual rag doll based on the given list of "bones" and "joints". Additionally it provides a simple autoDisable method that can be used to freeze the whole rag doll when the movement of the bodies is minimal. Usually rag doll bodies tend to oscillate due to the high number of hard constraints and disabling only some of them does not work.
Additionally, there is a demo with an example of a humanoid rag doll based on the tutorial mentioned above. The demo is extremely simple, you can only press space to apply some force.