### PR TITLE
Correct scaling of tacc vector in QuickStep (issue #38).

### DIFF
--- a/core/src/main/java/org/ode4j/ode/internal/DxQuickStep.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxQuickStep.java
@@ -1883,8 +1883,8 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 		        double body_invMass_mul_stepsize = stepsize * b.invMass;
 		        for (int j=0; j<3; j++) {
 		            b.lvel.add(j, body_invMass_mul_stepsize * b.facc.get(j) );
-		            b.tacc.scale( stepsize );
 		        }
+		        b.tacc.scale( stepsize );
 		        dMultiplyAdd0_331 (b.avel, invI,invIrowP, b.tacc);
 		    }
 		}


### PR DESCRIPTION
Fix for #38.
Compared to VRep behaviour and regular Step.