### PR TITLE
Add support for convex-trimesh collisions

### DIFF
--- a/core/src/main/java/org/ode4j/ode/internal/CollideConvexTrimesh.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideConvexTrimesh.java
@@ -1,0 +1,42 @@
+package org.ode4j.ode.internal;
+
+import org.ode4j.ode.DAABBC;
+import org.ode4j.ode.DColliderFn;
+import org.ode4j.ode.DContactGeomBuffer;
+import org.ode4j.ode.DGeom;
+import org.ode4j.ode.internal.CollisionLibccd.CollideConvexTrimeshTrianglesCCD;
+import org.ode4j.ode.internal.gimpact.GimDynArrayInt;
+import org.ode4j.ode.internal.gimpact.GimGeometry.aabb3f;
+import org.ode4j.ode.internal.gimpact.GimTrimesh;
+
+public class CollideConvexTrimesh implements DColliderFn {
+
+	@Override
+	public int dColliderFn(DGeom o1, DGeom o2, int flags, DContactGeomBuffer contacts) {
+
+		DxGimpact trimesh = (DxGimpact) o2; 
+		GimTrimesh ptrimesh = trimesh.m_collision_trimesh;
+		aabb3f test_aabb = new aabb3f();
+
+		DAABBC aabb = o1.getAABB();
+		test_aabb.minX = (float) aabb.getMin0();
+		test_aabb.maxX = (float) aabb.getMax0();
+		test_aabb.minY = (float) aabb.getMin1();
+		test_aabb.maxY = (float) aabb.getMax1();
+		test_aabb.minZ = (float) aabb.getMin2();
+		test_aabb.maxZ = (float) aabb.getMax2();
+
+		GimDynArrayInt collision_result = GimDynArrayInt.GIM_CREATE_BOXQUERY_LIST();
+		ptrimesh.getAabbSet().gim_aabbset_box_collision(test_aabb, collision_result);
+		int contactcount = 0;
+		if (collision_result.size() != 0) {
+			int[] boxesresult = collision_result.GIM_DYNARRAY_POINTER();
+			ptrimesh.gim_trimesh_locks_work_data();
+			CollideConvexTrimeshTrianglesCCD collideFn = new CollideConvexTrimeshTrianglesCCD();
+			contactcount = collideFn.collide(o1, o2, boxesresult, flags, contacts);
+			ptrimesh.gim_trimesh_unlocks_work_data();
+		}
+		collision_result.GIM_DYNARRAY_DESTROY();
+		return contactcount;
+	}
+}

--- a/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
@@ -591,10 +591,8 @@ public class CollisionLibccd {
 		private int addPerturbedContacts(DGeom o1, DGeom o2, int flags, ccd_convex_t c1, ccd_triangle_t c2,
 				DContactGeomBuffer contacts, DVector3[] triangle, DContactGeom contact, int contactcount,
 				int maxcontacts) {
-			DVector3 upAxis = new DVector3();
-			if (Math.abs(contact.normal.dot(new DVector3(0.0, 1.0, 0.0))) < 0.7) {
-				upAxis.set(0, 1, 0);
-			} else {
+			DVector3 upAxis = new DVector3(0, 1, 0);
+			if (Math.abs(contact.normal.dot(upAxis)) > 0.7) {
 				upAxis.set(0, 0, 1);
 			}
 			DVector3 cross = new DVector3();
@@ -608,8 +606,8 @@ public class CollisionLibccd {
 			DVector3 p = new DVector3();
 			DVector3 perturbed = new DVector3();
 			for (int k = 0; k < 4; k++) {
-				dQFromAxisAndAngle(q1, upAxis, k % 1 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
-				dQFromAxisAndAngle(q2, cross, k % 2 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
+				dQFromAxisAndAngle(q1, upAxis, k % 2 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
+				dQFromAxisAndAngle(q2, cross, k / 2 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
 				dQMultiply3(qr, q1, q2);
 				for (int j = 0; j < 3; j++) {
 					p.eqDiff(triangle[j], contact.pos);

--- a/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
@@ -46,9 +46,6 @@ import static org.ode4j.ode.internal.libccd.CCDVec3.*;
 import static org.ode4j.ode.internal.Rotation.dQFromAxisAndAngle;
 import static org.ode4j.ode.internal.Rotation.dQMultiply0;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Lib ccd.
  *
@@ -527,30 +524,26 @@ public class CollisionLibccd {
 			int maxcontacts = (flags & 0xffff);
 			final DVector3[] triangle = new DVector3[] { new DVector3(), new DVector3(), new DVector3() };
 			int contactcount = 0;
+			DContactGeomBuffer tempContacts = new DContactGeomBuffer(1);
 			for (int i : triindices) {
-				DContactGeomBuffer tempContacts = new DContactGeomBuffer(1);
 				((DxTriMesh) o2).FetchTransformedTriangle(i, triangle);
 				for (int j = 0; j < 3; j++) {
 					c2.vertices[j].set(triangle[j].get0(), triangle[j].get1(), triangle[j].get2());
 				}
 				if (ccdCollide(o1, o2, flags, tempContacts, c1, ccdSupportConvex, ccdCenter, c2, ccdSupportTriangle,
 						ccdCenter) == 1) {
-					if ((flags & OdeConstants.CONTACTS_UNIMPORTANT) == 0) {
-						DContactGeom c = tempContacts.get();
-						c.side2 = i;
-						contactcount = addUniqueContact(contacts, c, contactcount, maxcontacts);
-					} else {
-						contactcount++;
+					DContactGeom c = tempContacts.get();
+					c.side2 = i;
+					contactcount = addUniqueContact(contacts, c, contactcount, maxcontacts);
+					if ((flags & OdeConstants.CONTACTS_UNIMPORTANT) != 0) {
+						break;
 					}
 				}
 			}
 			if (contactcount == 1 && (flags & OdeConstants.CONTACTS_UNIMPORTANT) == 0) {
-				((DxTriMesh) o2).FetchTransformedTriangle(contacts.get(0).side2, triangle);
-				for (int j = 0; j < 3; j++) {
-					c2.vertices[j].set(triangle[j].get0(), triangle[j].get1(), triangle[j].get2());
-				}
-				contactcount = addPerturbedContacts(o1, o2, flags, c1, c2, contacts, triangle, contacts.get(0),
-						contactcount);
+				DContactGeom contact = contacts.get(0);
+				((DxTriMesh) o2).FetchTransformedTriangle(contact.side2, triangle);
+				contactcount = addPerturbedContacts(o1, o2, flags, c1, c2, contacts, triangle, contact, contactcount);
 			}
 			return contactcount;
 		}
@@ -563,10 +556,7 @@ public class CollisionLibccd {
 				if (Math.abs(c.pos.get0() - pc.pos.get0()) < CONTACT_POS_EPSILON
 						&& Math.abs(c.pos.get1() - pc.pos.get1()) < CONTACT_POS_EPSILON
 						&& Math.abs(c.pos.get2() - pc.pos.get2()) < CONTACT_POS_EPSILON) {
-					index = maxcontacts;
-					if (c.depth > pc.depth + CONTACT_DEPTH_EPSILON) {
-						index = k;
-					}
+					index = pc.depth + CONTACT_DEPTH_EPSILON < c.depth ? k : maxcontacts;
 					break;
 				}
 				if (contactcount == maxcontacts && pc.depth < minDepth && pc.depth < c.depth) {
@@ -583,7 +573,7 @@ public class CollisionLibccd {
 				contact.side2 = c.side2;
 				contact.pos.set(c.pos);
 				contact.normal.set(c.normal);
-				contactcount = Math.max(index + 1, contactcount);
+				contactcount = index == contactcount ? contactcount + 1 : contactcount;
 			}
 			return contactcount;
 		}
@@ -605,17 +595,18 @@ public class CollisionLibccd {
 			DQuaternion qr = new DQuaternion();
 			DVector3 p = new DVector3();
 			DVector3 perturbed = new DVector3();
+			DVector3 pos = new DVector3(contact.pos);
+			DContactGeomBuffer perturbedContacts = new DContactGeomBuffer(1);
 			for (int k = 0; k < 4; k++) {
 				dQFromAxisAndAngle(q1, upAxis, k % 2 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
 				dQFromAxisAndAngle(q2, cross, k / 2 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
 				dQMultiply0(qr, q1, q2);
 				for (int j = 0; j < 3; j++) {
-					p.eqDiff(triangle[j], contact.pos);
+					p.eqDiff(triangle[j], pos);
 					dQuatTransform(qr, p, perturbed);
-					perturbed.add(contact.pos);
+					perturbed.add(pos);
 					c2.vertices[j].set(perturbed.get0(), perturbed.get1(), perturbed.get2());
 				}
-				DContactGeomBuffer perturbedContacts = new DContactGeomBuffer(1);
 				if (ccdCollide(o1, o2, flags, perturbedContacts, c1, ccdSupportConvex, ccdCenter, c2,
 						ccdSupportTriangle, ccdCenter) == 1) {
 					perturbedContacts.get().side2 = contact.side2;

--- a/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
@@ -24,6 +24,7 @@
  *************************************************************************/
 package org.ode4j.ode.internal;
 
+import org.ode4j.math.DQuaternion;
 import org.ode4j.math.DQuaternionC;
 import org.ode4j.math.DVector3;
 import org.ode4j.math.DVector3C;
@@ -37,10 +38,16 @@ import org.ode4j.ode.internal.libccd.CCD.ccd_center_fn;
 import org.ode4j.ode.internal.libccd.CCD.ccd_support_fn;
 import org.ode4j.ode.internal.libccd.CCDVec3.ccd_vec3_t;
 
+import static org.ode4j.ode.internal.DxCollisionUtil.dQuatTransform;
 import static org.ode4j.ode.internal.libccd.CCD.*;
 import static org.ode4j.ode.internal.libccd.CCDMPR.*;
 import static org.ode4j.ode.internal.libccd.CCDQuat.*;
 import static org.ode4j.ode.internal.libccd.CCDVec3.*;
+import static org.ode4j.ode.internal.Rotation.dQFromAxisAndAngle;
+import static org.ode4j.ode.internal.Rotation.dQMultiply3;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Lib ccd.
@@ -479,6 +486,145 @@ public class CollisionLibccd {
 			return ccdCollide(o1, o2, flags, contacts,
 					c1, ccdSupportConvex, ccdCenter,
 					c2, ccdSupportConvex, ccdCenter);
+		}
+	};
+
+	private static class ccd_triangle_t extends ccd_obj_t {
+		ccd_vec3_t[] vertices = new ccd_vec3_t[]{new ccd_vec3_t(), new ccd_vec3_t(), new ccd_vec3_t()};
+	};
+
+	private static final ccd_support_fn ccdSupportTriangle = new ccd_support_fn() {
+		@Override
+		public void run(Object obj, ccd_vec3_t _dir, ccd_vec3_t v) {
+			final ccd_triangle_t o = (ccd_triangle_t) obj;
+			// Not needed as trimesh already returns transformed vertices
+			// final ccd_vec3_t dir = new ccd_vec3_t();
+			// ccdVec3Copy(dir, _dir);
+			// ccdQuatRotVec(dir, o.rot_inv);
+			double maxdot = -CCD_REAL_MAX;
+			for (int i = 0; i < 3; i++) {
+				double dot = ccdVec3Dot(_dir, o.vertices[i]);
+				if (dot > maxdot) {
+					ccdVec3Copy(v, o.vertices[i]);
+					maxdot = dot;
+				}
+			}
+			// ccdQuatRotVec(v, o.rot);
+			// ccdVec3Add(v, o.pos);
+		}
+	};
+	
+	private static final float CONTACT_DEPTH_EPSILON = 0.0001f;
+	private static final float CONTACT_POS_EPSILON = 0.0001f;
+	private static final float CONTACT_PERTURBATION_ANGLE = 0.001f;
+
+	public static class CollideConvexTrimeshTrianglesCCD {
+		public int collide(DGeom o1, DGeom o2, int[] triindices, int flags, DContactGeomBuffer contacts) {
+			ccd_convex_t c1 = new ccd_convex_t();
+			ccd_triangle_t c2 = new ccd_triangle_t();
+			ccdGeomToConvex((DxConvex) o1, c1);
+			ccdGeomToObj(o2, c2);
+			int maxcontacts = (flags & 0xffff);
+			final DVector3[] triangle = new DVector3[] { new DVector3(), new DVector3(), new DVector3() };
+			int contactcount = 0;
+			for (int i : triindices) {
+				DContactGeomBuffer tempContacts = new DContactGeomBuffer(1);
+				((DxTriMesh) o2).FetchTransformedTriangle(i, triangle);
+				for (int j = 0; j < 3; j++) {
+					c2.vertices[j].set(triangle[j].get0(), triangle[j].get1(), triangle[j].get2());
+				}
+				if (ccdCollide(o1, o2, flags, tempContacts, c1, ccdSupportConvex, ccdCenter, c2, ccdSupportTriangle,
+						ccdCenter) == 1) {
+					if ((flags & OdeConstants.CONTACTS_UNIMPORTANT) == 0) {
+						DContactGeom c = tempContacts.get();
+						c.side2 = i;
+						contactcount = addUniqueContact(contacts, c, contactcount, maxcontacts);
+					} else {
+						contactcount++;
+					}
+				}
+			}
+			if (contactcount == 1 && (flags & OdeConstants.CONTACTS_UNIMPORTANT) == 0) {
+				((DxTriMesh) o2).FetchTransformedTriangle(contacts.get(0).side2, triangle);
+				for (int j = 0; j < 3; j++) {
+					c2.vertices[j].set(triangle[j].get0(), triangle[j].get1(), triangle[j].get2());
+				}
+				contactcount = addPerturbedContacts(o1, o2, flags, c1, c2, contacts, triangle, contacts.get(0),
+						contactcount, maxcontacts);
+			}
+			return contactcount;
+		}
+
+		private int addUniqueContact(DContactGeomBuffer contacts, DContactGeom c, int contactcount, int maxcontacts) {
+			double minDepth = Double.MAX_VALUE;
+			int index = contactcount;
+			for (int k = 0; k < contactcount; k++) {
+				DContactGeom pc = contacts.get(k);
+				if (Math.abs(c.pos.get0() - pc.pos.get0()) < CONTACT_POS_EPSILON
+						&& Math.abs(c.pos.get1() - pc.pos.get1()) < CONTACT_POS_EPSILON
+						&& Math.abs(c.pos.get2() - pc.pos.get2()) < CONTACT_POS_EPSILON) {
+					index = maxcontacts;
+					if (c.depth > pc.depth + CONTACT_DEPTH_EPSILON) {
+						index = k;
+					}
+					break;
+				}
+				if (contactcount == maxcontacts && pc.depth < minDepth && pc.depth < c.depth) {
+					minDepth = pc.depth;
+					index = k;
+				}
+			}
+			if (index < maxcontacts) {
+				DContactGeom contact = contacts.get(index);
+				contact.g1 = c.g1;
+				contact.g2 = c.g2;
+				contact.depth = c.depth;
+				contact.side1 = c.side1;
+				contact.side2 = c.side2;
+				contact.pos.set(c.pos);
+				contact.normal.set(c.normal);
+				contactcount = Math.max(index + 1, contactcount);
+			}
+			return contactcount;
+		}
+
+		private int addPerturbedContacts(DGeom o1, DGeom o2, int flags, ccd_convex_t c1, ccd_triangle_t c2,
+				DContactGeomBuffer contacts, DVector3[] triangle, DContactGeom contact, int contactcount,
+				int maxcontacts) {
+			DVector3 upAxis = new DVector3();
+			if (Math.abs(contact.normal.dot(new DVector3(0.0, 1.0, 0.0))) < 0.7) {
+				upAxis.set(0, 1, 0);
+			} else {
+				upAxis.set(0, 0, 1);
+			}
+			DVector3 cross = new DVector3();
+			cross.eqCross(contact.normal, upAxis);
+			cross.safeNormalize();
+			upAxis.eqCross(cross, contact.normal);
+			upAxis.safeNormalize();
+			DQuaternion q1 = new DQuaternion();
+			DQuaternion q2 = new DQuaternion();
+			DQuaternion qr = new DQuaternion();
+			DVector3 p = new DVector3();
+			DVector3 perturbed = new DVector3();
+			for (int k = 0; k < 4; k++) {
+				dQFromAxisAndAngle(q1, upAxis, k % 1 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
+				dQFromAxisAndAngle(q2, cross, k % 2 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
+				dQMultiply3(qr, q1, q2);
+				for (int j = 0; j < 3; j++) {
+					p.eqDiff(triangle[j], contact.pos);
+					dQuatTransform(qr, p, perturbed);
+					perturbed.add(contact.pos);
+					c2.vertices[j].set(perturbed.get0(), perturbed.get1(), perturbed.get2());
+				}
+				DContactGeomBuffer perturbedContacts = new DContactGeomBuffer(1);
+				if (ccdCollide(o1, o2, flags, perturbedContacts, c1, ccdSupportConvex, ccdCenter, c2,
+						ccdSupportTriangle, ccdCenter) == 1) {
+					perturbedContacts.get().side2 = contact.side2;
+					contactcount = addUniqueContact(contacts, perturbedContacts.get(), contactcount, maxcontacts);
+				}
+			}
+			return contactcount;
 		}
 	};
 

--- a/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
@@ -44,7 +44,7 @@ import static org.ode4j.ode.internal.libccd.CCDMPR.*;
 import static org.ode4j.ode.internal.libccd.CCDQuat.*;
 import static org.ode4j.ode.internal.libccd.CCDVec3.*;
 import static org.ode4j.ode.internal.Rotation.dQFromAxisAndAngle;
-import static org.ode4j.ode.internal.Rotation.dQMultiply3;
+import static org.ode4j.ode.internal.Rotation.dQMultiply0;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -550,7 +550,7 @@ public class CollisionLibccd {
 					c2.vertices[j].set(triangle[j].get0(), triangle[j].get1(), triangle[j].get2());
 				}
 				contactcount = addPerturbedContacts(o1, o2, flags, c1, c2, contacts, triangle, contacts.get(0),
-						contactcount, maxcontacts);
+						contactcount);
 			}
 			return contactcount;
 		}
@@ -589,8 +589,8 @@ public class CollisionLibccd {
 		}
 
 		private int addPerturbedContacts(DGeom o1, DGeom o2, int flags, ccd_convex_t c1, ccd_triangle_t c2,
-				DContactGeomBuffer contacts, DVector3[] triangle, DContactGeom contact, int contactcount,
-				int maxcontacts) {
+				DContactGeomBuffer contacts, DVector3[] triangle, DContactGeom contact, int contactcount) {
+			int maxcontacts = (flags & 0xffff);
 			DVector3 upAxis = new DVector3(0, 1, 0);
 			if (Math.abs(contact.normal.dot(upAxis)) > 0.7) {
 				upAxis.set(0, 0, 1);
@@ -608,7 +608,7 @@ public class CollisionLibccd {
 			for (int k = 0; k < 4; k++) {
 				dQFromAxisAndAngle(q1, upAxis, k % 2 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
 				dQFromAxisAndAngle(q2, cross, k / 2 == 0 ? CONTACT_PERTURBATION_ANGLE : -CONTACT_PERTURBATION_ANGLE);
-				dQMultiply3(qr, q1, q2);
+				dQMultiply0(qr, q1, q2);
 				for (int j = 0; j < 3; j++) {
 					p.eqDiff(triangle[j], contact.pos);
 					dQuatTransform(qr, p, perturbed);

--- a/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
@@ -1574,6 +1574,7 @@ public abstract class DxGeom extends DBase implements DGeom {
 			setCollider (dTriMeshClass,dCapsuleClass, new CollideTrimeshCCylinder());// dCollideCCTL);
 			setCollider (dTriMeshClass,dPlaneClass, new CollideTrimeshPlane());// dCollideTrimeshPlane);
 			setCollider (dCylinderClass,dTriMeshClass, new CollideCylinderTrimesh());// dCollideCylinderTrimesh);
+			setCollider (dConvexClass,dTriMeshClass, new CollideConvexTrimesh());
 //		}
 
 		if (dLIBCCD_BOX_CYL) {//#ifdef dLIBCCD_BOX_CYL

--- a/demo/src/main/java/org/ode4j/demo/ConvexCubeGeom.java
+++ b/demo/src/main/java/org/ode4j/demo/ConvexCubeGeom.java
@@ -1,0 +1,30 @@
+package org.ode4j.demo;
+
+class ConvexCubeGeom {
+	static final double[] planes = // planes for a cube
+	{ 1.0f, 0.0f, 0.0f, 0.25f, 0.0f, 1.0f, 0.0f, 0.25f, 0.0f, 0.0f, 1.0f, 0.25f, 0.0f, 0.0f, -1.0f, 0.25f, 0.0f, -1.0f,
+			0.0f, 0.25f, -1.0f, 0.0f, 0.0f, 0.25f };
+	static final int planecount = 6;
+	static final double points[] = // points for a cube
+	{ 0.25f, 0.25f, 0.25f, // point 0
+			-0.25f, 0.25f, 0.25f, // point 1
+
+			0.25f, -0.25f, 0.25f, // point 2
+			-0.25f, -0.25f, 0.25f, // point 3
+
+			0.25f, 0.25f, -0.25f, // point 4
+			-0.25f, 0.25f, -0.25f, // point 5
+
+			0.25f, -0.25f, -0.25f, // point 6
+			-0.25f, -0.25f, -0.25f,// point 7
+	};
+	static final int pointcount = 8;
+	static final int polygons[] = // Polygons for a cube (6 squares)
+	{ 4, 0, 2, 6, 4, // positive X
+			4, 1, 0, 4, 5, // positive Y
+			4, 0, 1, 3, 2, // positive Z
+			4, 3, 1, 5, 7, // negative X
+			4, 2, 3, 7, 6, // negative Y
+			4, 5, 4, 6, 7, // negative Z
+	};
+}

--- a/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
@@ -35,6 +35,7 @@ import org.ode4j.ode.DCapsule;
 import org.ode4j.ode.DContact;
 import org.ode4j.ode.DContactBuffer;
 import org.ode4j.ode.DContactJoint;
+import org.ode4j.ode.DConvex;
 import org.ode4j.ode.DCylinder;
 import org.ode4j.ode.DGeom;
 import org.ode4j.ode.DJoint;
@@ -144,6 +145,7 @@ public class DemoMovingTrimesh extends dsFunctions {
 		System.out.println ("   b for box.");
 		System.out.println ("   s for sphere.");
 		System.out.println ("   y for cylinder.");
+		System.out.println ("   v for a convex object.");
 		System.out.println ("   c for capsule.");
 		System.out.println ("   x for a composite object.");
 		System.out.println ("   m for a trimesh.");
@@ -167,7 +169,7 @@ public class DemoMovingTrimesh extends dsFunctions {
 		boolean setBody = false;
 
 		cmd = Character.toLowerCase (cmd);
-		if (cmd == 'b' || cmd == 's' || cmd == 'c' || cmd == 'x' || cmd == 'm' || cmd == 'y' ) {
+		if (cmd == 'b' || cmd == 's' || cmd == 'c' || cmd == 'x' || cmd == 'm' || cmd == 'y' || cmd == 'v') {
 			if (num < NUM) {
 				i = num;
 				num++;
@@ -219,6 +221,14 @@ public class DemoMovingTrimesh extends dsFunctions {
 				sides[0] *= 0.5;
 				m.setCapsule (DENSITY,3,sides[0],sides[1]);
 				obj[i].geom[0] = OdeHelper.createCapsule (space,sides[0],sides[1]);
+			} else if (cmd == 'v') {
+				m.setBox (DENSITY,0.25,0.25,0.25);
+				obj[i].geom[0] = OdeHelper.createConvex (space,
+						ConvexCubeGeom.planes,
+						ConvexCubeGeom.planecount,
+						ConvexCubeGeom.points,
+						ConvexCubeGeom.pointcount,
+						ConvexCubeGeom.polygons);
 			}
 			else if (cmd == 'y') {
 				sides[1] *= 0.5;
@@ -360,6 +370,14 @@ public class DemoMovingTrimesh extends dsFunctions {
 			DCylinder c = (DCylinder) g;
 			dsDrawCylinder (pos,R, c.getLength(), c.getRadius());
 			
+		} else if (g instanceof DConvex) {
+			//dVector3 sides={0.50,0.50,0.50};
+			dsDrawConvex(pos,R,
+					ConvexCubeGeom.planes,
+					ConvexCubeGeom.planecount,
+					ConvexCubeGeom.points,
+					ConvexCubeGeom.pointcount,
+					ConvexCubeGeom.polygons);
 		}
 
 		if (show_aabb) {

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimesh.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimesh.java
@@ -36,6 +36,7 @@ import org.ode4j.ode.DCapsule;
 import org.ode4j.ode.DContact;
 import org.ode4j.ode.DContactBuffer;
 import org.ode4j.ode.DContactJoint;
+import org.ode4j.ode.DConvex;
 import org.ode4j.ode.DCylinder;
 import org.ode4j.ode.DGeom;
 import org.ode4j.ode.DJoint;
@@ -163,6 +164,7 @@ class DemoTrimesh extends dsFunctions {
 		System.out.println ("   s for sphere.");
 		System.out.println ("   c for capsule.");
 		System.out.println ("   y for cylinder.");
+		System.out.println ("   v for a convex object.");
 		System.out.println ("   x for a composite object.");
 		System.out.println ("To select an object, press space.");
 		System.out.println ("To disable the selected object, press d.");
@@ -183,7 +185,7 @@ class DemoTrimesh extends dsFunctions {
 		boolean setBody = false;
 
 		cmd = Character.toLowerCase (cmd);
-		if (cmd == 'b' || cmd == 's' || cmd == 'c' || cmd == 'x' || cmd == 'y' ) {
+		if (cmd == 'b' || cmd == 's' || cmd == 'c' || cmd == 'x' || cmd == 'y' || cmd == 'v') {
 			if (num < NUM) {
 				i = num;
 				num++;
@@ -231,6 +233,14 @@ class DemoTrimesh extends dsFunctions {
 				sides[0] *= 0.5;
 				m.setCapsule (DENSITY,3,sides[0],sides[1]);
 				obj[i].geom[0] = OdeHelper.createCapsule (space,sides[0],sides[1]);
+			} else if (cmd == 'v') {
+				m.setBox (DENSITY,0.25,0.25,0.25);
+				obj[i].geom[0] = OdeHelper.createConvex (space,
+						ConvexCubeGeom.planes,
+						ConvexCubeGeom.planecount,
+						ConvexCubeGeom.points,
+						ConvexCubeGeom.pointcount,
+						ConvexCubeGeom.polygons);
 			}
 			else if (cmd == 'y') {
 				sides[1] *= 0.5;
@@ -346,6 +356,13 @@ class DemoTrimesh extends dsFunctions {
 		} else if (g instanceof DCylinder) {
 			DCylinder c = (DCylinder) g;
 			dsDrawCylinder (pos, R, c.getLength(), c.getRadius());
+		} else if (g instanceof DConvex) {
+			//dVector3 sides={0.50,0.50,0.50};
+			dsDrawConvex(pos,R,ConvexCubeGeom.planes,
+					ConvexCubeGeom.planecount,
+					ConvexCubeGeom.points,
+					ConvexCubeGeom.pointcount,
+					ConvexCubeGeom.polygons);
 		}
 
 		if (show_aabb) {

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimeshHeightfield.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimeshHeightfield.java
@@ -94,47 +94,6 @@ class DemoTrimeshHeightfield extends dsFunctions {
 	private static final float HFIELD_WSAMP =			( HFIELD_WIDTH / ( HFIELD_WSTEP-1 ) );
 	private static final float HFIELD_DSAMP =			( HFIELD_DEPTH / ( HFIELD_DSTEP-1 ) );
 
-
-
-	//<---- Convex Object
-	private double[] planes= // planes for a cube
-	{
-			1.0f ,0.0f ,0.0f ,0.25f,
-			0.0f ,1.0f ,0.0f ,0.25f,
-			0.0f ,0.0f ,1.0f ,0.25f,
-			0.0f ,0.0f ,-1.0f,0.25f,
-			0.0f ,-1.0f,0.0f ,0.25f,
-			-1.0f,0.0f ,0.0f ,0.25f
-	};
-	private final int planecount=6;
-
-	private double points[]= // points for a cube
-	{
-			0.25f,0.25f,0.25f,  //  point 0
-			-0.25f,0.25f,0.25f, //  point 1
-
-			0.25f,-0.25f,0.25f, //  point 2
-			-0.25f,-0.25f,0.25f,//  point 3
-
-			0.25f,0.25f,-0.25f, //  point 4
-			-0.25f,0.25f,-0.25f,//  point 5
-
-			0.25f,-0.25f,-0.25f,//  point 6
-			-0.25f,-0.25f,-0.25f,// point 7
-	};
-	private final int pointcount=8;
-	private int polygons[] = //Polygons for a cube (6 squares)
-	{
-			4,0,2,6,4, // positive X
-			4,1,0,4,5, // positive Y
-			4,0,1,3,2, // positive Z
-			4,3,1,5,7, // negative X
-			4,2,3,7,6, // negative Y
-			4,5,4,6,7, // negative Z
-	};
-	//----> Convex Object
-
-
 	// some constants
 
 	private static final int NUM = 100;			// max number of objects
@@ -342,11 +301,11 @@ class DemoTrimeshHeightfield extends dsFunctions {
 			} else if (cmd == 'v') {
 				m.setBox (DENSITY,0.25,0.25,0.25);
 				obj[i].geom[0] = OdeHelper.createConvex (space,
-						planes,
-						planecount,
-						points,
-						pointcount,
-						polygons);
+						IcosahedronGeom.Sphere_planes,
+						IcosahedronGeom.Sphere_planecount,
+						IcosahedronGeom.Sphere_points,
+						IcosahedronGeom.Sphere_pointcount,
+						IcosahedronGeom.Sphere_polygons);
 			} else if (cmd == 'y') {
 				m.setCylinder (DENSITY,3,sides[0],sides[1]);
 				obj[i].geom[0] = OdeHelper.createCylinder (space,sides[0],sides[1]);
@@ -480,11 +439,12 @@ class DemoTrimeshHeightfield extends dsFunctions {
 			
 		} else if (g instanceof DConvex) {
 			//dVector3 sides={0.50,0.50,0.50};
-			dsDrawConvex(pos,R,planes,
-					planecount,
-					points,
-					pointcount,
-					polygons);
+			dsDrawConvex(pos,R,
+					IcosahedronGeom.Sphere_planes,
+					IcosahedronGeom.Sphere_planecount,
+					IcosahedronGeom.Sphere_points,
+					IcosahedronGeom.Sphere_pointcount,
+					IcosahedronGeom.Sphere_polygons);
 			
 		} else if (g instanceof DCylinder) {
 			DCylinder cyl = (DCylinder) g;


### PR DESCRIPTION
Hi,

The patch adds support for convex vs trimesh coliision detection. It uses libCCD and gimpact to do a convex - triangle check for all potentially colliding triangles. Additionally some contact perturbation is applied as described in https://bullet.googlecode.com/files/GDC10_Coumans_Erwin_Contact.pdf when only a single contact is found to improve the stability.
The respective patch has also been submitted to ODE and merged in https://bitbucket.org/odedevs/ode/commits/79c1ae08892b12bf6f8ac89040d4f1f89cd57ee0
