### PR TITLE
Fix broken linked list when removing geoms from spaces

### DIFF
--- a/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
@@ -382,8 +382,11 @@ public abstract class DxGeom extends DBase implements DGeom {
 		if (_next != null) {
 			_next._prev = _prev;
 		}
-		parent.setFirst(_next);
-//		parent_space.
+        if (_prev != null) {
+            _prev._next = _next;
+        } else {
+            parent.setFirst(_next);
+        }
 		
 		//TODO use HashSet or IdentitySet or ArrayList? Check call hierarchy for type of usage!
 		geoms.remove(this);


### PR DESCRIPTION
Hi,

While playing with space implementation I noticed the following issue: when a geom is removed from a space the linked list of geoms is not updated correctly leading to broken list. An element should be removed from the links by updating both next and prev and the first element should be updated only if the one being removed is currently the first element in the list.

Moreover, I noticed that the _geoms list in DxSpace is not really needed, it does not seem to have any benefits compared to ODE's original linked list of geom, it might be actually slower. In reality it does not seem to impact the performance much but I would suggest removing it as currently the same list is kept twice. Please let me know what you think and if it is ok and I will create a separate PR for this change.

Piotr