### PR TITLE
Temporally coherent SAP space

### DIFF
--- a/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
@@ -382,8 +382,11 @@ public abstract class DxGeom extends DBase implements DGeom {
 		if (_next != null) {
 			_next._prev = _prev;
 		}
-		parent.setFirst(_next);
-//		parent_space.
+        if (_prev != null) {
+            _prev._next = _next;
+        } else {
+            parent.setFirst(_next);
+        }
 		
 		//TODO use HashSet or IdentitySet or ArrayList? Check call hierarchy for type of usage!
 		geoms.remove(this);

--- a/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
@@ -44,7 +44,7 @@ import org.ode4j.ode.DSpace;
  * Original code: OPCODE - Optimized Collision Detection Copyright (C) 2001
  * Pierre Terdiman Homepage: http://www.codercorner.com/Opcode.htm
  *
- * Temporally coherent version of SAPSpace.
+ * Temporally coherent version of SAPSpace with additional BVH tree for collide2 performance improvement.
  * 
  * @author Piotr Piastucki
  *

--- a/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
@@ -226,7 +226,7 @@ public class DxPersistentSAPSpace extends DxSpace implements DSapSpace {
 
         for (int m = 0; m < infSize; ++m) {
             DxGeom g1 = infGeomList.get(m);
-            if (GEOM_ENABLED(g1))
+            if (!GEOM_ENABLED(g1))
             	continue;
 
             // collide infinite ones

--- a/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
@@ -32,261 +32,236 @@ import static org.ode4j.ode.internal.Common.dUASSERT;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
-import java.util.TreeSet;
 
 import org.ode4j.ode.DAABB;
+import org.ode4j.ode.DAABBC;
 import org.ode4j.ode.DSapSpace;
 import org.ode4j.ode.DSpace;
 
 /**
- * Original code: OPCODE - Optimized Collision Detection
- * Copyright (C) 2001 Pierre Terdiman Homepage:
- * http://www.codercorner.com/Opcode.htm
+ * Original code: OPCODE - Optimized Collision Detection Copyright (C) 2001
+ * Pierre Terdiman Homepage: http://www.codercorner.com/Opcode.htm
  *
  * Temporally coherent version of SAPSpace.
+ * 
  * @author Piotr Piastucki
  *
  */
 public class DxPersistentSAPSpace extends DxSpace implements DSapSpace {
 
-    private List<DxGeom> geoms = new ArrayList<DxGeom>();
-    private Set<Integer> dirty = new TreeSet<Integer>(); // dirty geoms
-    // geoms with infinite AABBs
-    private List<DxGeom> infGeomList = new ArrayList<DxGeom>(); 
-    // geoms with normal AABBs
-    private List<DxGeom> normGeomList = new ArrayList<DxGeom>();
-    // temporary storage for enabled geoms with normal AABBs
-    private List<DxGeom> tempGeomList = new ArrayList<DxGeom>();
-    // temporary storage for tracking overlapping geoms
-    private int[] overlaps = new int[0];
-    private boolean dirtyOverlaps;
-    // Our sorting axes. (X,Z,Y is often best). Stored *2 for minor speedup
-    // Axis indices into geom's aabb are: min=idx, max=idx+1
-    private int ax0id;
-    private int ax1id;
-    private int ax2id;
+	private static class BVHNode {
+		DAABB aabb;
+		int imin, imax;
+		int escape;
 
-    /**
-     * Creation.
-     */
-    public static DxPersistentSAPSpace dSweepAndPruneSpaceCreate(DxSpace space, int axisorder) {
-        return new DxPersistentSAPSpace(space, axisorder);
-    }
+		private BVHNode() {
+			aabb = new DAABB();
+			aabb.set(dInfinity, -dInfinity, dInfinity, -dInfinity, dInfinity, -dInfinity);
 
-    /**
-     * As an alternative to the above, be implement separate fields in dxGeom.
-     * This should be faster than having a generic class for SAP and QT-Space
-     * info.
-     */
-    private void GEOM_SET_GEOM_IDX(DxGeom g, int idx) {
-        g._sapIdxGeomEx = idx;
-    }
+		}
+	}
 
-    private int GEOM_GET_GEOM_IDX(DxGeom g) {
-        return g._sapIdxGeomEx;
-    }
+	private boolean dirtyGeoms;
+	// geoms with infinite AABBs
+	private List<DxGeom> infGeomList = new ArrayList<DxGeom>();
+	// geoms with normal AABBs
+	private List<DxGeom> normGeomList = new ArrayList<DxGeom>();
+	// temporary storage for enabled geoms with normal AABBs
+	private List<DxGeom> tempGeomList = new ArrayList<DxGeom>();
+	// temporary storage for tracking overlapping geoms
+	private List<BVHNode> bvhNodes = new ArrayList<BVHNode>();
+	// Our sorting axes. (X,Z,Y is often best). Stored *2 for minor speedup
+	// Axis indices into geom's aabb are: min=idx, max=idx+1
+	private int ax0id;
+	private int ax1id;
+	private int ax2id;
 
-    /**
-     * A bit of repetitive work - similar to collideAABBs, but doesn't check if
-     * AABBs intersect (because SAP returns pairs with overlapping AABBs).
-     */
-    void collideGeomsNoAABBs(DxGeom g1, DxGeom g2, Object data, DNearCallback callback) {
-        dIASSERT(!g1.hasFlagAabbBad());
-        dIASSERT(!g2.hasFlagAabbBad());
+	/**
+	 * Creation.
+	 */
+	public static DxPersistentSAPSpace dSweepAndPruneSpaceCreate(DxSpace space, int axisorder) {
+		return new DxPersistentSAPSpace(space, axisorder);
+	}
 
-        // no contacts if both geoms on the same body, and the body is not 0
-        if (g1.body == g2.body && g1.body != null)
-            return;
+	/**
+	 * A bit of repetitive work - similar to collideAABBs, but doesn't check if
+	 * AABBs intersect (because SAP returns pairs with overlapping AABBs).
+	 */
+	void collideGeomsNoAABBs(DxGeom g1, DxGeom g2, Object data, DNearCallback callback) {
+		dIASSERT(!g1.hasFlagAabbBad());
+		dIASSERT(!g2.hasFlagAabbBad());
 
-        // test if the category and collide bitfields match
-        if (((g1.category_bits & g2.collide_bits) != 0 || (g2.category_bits & g1.collide_bits) != 0) == false) {
-            return;
-        }
+		// no contacts if both geoms on the same body, and the body is not 0
+		if (g1.body == g2.body && g1.body != null)
+			return;
 
-        DAABB bounds1 = g1._aabb;
-        DAABB bounds2 = g2._aabb;
+		// test if the category and collide bitfields match
+		if (((g1.category_bits & g2.collide_bits) != 0 || (g2.category_bits & g1.collide_bits) != 0) == false) {
+			return;
+		}
 
-        // check if either object is able to prove that it doesn't intersect the
-        // AABB of the other
-        if (g1.AABBTest(g2, bounds2) == false)
-            return;
-        if (g2.AABBTest(g1, bounds1) == false)
-            return;
+		DAABB bounds1 = g1._aabb;
+		DAABB bounds2 = g2._aabb;
 
-        // the objects might actually intersect - call the space callback
-        // function
-        callback.call(data, g1, g2);
-    }
+		// check if either object is able to prove that it doesn't intersect the
+		// AABB of the other
+		if (g1.AABBTest(g2, bounds2) == false)
+			return;
+		if (g2.AABBTest(g1, bounds1) == false)
+			return;
 
-    private DxPersistentSAPSpace(DxSpace space, int axisorder) {
-        super(space);
-        type = dSweepAndPruneSpaceClass;
-        // Init AABB to infinity
-        _aabb.set(-dInfinity, dInfinity, -dInfinity, dInfinity, -dInfinity, dInfinity);
-        ax0id = ((axisorder) & 3);
-        ax1id = ((axisorder >> 2) & 3);
-        ax2id = ((axisorder >> 4) & 3);
-    }
+		// the objects might actually intersect - call the space callback
+		// function
+		callback.call(data, g1, g2);
+	}
 
-    @Override
-    void add(DxGeom g) {
-        CHECK_NOT_LOCKED(this);
-        dAASSERT(g);
-        dUASSERT(g.parent_space == null, "geom is already in a space");
-        GEOM_SET_GEOM_IDX(g, geoms.size());
-        geoms.add(g);
-        dirty.add(GEOM_GET_GEOM_IDX(g));
-        super.add(g);
-    }
+	private DxPersistentSAPSpace(DxSpace space, int axisorder) {
+		super(space);
+		type = dSweepAndPruneSpaceClass;
+		// Init AABB to infinity
+		_aabb.set(-dInfinity, dInfinity, -dInfinity, dInfinity, -dInfinity, dInfinity);
+		ax0id = ((axisorder) & 3);
+		ax1id = ((axisorder >> 2) & 3);
+		ax2id = ((axisorder >> 4) & 3);
+	}
 
-    @Override
-    void remove(DxGeom g) {
-        CHECK_NOT_LOCKED(this);
-        dAASSERT(g);
-        dUASSERT(g.parent_space == this, "object is not in this space");
-        // remove
-        int geomIdx = GEOM_GET_GEOM_IDX(g);
-        dUASSERT(geomIdx >= 0 && geomIdx < geoms.size(), "geom indices messed up");
-        dirty.add(geomIdx);
-        GEOM_SET_GEOM_IDX(g, -1);
-        super.remove(g);
-    }
+	@Override
+	void add(DxGeom g) {
+		CHECK_NOT_LOCKED(this);
+		dAASSERT(g);
+		dUASSERT(g.parent_space == null, "geom is already in a space");
+		infGeomList.add(g);
+		dirtyGeoms = true;
+		super.add(g);
+	}
 
-    @Override
-    void dirty(DxGeom g) {
-        dAASSERT(g);
-        dUASSERT(g.parent_space == this, "object is not in this space");
-        int geomIdx = GEOM_GET_GEOM_IDX(g);
-        dUASSERT(geomIdx >= 0 && geomIdx < geoms.size(), "geom indices messed up");
-        dirty.add(geomIdx);
-    }
+	@Override
+	void remove(DxGeom g) {
+		CHECK_NOT_LOCKED(this);
+		dAASSERT(g);
+		dUASSERT(g.parent_space == this, "object is not in this space");
+		// remove
+		if (!infGeomList.remove(g)) {
+			normGeomList.remove(g);
+		}
+		dirtyGeoms = true;
+		super.remove(g);
+	}
 
-    @Override
-    public void cleanGeoms() {
-        dUASSERT(geoms.size() == count, "geom counts messed up");
-        // compute the AABBs of all dirty geoms, clear the dirty flags,
-        // remove from dirty list
-        lock_count++;
-        if (!dirty.isEmpty()) {
-        	int removed = 0;
-            for (int i : dirty) {
-                DxGeom g = geoms.get(i - removed);
-                if (GEOM_GET_GEOM_IDX(g) == -1) {
-                	geoms.remove(i - removed);
-                	removed++;
-                } else {
-	                if (g instanceof DSpace) {
-	                    ((DSpace) g).cleanGeoms();
-	                }
-	                g.recomputeAABB();
-	                g.unsetFlagDirtyAndBad();
-                }
-            }
-            dirty.clear();
-            dirtyOverlaps = true;
-            Collections.sort(geoms, new GeomComparator());
-            // update geom IDs based on the sort result
-            int axis0max = ax0id;// + 1;
-            infGeomList.clear();
-            normGeomList.clear();
-            for (int i = 0; i < geoms.size(); i++) {
-                DxGeom g = geoms.get(i);
-                GEOM_SET_GEOM_IDX(g, i);
-                final double amax = g._aabb.getMax(axis0max);
-                if (amax == dInfinity) {
-                	infGeomList.add(g);
-                } else {
-                	normGeomList.add(g);
-                }
-            }
-        }
-        lock_count--;
-    }
+	@Override
+	void dirty(DxGeom g) {
+		dAASSERT(g);
+		dUASSERT(g.parent_space == this, "object is not in this space");
+		dirtyGeoms = true;
+	}
 
-    @Override
-    public void collide(Object data, DNearCallback callback) {
-        dAASSERT(callback);
+	@Override
+	public void cleanGeoms() {
+		// compute the AABBs of all dirty geoms, clear the dirty flags,
+		// remove from dirty list
+		lock_count++;
+		if (dirtyGeoms) {
+			for (DxGeom g : normGeomList) {
+				if (g instanceof DSpace) {
+					((DSpace) g).cleanGeoms();
+				}
+				g.recomputeAABB();
+				g.unsetFlagDirtyAndBad();
+			}
+			for (Iterator<DxGeom> iter = infGeomList.iterator(); iter.hasNext();) {
+				DxGeom g = iter.next();
+				if (g instanceof DSpace) {
+					((DSpace) g).cleanGeoms();
+				}
+				g.recomputeAABB();
+				g.unsetFlagDirtyAndBad();
+				if (g._aabb.getMax(ax0id) != dInfinity) {
+					iter.remove();
+					normGeomList.add(g);
+				}
+			}
+			Collections.sort(normGeomList, new GeomComparator());
+			dirtyGeoms = false;
+			bvhNodes.clear();
+		}
+		lock_count--;
+	}
 
-        lock_count++;
+	@Override
+	public void collide(Object data, DNearCallback callback) {
+		dAASSERT(callback);
 
-        cleanGeoms();
-        tempGeomList.clear();
-        for (DxGeom g : normGeomList) {
-            if (GEOM_ENABLED(g)) {
-            	tempGeomList.add(g);
-            }
-        }
-        // do SAP on normal AABBs
-    	boxPruning(tempGeomList, data, callback);
+		lock_count++;
 
-        int infSize = infGeomList.size();
+		cleanGeoms();
+		tempGeomList.clear();
+		for (DxGeom g : normGeomList) {
+			if (GEOM_ENABLED(g)) {
+				tempGeomList.add(g);
+			}
+		}
+		// do SAP on normal AABBs
+		boxPruning(tempGeomList, data, callback);
 
-        for (int m = 0; m < infSize; ++m) {
-            DxGeom g1 = infGeomList.get(m);
-            if (!GEOM_ENABLED(g1))
-            	continue;
+		int infSize = infGeomList.size();
 
-            // collide infinite ones
-            for (int n = m + 1; n < infSize; ++n) {
-                DxGeom g2 = infGeomList.get(n);
-                if (GEOM_ENABLED(g2)) {
-                	collideGeomsNoAABBs(g1, g2, data, callback);
-                }
-            }
+		for (int m = 0; m < infSize; ++m) {
+			DxGeom g1 = infGeomList.get(m);
+			if (!GEOM_ENABLED(g1))
+				continue;
 
-            // collide infinite ones with normal ones
-            for (DxGeom g2 : tempGeomList) {
-            	collideGeomsNoAABBs(g1, g2, data, callback);
-            }
-        }
+			// collide infinite ones
+			for (int n = m + 1; n < infSize; ++n) {
+				DxGeom g2 = infGeomList.get(n);
+				if (GEOM_ENABLED(g2)) {
+					collideGeomsNoAABBs(g1, g2, data, callback);
+				}
+			}
 
-        lock_count--;
-    }
+			// collide infinite ones with normal ones
+			for (DxGeom g2 : tempGeomList) {
+				collideGeomsNoAABBs(g1, g2, data, callback);
+			}
+		}
 
-    @Override
+		lock_count--;
+	}
+
+	@Override
     void collide2(Object data, DxGeom geom, DNearCallback callback) {
         dAASSERT(geom != null && callback != null);
 
         lock_count++;
         cleanGeoms();
         geom.recomputeAABB();
-        int geom_count = normGeomList.size();
-        if (dirtyOverlaps) {
-        	if (overlaps.length < normGeomList.size()) {
-        		overlaps = new int[normGeomList.size()];
-        	}
-        	int o = 0;
-            for (int i = 0; i < geom_count; i++) {
-                DxGeom g0 = normGeomList.get(i);
-                final double idx0ax0max = g0._aabb.getMax(ax0id);
-                for (int j = o; j < geom_count; j++) {
-                    if (normGeomList.get(j)._aabb.getMin(ax0id) > idx0ax0max) {
-                        break;
-                    }
-                    overlaps[o++] = i; 
-                }
-            }
-        	dirtyOverlaps = false;
-        }
-        int index = Collections.binarySearch(normGeomList, geom, new GeomComparator());
-        if (index < 0) {
-        	index = -index - 1;
-            if (index > geom_count - 1) {
-            	index = geom_count - 1;
-            }
-        }
-        int start = overlaps[index];
-        for (int i = start; i < geom_count; i++) {
-            DxGeom g = normGeomList.get(i);
-            if (g._aabb.getMin(ax0id) > geom._aabb.getMax(ax0id)) {
-                break;
-            }
-            if (GEOM_ENABLED(g)) {
-            	collideAABBs(g, geom, data, callback);
-            }
-        }
+        if (normGeomList.size() > 0) {
+	        if (bvhNodes.isEmpty()) {
+	        	buildBVH();
+	        }
+			DAABBC aabb = geom.getAABB();
+			int i = 0;
+			int size = bvhNodes.size();
+			while (i < size) {
+				BVHNode node = bvhNodes.get(i);
+				boolean overlap = !node.aabb.isDisjoint(aabb); 
+				boolean isLeafNode = node.escape >= 0;
+				if (isLeafNode && overlap) {
+					for (int j = node.imin; j < node.imax; j++) {
+			            DxGeom g = normGeomList.get(j);
+			            if (GEOM_ENABLED(g)) {
+			            	collideAABBs(g, geom, data, callback);
+			            }
+					}
+				}
+				if (overlap || isLeafNode) {
+					i++;
+				} else {
+					i = -node.escape;
+				}
+			}
+		}
         for (DxGeom g : infGeomList) {
             if (GEOM_ENABLED(g)) {
             	collideAABBs(g, geom, data, callback);
@@ -295,42 +270,75 @@ public class DxPersistentSAPSpace extends DxSpace implements DSapSpace {
         lock_count--;
     }
 
-    private class GeomComparator implements Comparator<DxGeom> {
-        @Override
-        public int compare(DxGeom arg0, DxGeom arg1) {
-            double a0 = arg0._aabb.getMin(ax0id);
-            double a1 = arg1._aabb.getMin(ax0id);
-            return a1 > a0 ? -1 : (a1 < a0 ? 1 : 0);
-        }
-    }
+	private void buildBVH() {
+		subdivide(null, 0, normGeomList.size(), 10);
+	}
 
-    /**
-     * Complete box pruning. Returns a list of overlapping pairs of boxes, each
-     * box of the pair belongs to the same set.
-     * 
-     * @param geoms
-     *            [in] geoms of boxes.
-     */
-    void boxPruning(final List<DxGeom> geoms, Object data, DNearCallback callback) {
-        // Prune the list
-    	int size = geoms.size();
-        for (int i = 0; i < size; i++) {
-            DxGeom g0 = geoms.get(i);
-            DAABB aabb0 = g0._aabb;
-            final double idx0ax0max = aabb0.getMax(ax0id);// (ax0idx+1);
-            for (int j = i + 1; j < size; j++) {
-                DxGeom g1 = geoms.get(j);
-                if (g1._aabb.getMin(ax0id) > idx0ax0max) {
-                    // This and following elements can not intersect with g1.
-                    break;
-                }
-                if (aabb0.getMax(ax1id) >= g1._aabb.getMin(ax1id))
-                    if (g1._aabb.getMax(ax1id) >= aabb0.getMin(ax1id))
-                        if (aabb0.getMax(ax2id) >= g1._aabb.getMin(ax2id))
-                            if (g1._aabb.getMax(ax2id) >= aabb0.getMin(ax2id))
-                                collideGeomsNoAABBs(g0, g1, data, callback);
-            }
-        }
-    }
+	private void subdivide(BVHNode parent, int imin, int imax, int geomsPerNode) {
+		int inum = imax - imin;
+		if (inum == 0)
+			return;
+		BVHNode node = new BVHNode();
+		node.imin = imin;
+		node.imax = imax;
+		bvhNodes.add(node);
+		if (inum <= geomsPerNode) {
+			// Leaf
+			node.escape = bvhNodes.size();
+			for (int i = imin; i < imax; i++) {
+				node.aabb.expand(normGeomList.get(i)._aabb);
+			}
+			if (parent != null) {
+				parent.aabb.expand(node.aabb);
+			}
+		} else {
+			// Split
+			int isplit = imin + inum / 2;
+			subdivide(node, imin, isplit, geomsPerNode);
+			subdivide(node, isplit, imax, geomsPerNode);
+			if (parent != null) {
+				parent.aabb.expand(node.aabb);
+			}
+			node.escape = -bvhNodes.size();
+		}
+	}
+
+	private class GeomComparator implements Comparator<DxGeom> {
+		@Override
+		public int compare(DxGeom arg0, DxGeom arg1) {
+			double a0 = arg0._aabb.getMin(ax0id);
+			double a1 = arg1._aabb.getMin(ax0id);
+			return a1 > a0 ? -1 : (a1 < a0 ? 1 : 0);
+		}
+	}
+
+	/**
+	 * Complete box pruning. Returns a list of overlapping pairs of boxes, each
+	 * box of the pair belongs to the same set.
+	 * 
+	 * @param geoms
+	 *            [in] geoms of boxes.
+	 */
+	void boxPruning(final List<DxGeom> geoms, Object data, DNearCallback callback) {
+		// Prune the list
+		int size = geoms.size();
+		for (int i = 0; i < size; i++) {
+			DxGeom g0 = geoms.get(i);
+			DAABB aabb0 = g0._aabb;
+			final double idx0ax0max = aabb0.getMax(ax0id);// (ax0idx+1);
+			for (int j = i + 1; j < size; j++) {
+				DxGeom g1 = geoms.get(j);
+				if (g1._aabb.getMin(ax0id) > idx0ax0max) {
+					// This and following elements can not intersect with g1.
+					break;
+				}
+				if (aabb0.getMax(ax1id) >= g1._aabb.getMin(ax1id))
+					if (g1._aabb.getMax(ax1id) >= aabb0.getMin(ax1id))
+						if (aabb0.getMax(ax2id) >= g1._aabb.getMin(ax2id))
+							if (g1._aabb.getMax(ax2id) >= aabb0.getMin(ax2id))
+								collideGeomsNoAABBs(g0, g1, data, callback);
+			}
+		}
+	}
 
 }

--- a/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
@@ -1,0 +1,322 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal;
+
+import static org.ode4j.ode.OdeConstants.dInfinity;
+import static org.ode4j.ode.internal.Common.dAASSERT;
+import static org.ode4j.ode.internal.Common.dIASSERT;
+import static org.ode4j.ode.internal.Common.dUASSERT;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.ode4j.ode.DAABB;
+import org.ode4j.ode.DSapSpace;
+import org.ode4j.ode.DSpace;
+
+/**
+ * Original code: OPCODE - Optimized Collision Detection
+ * Copyright (C) 2001 Pierre Terdiman Homepage:
+ * http://www.codercorner.com/Opcode.htm
+ *
+ * Temporarily coherent version of SAPSpace.
+ * @author Piotr Piastucki
+ *
+ */
+public class DxPersistentSAPSpace extends DxSpace implements DSapSpace {
+
+    private List<DxGeom> geoms = new ArrayList<DxGeom>();
+    private Set<Integer> dirty = new HashSet<Integer>(); // dirty geoms
+    // temporary for geoms with infinite AABBs
+    private List<DxGeom> TmpInfGeomList = new ArrayList<DxGeom>(); 
+    // temporary for geoms with finite AABBs
+    private List<DxGeom> TmpGeomList = new ArrayList<DxGeom>();
+    // Our sorting axes. (X,Z,Y is often best). Stored *2 for minor speedup
+    // Axis indices into geom's aabb are: min=idx, max=idx+1
+    private int ax0id;
+    private int ax1id;
+    private int ax2id;
+
+    /**
+     * Creation.
+     */
+    public static DxPersistentSAPSpace dSweepAndPruneSpaceCreate(DxSpace space, int axisorder) {
+        return new DxPersistentSAPSpace(space, axisorder);
+    }
+
+    /**
+     * As an alternative to the above, be implement separate fields in dxGeom.
+     * This should be faster than having a generic class for SAP and QT-Space
+     * info.
+     */
+    private void GEOM_SET_GEOM_IDX(DxGeom g, int idx) {
+        g._sapIdxGeomEx = idx;
+    }
+
+    private int GEOM_GET_GEOM_IDX(DxGeom g) {
+        return g._sapIdxGeomEx;
+    }
+
+    /**
+     * A bit of repetitive work - similar to collideAABBs, but doesn't check if
+     * AABBs intersect (because SAP returns pairs with overlapping AABBs).
+     */
+    void collideGeomsNoAABBs(DxGeom g1, DxGeom g2, Object data, DNearCallback callback) {
+        dIASSERT(!g1.hasFlagAabbBad());
+        dIASSERT(!g2.hasFlagAabbBad());
+
+        // no contacts if both geoms on the same body, and the body is not 0
+        if (g1.body == g2.body && g1.body != null)
+            return;
+
+        // test if the category and collide bitfields match
+        if (((g1.category_bits & g2.collide_bits) != 0 || (g2.category_bits & g1.collide_bits) != 0) == false) {
+            return;
+        }
+
+        DAABB bounds1 = g1._aabb;
+        DAABB bounds2 = g2._aabb;
+
+        // check if either object is able to prove that it doesn't intersect the
+        // AABB of the other
+        if (g1.AABBTest(g2, bounds2) == false)
+            return;
+        if (g2.AABBTest(g1, bounds1) == false)
+            return;
+
+        // the objects might actually intersect - call the space callback
+        // function
+        callback.call(data, g1, g2);
+    }
+
+    private DxPersistentSAPSpace(DxSpace space, int axisorder) {
+        super(space);
+        type = dSweepAndPruneSpaceClass;
+        // Init AABB to infinity
+        _aabb.set(-dInfinity, dInfinity, -dInfinity, dInfinity, -dInfinity, dInfinity);
+        ax0id = ((axisorder) & 3);
+        ax1id = ((axisorder >> 2) & 3);
+        ax2id = ((axisorder >> 4) & 3);
+    }
+
+    @Override
+    void add(DxGeom g) {
+        CHECK_NOT_LOCKED(this);
+        dAASSERT(g);
+        dUASSERT(g.parent_space == null, "geom is already in a space");
+        GEOM_SET_GEOM_IDX(g, geoms.size());
+        geoms.add(g);
+        dirty.add(GEOM_GET_GEOM_IDX(g));
+        super.add(g);
+    }
+
+    @Override
+    void remove(DxGeom g) {
+        CHECK_NOT_LOCKED(this);
+        dAASSERT(g);
+        dUASSERT(g.parent_space == this, "object is not in this space");
+        // remove
+        int geomIdx = GEOM_GET_GEOM_IDX(g);
+        dUASSERT(geomIdx >= 0 && geomIdx < geoms.size(), "geom indices messed up");
+        DxGeom lastG = geoms.remove(geoms.size() - 1);
+        if (geomIdx != geoms.size()) {
+            geoms.set(geomIdx, lastG);
+            GEOM_SET_GEOM_IDX(lastG, geomIdx);
+            if (dirty.remove(geoms.size())) {
+                dirty.add(geomIdx);
+            }
+        }
+        GEOM_SET_GEOM_IDX(g, -1);
+        super.remove(g);
+    }
+
+    @Override
+    void dirty(DxGeom g) {
+        dAASSERT(g);
+        dUASSERT(g.parent_space == this, "object is not in this space");
+        int geomIdx = GEOM_GET_GEOM_IDX(g);
+        dUASSERT(geomIdx >= 0 && geomIdx < geoms.size(), "geom indices messed up");
+        dirty.add(geomIdx);
+    }
+
+    @Override
+    void computeAABB() {
+        // TODO?
+    }
+
+    @Override
+    public void cleanGeoms() {
+        dUASSERT(geoms.size() == count, "geom counts messed up");
+        // compute the AABBs of all dirty geoms, clear the dirty flags,
+        // remove from dirty list
+        lock_count++;
+        if (!dirty.isEmpty()) {
+            for (int i : dirty) {
+                DxGeom g = geoms.get(i);
+                if (g instanceof DSpace) {
+                    ((DSpace) g).cleanGeoms();
+                }
+                g.recomputeAABB();
+                g.unsetFlagDirtyAndBad();
+            }
+            dirty.clear();
+            Collections.sort(geoms, new GeomComparator());
+            // update geom IDs based on the sort result
+            for (int i = 0; i < geoms.size(); i++) {
+                DxGeom g = geoms.get(i);
+                GEOM_SET_GEOM_IDX(g, i);
+            }
+        }
+        lock_count--;
+    }
+
+    @Override
+    public void collide(Object data, DNearCallback callback) {
+        dAASSERT(callback);
+
+        lock_count++;
+
+        cleanGeoms();
+
+        // separate all ENABLED geoms into infinite AABBs and normal AABBs
+
+        TmpInfGeomList.clear();
+        TmpGeomList.clear();
+        int axis0max = ax0id;// + 1;
+        for (DxGeom g : geoms) {
+            if (!GEOM_ENABLED(g)) // skip disabled ones
+                continue;
+            final double amax = g._aabb.getMax(axis0max);
+            if (amax == dInfinity) // HACK? probably not...
+                TmpInfGeomList.add(g);
+            else
+                TmpGeomList.add(g);
+        }
+
+        // do SAP on normal AABBs
+        int tmp_geom_count = TmpGeomList.size();
+        if (tmp_geom_count > 0) {
+        	boxPruning(TmpGeomList, data, callback);
+        }
+
+        int infSize = TmpInfGeomList.size();
+        int normSize = TmpGeomList.size();
+        int m, n;
+
+        for (m = 0; m < infSize; ++m) {
+            DxGeom g1 = TmpInfGeomList.get(m);
+
+            // collide infinite ones
+            for (n = m + 1; n < infSize; ++n) {
+                DxGeom g2 = TmpInfGeomList.get(n);
+                collideGeomsNoAABBs(g1, g2, data, callback);
+            }
+
+            // collide infinite ones with normal ones
+            for (n = 0; n < normSize; ++n) {
+                DxGeom g2 = TmpGeomList.get(n);
+                collideGeomsNoAABBs(g1, g2, data, callback);
+            }
+        }
+
+        lock_count--;
+    }
+
+    @Override
+    void collide2(Object data, DxGeom geom, DNearCallback callback) {
+        dAASSERT(geom != null && callback != null);
+
+        lock_count++;
+        cleanGeoms();
+        geom.recomputeAABB();
+        int index = Collections.binarySearch(geoms, geom, new GeomComparator());
+        if (index < 0) {
+        	index = -index - 1;
+        }
+        for (int i = index - 1; i >= 0; i--) {
+            DxGeom g = geoms.get(i);
+            if (g._aabb.getMax(ax0id) < geom._aabb.getMin(ax0id)) {
+                break;
+            }
+            if (GEOM_ENABLED(g)) {
+                collideAABBs(g, geom, data, callback);
+            }
+        }
+        int geom_count = geoms.size();
+        for (int i = index; i < geom_count; ++i) {
+            DxGeom g = geoms.get(i);
+            if (g._aabb.getMin(ax0id) > geom._aabb.getMax(ax0id)) {
+                break;
+            }
+            if (GEOM_ENABLED(g)) {
+                collideAABBs(g, geom, data, callback);
+            }
+        }
+
+        lock_count--;
+    }
+
+    private class GeomComparator implements Comparator<DxGeom> {
+        @Override
+        public int compare(DxGeom arg0, DxGeom arg1) {
+            double a0 = arg0._aabb.getMin(ax0id);
+            double a1 = arg1._aabb.getMin(ax0id);
+            return a1 > a0 ? -1 : (a1 < a0 ? 1 : 0);
+        }
+    }
+
+    /**
+     * Complete box pruning. Returns a list of overlapping pairs of boxes, each
+     * box of the pair belongs to the same set.
+     * 
+     * @param geoms
+     *            [in] geoms of boxes.
+     */
+    void boxPruning(final List<DxGeom> geoms, Object data, DNearCallback callback) {
+        // Prune the list
+        for (int i = 0; i < geoms.size(); i++) {
+            DxGeom g0 = geoms.get(i);
+            DAABB aabb0 = g0._aabb;
+            final double idx0ax0max = aabb0.getMax(ax0id);// (ax0idx+1);
+            for (int j = i + 1; j < geoms.size(); j++) {
+                DxGeom g1 = geoms.get(j);
+                if (g1._aabb.getMin(ax0id) > idx0ax0max) {
+                    // This and following elements can not intersect with g1.
+                    break;
+                }
+                if (aabb0.getMax(ax1id) >= g1._aabb.getMin(ax1id))
+                    if (g1._aabb.getMax(ax1id) >= aabb0.getMin(ax1id))
+                        if (aabb0.getMax(ax2id) >= g1._aabb.getMin(ax2id))
+                            if (g1._aabb.getMax(ax2id) >= aabb0.getMin(ax2id))
+                                collideGeomsNoAABBs(g0, g1, data, callback);
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxPersistentSAPSpace.java
@@ -253,22 +253,12 @@ public class DxPersistentSAPSpace extends DxSpace implements DSapSpace {
         lock_count++;
         cleanGeoms();
         geom.recomputeAABB();
-        int index = Collections.binarySearch(normGeomList, geom, new GeomComparator());
-        if (index < 0) {
-        	index = -index - 1;
-        }
-        for (int i = index - 1; i >= 0; i--) {
+        int geom_count = normGeomList.size();
+        for (int i = 0; i < geom_count; i++) {
             DxGeom g = normGeomList.get(i);
             if (g._aabb.getMax(ax0id) < geom._aabb.getMin(ax0id)) {
-                break;
+                continue;
             }
-            if (GEOM_ENABLED(g)) {
-            	collideAABBs(g, geom, data, callback);
-            }
-        }
-        int geom_count = normGeomList.size();
-        for (int i = index; i < geom_count; ++i) {
-            DxGeom g = normGeomList.get(i);
             if (g._aabb.getMin(ax0id) > geom._aabb.getMax(ax0id)) {
                 break;
             }

--- a/core/src/main/java/org/ode4j/ode/internal/DxSAPSpace2.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxSAPSpace2.java
@@ -30,10 +30,8 @@ import static org.ode4j.ode.internal.Common.dIASSERT;
 import static org.ode4j.ode.internal.Common.dUASSERT;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 

--- a/demo/src/test/java/org/ode4j/tests/SpacePerformanceTest.java
+++ b/demo/src/test/java/org/ode4j/tests/SpacePerformanceTest.java
@@ -1,0 +1,101 @@
+package org.ode4j.tests;
+
+import java.util.Random;
+
+import org.junit.Test;
+import org.ode4j.ode.DGeom;
+import org.ode4j.ode.DGeom.DNearCallback;
+import org.ode4j.ode.DHashSpace;
+import org.ode4j.ode.DSapSpace.AXES;
+import org.ode4j.ode.DSimpleSpace;
+import org.ode4j.ode.DSpace;
+import org.ode4j.ode.OdeHelper;
+import org.ode4j.ode.internal.DxPersistentSAPSpace;
+
+public class SpacePerformanceTest {
+
+    int spaceCollisions = 0;
+    int geomCollisions = 0;
+
+    @Test
+    public void test() {
+        OdeHelper.initODE2(0);
+        // Warmup
+        DSpace space0 = OdeHelper.createSapSpace(AXES.XZY);
+        testSpace(space0, 1000);
+        space0 = DxPersistentSAPSpace.dSweepAndPruneSpaceCreate(null, AXES.XZY.getCode());
+        testSpace(space0, 1000);
+        space0 = OdeHelper.createHashSpace();
+        testSpace(space0, 1000);
+        System.out.println("---------------");
+       // DSimpleSpace simple = OdeHelper.createSimpleSpace();
+       // testSpace(simple);
+        DSpace space = OdeHelper.createSapSpace(AXES.XZY);
+        testSpace(space, 10000);
+        DSpace space2 = DxPersistentSAPSpace.dSweepAndPruneSpaceCreate(null, AXES.XZY.getCode());
+        testSpace(space2, 10000);
+        DHashSpace hash = OdeHelper.createHashSpace();
+        hash.setLevels(-1, 8);
+        testSpace(hash, 10000);
+    }
+
+    private void testSpace(DSpace space, int num) {
+        spaceCollisions = 0;
+        geomCollisions = 0;
+        System.out.println("==== " + space.getClass().getSimpleName());
+        int geomnum = 1000;
+        DGeom[] geoms = new DGeom[geomnum];
+        Random r = new Random(123);
+        for (int i = 0; i < geomnum; i++) {
+            geoms[i] = OdeHelper.createBox(space, 1, 1, 1);
+            geoms[i].setPosition(r.nextInt(100), r.nextInt(100), r.nextInt(100));
+        }
+        DGeom[] geoms2 = new DGeom[10];
+        for (int i = 0; i < 10; i++) {
+        	geoms2[i] = OdeHelper.createBox(space, 4, 4, 4);
+            geoms2[i].setPosition(0.5 + r.nextInt(100), 0.5 + r.nextInt(100), 0.5 + r.nextInt(100));
+        }
+        long timer1 = 0;
+        long timer2 = 0;
+        for (int j = 0; j < num; j++) {
+            long time1 = System.nanoTime();
+            space.collide(null, new DNearCallback() {
+                @Override
+                public void call(Object data, DGeom o1, DGeom o2) {
+                    spaceCollisions++;   
+                }
+            });
+            long time2 = System.nanoTime();
+            for (int k = 0; k < 10; k++) {
+                int i = r.nextInt(geoms2.length);
+                space.collide2(geoms2[i], null, new DNearCallback() {
+                    @Override
+                    public void call(Object data, DGeom o1, DGeom o2) {
+                        geomCollisions++;
+                    }
+                });
+            }
+            long time3 = System.nanoTime();
+            timer1 += time2 - time1;
+            timer2 += time3 - time2;
+            for (int k = 0; k < 40; k++) {
+                int i = r.nextInt(geoms.length);
+                geoms[i].setPosition(r.nextInt(100), r.nextInt(100), r.nextInt(100));
+            }
+            for (int k = 0; k < 20; k++) {
+                int i = r.nextInt(geoms.length);
+                geoms[i].disable();
+            }
+            for (int k = 0; k < 20; k++) {
+                int i = r.nextInt(geoms.length);
+                geoms[i].enable();
+            }
+            for (int k = 0; k < 10; k++) {
+                int i = r.nextInt(geoms.length);
+                geoms[i].destroy();
+                geoms[i] = OdeHelper.createBox(space, 1, 1, 1);
+            }
+        }
+        System.out.println(spaceCollisions + "   " + geomCollisions + "   " + timer1 / 1000 + "  " + timer2 / 1000);
+    }
+}


### PR DESCRIPTION
The PR adds a new space - DxSAPSpace2. It is a temporally coherent and heavily refactored variant of the original SAP space resulting in significant performance boost. The performance gain comes from the following changes:
1) no additional collections are created in boxPrunning method (see PR #43 )
2) sort algorithm is called on an already pre-sorted (from previous iterations) list and takes advantage of this
3) collide2 takes advantage of the persistent sorted list and uses BVH tree to accelerate queries instead of a brute-force N^2 approach resulting in a tremendous performance gain (very handy in my use case).

I am also attaching a test useful for testing space performance. 
In my case I get roughly the following results in microseconds for collide2 :
```
  iterations   geoms        old          new       gain
      500000      10    7830177       5886252       20%
      100000     100    4349950       2012539       50%
       40000     200    4052088       1195051       70%
        5000    1000    3776681        398865       85%
        1200    2000    2650909        208568       90%
         250    5000    1613238        125016       90%
         100   10000    1399499        177928       85%
```
Regards,
Piotr