### PR TITLE
Refactor space geom access to use iterators

### DIFF
--- a/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppCollisionSpace.java
+++ b/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppCollisionSpace.java
@@ -194,9 +194,15 @@ public abstract class ApiCppCollisionSpace extends ApiCppCollisionTrimesh {
 	public static int dSpaceGetNumGeoms (DSpace s) {
 		return s.getNumGeoms();
 	}
-	//ODE_API 
+	//ODE_API
+	/** @deprecated Use dSpaceGetGeoms() instead */
+	@Deprecated
 	public static DGeom dSpaceGetGeom (DSpace s, int i) {
 		return s.getGeom(i);
+	}
+	
+	public static Iterable<? extends DGeom> dSpaceGetGeoms (DSpace s) {
+		return s.getGeoms();
 	}
 
 	/**

--- a/core/src/main/java/org/ode4j/ode/DSpace.java
+++ b/core/src/main/java/org/ode4j/ode/DSpace.java
@@ -24,6 +24,7 @@
  *************************************************************************/
 package org.ode4j.ode;
 
+import org.ode4j.ode.internal.DxGeom;
 
 /**
  * collision space.
@@ -45,7 +46,10 @@ public interface DSpace extends DGeom {
 	boolean query (DGeom x);
 
 	int getNumGeoms();
+	/** @deprecated Use getGeoms() instead */
+	@Deprecated
 	DGeom getGeom (int i);
+	Iterable<DxGeom> getGeoms();
 
 	/** This is equivalent to OdeHelper.spaceCollide(...) */
 	void collide (Object data, DNearCallback callback);

--- a/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
@@ -24,8 +24,6 @@
  *************************************************************************/
 package org.ode4j.ode.internal;
 
-import java.util.List;
-
 import static org.ode4j.ode.OdeMath.*;
 import static org.ode4j.ode.internal.Rotation.dQfromR;
 
@@ -164,7 +162,7 @@ public abstract class DxGeom extends DBase implements DGeom {
 	 * For the first element, it is a pointer to (container.first).
 	 */
 //	private final Ref<dxGeom> tome = new Ref<dxGeom>();
-	DxGeom _next = null;// next geom in linked list of geoms
+	private DxGeom _next = null;// next geom in linked list of geoms
 	private DxGeom _prev = null;
 	//dxGeom tome;	// linked list backpointer
     private DxGeom _next_ex;	// next geom in extra linked list of geoms (for higher level structures)
@@ -351,7 +349,7 @@ public abstract class DxGeom extends DBase implements DGeom {
 //		tome.set(next);
 //	}
 
-	void spaceAdd (DxGeom next, DxSpace parent, List<DxGeom> geoms) {
+	void spaceAdd (DxGeom next, DxSpace parent) {
 //		next = *first_ptr;
 //		tome = first_ptr;
 //		if (*first_ptr) (*first_ptr).tome = &next;
@@ -371,10 +369,9 @@ public abstract class DxGeom extends DBase implements DGeom {
 		parent.setFirst(this);
 //		parent_space = parent;
 		
-		geoms.add(0, this);
 	}
 
-	void spaceRemove(DxSpace parent, List<DxGeom> geoms) {
+	void spaceRemove(DxSpace parent) {
 //		   if (next) next->tome = tome;
 //		    *tome = next;
 //		if (next != null) next.tome = tome;
@@ -388,8 +385,6 @@ public abstract class DxGeom extends DBase implements DGeom {
             parent.setFirst(_next);
         }
 		
-		//TODO use HashSet or IdentitySet or ArrayList? Check call hierarchy for type of usage!
-		geoms.remove(this);
 	}
 
 	

--- a/core/src/main/java/org/ode4j/ode/internal/DxHashSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxHashSpace.java
@@ -183,9 +183,7 @@ public class DxHashSpace extends DxSpace implements DHashSpace {
 	{
 		// compute the AABBs of all dirty geoms, and clear the dirty flags
 		lock_count++;
-		//for (dxGeom g=_first; (g!= null) && (g.gflags & GEOM_DIRTY) != 0;
-		//g=g.getNext()) {
-		for (DxGeom g: _geoms) {
+		for (DxGeom g : getGeoms()) {
 			//if ((g._gflags & GEOM_DIRTY)==0) break;
 			if (!g.hasFlagDirty()) break;
 			if (g instanceof DxSpace) {
@@ -206,7 +204,7 @@ public class DxHashSpace extends DxSpace implements DHashSpace {
 		int i,maxlevel;
 
 		// 0 or 1 geoms can't collide with anything
-		if (count < 2) return;
+		if (getNumGeoms() < 2) return;
 
 		lock_count++;
 		cleanGeoms();
@@ -220,8 +218,7 @@ public class DxHashSpace extends DxSpace implements DHashSpace {
 		ArrayList<dxAABB> hash_boxes = new ArrayList<dxAABB>();	// list of AABBs in hash table
 		ArrayList<dxAABB> big_boxes = new ArrayList<dxAABB>();	// list of AABBs too big for hash table
 		maxlevel = global_minlevel - 1;
-		//for (geom = _first; geom != null; geom=geom.getNext()) {
-		for (DxGeom geom: _geoms) {
+		for (DxGeom geom : getGeoms()) {
 			if (!GEOM_ENABLED(geom)){
 				continue;
 			}
@@ -393,8 +390,7 @@ public class DxHashSpace extends DxSpace implements DHashSpace {
 		geom.recomputeAABB();
 
 		// intersect bounding boxes
-//		for (dxGeom g=_first; g != null; g=g.getNext()) {
-		for (DxGeom g: _geoms) {
+		for (DxGeom g : getGeoms()) {
 			if (GEOM_ENABLED(g)) collideAABBs (g,geom,data,callback);
 		}
 

--- a/core/src/main/java/org/ode4j/ode/internal/DxQuadTreeSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxQuadTreeSpace.java
@@ -28,8 +28,6 @@ import static org.ode4j.ode.OdeConstants.dInfinity;
 import static org.ode4j.ode.internal.Common.dAASSERT;
 import static org.ode4j.ode.internal.Common.dIASSERT;
 import static org.ode4j.ode.internal.Common.dNextAfter;
-import static org.ode4j.ode.internal.Common.dUASSERT;
-import static org.ode4j.ode.internal.ErrorHandler.dDebug;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -476,81 +474,6 @@ public class DxQuadTreeSpace extends DxSpace implements DQuadTreeSpace {
 		//	dFree(CurrentChild, (Depth + 1));// * sizeof(int));
 
 		super.DESTRUCTOR();
-	}
-
-	//dxGeom* dxQuadTreeSpace::getGeom(int Index){
-	@Override
-	public DxGeom getGeom(int Index) {
-		dUASSERT(Index >= 0 && Index < count, "index out of range");
-
-		//@@@
-		dDebug (0,"dxQuadTreeSpace::getGeom() not yet implemented");
-
-		return null;
-
-		// This doesnt work
-
-		/*if (CurrentIndex == Index){
-		// Loop through all objects in the local list
-CHILDRECURSE:
-		if (CurrentObject){
-			dGeom g = CurrentObject;
-			CurrentObject = CurrentObject->next;
-			CurrentIndex++;
-
-#ifdef DRAWBLOCKS
-			DrawBlock(CurrentBlock);
-#endif	//DRAWBLOCKS
-			return g;
-		}
-		else{
-			// Now lets loop through our children. Starting at index 0.
-			if (CurrentBlock->Children){
-				CurrentChild[CurrentLevel] = 0;
-PARENTRECURSE:
-				for (int& i = CurrentChild[CurrentLevel]; i < SPLITS; i++){
-					if (CurrentBlock->Children[i].GeomCount == 0){
-						continue;
-					}
-					CurrentBlock = &CurrentBlock->Children[i];
-					CurrentObject = CurrentBlock->First;
-
-					i++;
-
-					CurrentLevel++;
-					goto CHILDRECURSE;
-				}
-			}
-		}
-
-		// Now lets go back to the parent so it can continue processing its other children.
-		if (CurrentBlock->Parent){
-			CurrentBlock = CurrentBlock->Parent;
-			CurrentLevel--;
-			goto PARENTRECURSE;
-		}
-	}
-	else{
-		CurrentBlock = &Blocks[0];
-		CurrentLevel = 0;
-		CurrentObject = CurrentObject;
-		CurrentIndex = 0;
-
-		// Other states are already set
-		CurrentObject = CurrentBlock->First;
-	}
-
-
-	if (current_geom && current_index == Index - 1){
-		//current_geom = current_geom->next; // next
-		current_index = Index;
-		return current_geom;
-	}
-	else for (int i = 0; i < Index; i++){	// this will be verrrrrrry slow
-		getGeom(i);
-	}*/
-
-		//TODO return null;
 	}
 
 	//void dxQuadTreeSpace::add(dxGeom* g){

--- a/core/src/main/java/org/ode4j/ode/internal/DxSAPSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxSAPSpace.java
@@ -205,25 +205,13 @@ public class DxSAPSpace extends DxSpace implements DSapSpace {
 		super.DESTRUCTOR();
 	}
 
-	//dxGeom* dxSAPSpace::getGeom( int i )
-	@Override
-	public DxGeom getGeom( int i )
-	{
-		dUASSERT( i >= 0 && i < count, "index out of range" );
-		int dirtySize = DirtyList.size();
-		if( i < dirtySize )
-			return DirtyList.get(i);
-		else
-			return GeomList.get(i-dirtySize);
-	}
-
 	//void dxSAPSpace::add( dxGeom* g )
 	@Override
 	void add( DxGeom g )
 	{
 		CHECK_NOT_LOCKED (this);
 		//dAASSERT(g);
-		dUASSERT(g.parent_space == null && g.getNext() == null, "geom is already in a space");
+		dUASSERT(g.parent_space == null, "geom is already in a space");
 
 		// add to dirty list
 		GEOM_SET_DIRTY_IDX( g, DirtyList.size() );
@@ -344,7 +332,7 @@ public class DxSAPSpace extends DxSpace implements DSapSpace {
 
 		// by now all geoms are in GeomList, and DirtyList must be empty
 		int geom_count = GeomList.size();
-		dUASSERT( geom_count == count, "geom counts messed up" );
+		dUASSERT( geom_count == getNumGeoms(), "geom counts messed up" );
 
 		// separate all ENABLED geoms into infinite AABBs and normal AABBs
 		TmpGeomList.clear();//setSize(0);

--- a/core/src/main/java/org/ode4j/ode/internal/DxSimpleSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxSimpleSpace.java
@@ -59,8 +59,7 @@ public class DxSimpleSpace extends DxSpace implements DSimpleSpace {
 	{
 		// compute the AABBs of all dirty geoms, and clear the dirty flags
 		lock_count++;
-		//for (dxGeom g=_first; g!=null && (g.gflags & GEOM_DIRTY) != 0; g=g.getNext()) {
-		for (DxGeom g: _geoms) {
+		for (DxGeom g : getGeoms()) {
 			//if ((g._gflags & GEOM_DIRTY) == 0) break;
 			if (!g.hasFlagDirty()) break;
 			if (g instanceof DxSpace) {
@@ -82,13 +81,9 @@ public class DxSimpleSpace extends DxSpace implements DSimpleSpace {
 		cleanGeoms();
 
 		// intersect all bounding boxes
-		//for (dxGeom g1=_first; g1!=null; g1=g1.getNext()) {
-		for (int i = 0; i < _geoms.size(); i++) {
-			DxGeom g1 = _geoms.get(i);
+		for (DxGeom g1 : getGeoms()) {
 			if (GEOM_ENABLED(g1)){
-				//for (dxGeom g2=g1.getNext(); g2!=null; g2=g2.getNext()) {
-				for (int j = i+1; j< _geoms.size(); j++ ) {
-					DxGeom g2 = _geoms.get(j);
+				for (DxGeom g2=g1.getNext(); g2!=null; g2=g2.getNext()) {
 					if (GEOM_ENABLED(g2)){
 						collideAABBs (g1,g2,data,callback);
 					}
@@ -110,8 +105,7 @@ public class DxSimpleSpace extends DxSpace implements DSimpleSpace {
 		geom.recomputeAABB();
 
 		// intersect bounding boxes
-		//for (dxGeom g=_first; g!=null; g=g.getNext()) {
-		for (DxGeom g: _geoms) {
+		for (DxGeom g : getGeoms()) {
 			if (GEOM_ENABLED(g)){
 				collideAABBs (g,geom,data,callback);
 			}

--- a/demo-cpp/src/main/java/org/ode4j/democpp/DemoCollision.java
+++ b/demo-cpp/src/main/java/org/ode4j/democpp/DemoCollision.java
@@ -55,8 +55,8 @@ import static org.ode4j.cpp.internal.ApiCppCollision.dGeomSphereSetRadius;
 import static org.ode4j.cpp.internal.ApiCppCollision.dSpaceCollide;
 import static org.ode4j.cpp.internal.ApiCppCollisionSpace.dSimpleSpaceCreate;
 import static org.ode4j.cpp.internal.ApiCppCollisionSpace.dSpaceAdd;
-import static org.ode4j.cpp.internal.ApiCppCollisionSpace.dSpaceGetGeom;
 import static org.ode4j.cpp.internal.ApiCppCollisionSpace.dSpaceGetNumGeoms;
+import static org.ode4j.cpp.internal.ApiCppCollisionSpace.dSpaceGetGeoms;
 import static org.ode4j.cpp.internal.ApiCppOdeInit.dCloseODE;
 import static org.ode4j.cpp.internal.ApiCppOdeInit.dInitODE2;
 import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
@@ -283,8 +283,7 @@ class DemoCollision extends dsFunctions {
 		dSpaceCollide (space,0,nearCallback);
 
 		// draw all rays
-		for (i=0; i<nGeoms; i++) {
-			DGeom g = dSpaceGetGeom (space,i);
+		for (DGeom g : dSpaceGetGeoms(space)) {
 			if (g instanceof DRay) {
 				dsSetColor (1,1,1);
 				DVector3 origin = new DVector3(),dir=new DVector3();
@@ -300,8 +299,7 @@ class DemoCollision extends dsFunctions {
 		}
 
 		// draw all other objects
-		for (i=0; i<nGeoms; i++) {
-			DGeom g = dSpaceGetGeom (space,i);
+		for (DGeom g : dSpaceGetGeoms(space)) {
 			DVector3 pos = new DVector3();
 			if (!(g instanceof DPlane)) {//dGeomGetClass (g) != dPlaneClass) {
 				//memcpy (pos,dGeomGetPosition(g),sizeof(pos));

--- a/demo-cpp/src/main/java/org/ode4j/democpp/DemoMovingConvex.java
+++ b/demo-cpp/src/main/java/org/ode4j/democpp/DemoMovingConvex.java
@@ -371,9 +371,8 @@ public class DemoMovingConvex extends dsFunctions {
 
 		if ( !pause ) dWorldQuickStep( world,0.05 );
 
-		for ( int j = 0; j < dSpaceGetNumGeoms( space ); j++ )
-		{
-			dSpaceGetGeom( space, j );
+		for (DGeom g : dSpaceGetGeoms(space)) {
+			
 		}
 
 		// remove all contact joints

--- a/demo/src/main/java/org/ode4j/demo/DemoCollision.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCollision.java
@@ -216,8 +216,7 @@ class DemoCollision extends dsFunctions {
 		space.collide(null,nearCallback);
 
 		// draw all rays
-		for (i=0; i<nGeoms; i++) {
-			DGeom g = space.getGeom (i);
+		for (DGeom g : space.getGeoms()) {
 			if (g instanceof DRay) {
 				dsSetColor (1,1,1);
 				DVector3 origin = new DVector3(),dir=new DVector3();
@@ -233,8 +232,7 @@ class DemoCollision extends dsFunctions {
 		}
 
 		// draw all other objects
-		for (i=0; i<nGeoms; i++) {
-			DGeom g = space.getGeom (i);
+		for (DGeom g : space.getGeoms()) {
 			DVector3 pos = new DVector3();
 			if (!(g instanceof DPlane)) {//dGeomGetClass (g) != dPlaneClass) {
 				//memcpy (pos,dGeomGetPosition(g),sizeof(pos));

--- a/demo/src/main/java/org/ode4j/demo/DemoDBall.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoDBall.java
@@ -159,9 +159,7 @@ public class DemoDBall extends dsFunctions {
 		}
 
 		// now we draw everything
-		int ngeoms = space.getNumGeoms();
-		for (int i=0; i<ngeoms; ++i) {
-			DGeom g = space.getGeom(i);
+		for (DGeom g : space.getGeoms()) {
 
 			drawGeom(g);
 		}

--- a/demo/src/main/java/org/ode4j/demo/DemoDHinge.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoDHinge.java
@@ -170,9 +170,7 @@ public class DemoDHinge extends dsFunctions {
 		}
 
 		// now we draw everything
-		int ngeoms = space.getNumGeoms();
-		for (int i=0; i<ngeoms; ++i) {
-			DGeom g = space.getGeom(i);
+		for (DGeom g : space.getGeoms()) {
 			drawGeom(g);
 		}
 

--- a/demo/src/main/java/org/ode4j/demo/DemoJointConstrainedBall.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJointConstrainedBall.java
@@ -159,9 +159,7 @@ public class DemoJointConstrainedBall extends dsFunctions {
 		}
 
 		// now we draw everything
-		int ngeoms = space.getNumGeoms();
-		for (int i=0; i<ngeoms; ++i) {
-			DGeom g = space.getGeom(i);
+		for (DGeom g : space.getGeoms()) {
 
 			drawGeom(g);
 		}

--- a/demo/src/main/java/org/ode4j/demo/DemoMovingConvex.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMovingConvex.java
@@ -363,9 +363,7 @@ public class DemoMovingConvex extends dsFunctions {
 
 		if ( !pause ) world.quickStep( 0.05 );
 
-		for ( int j = 0; j < space.getNumGeoms(); j++ )
-		{
-			space.getGeom( j );
+		for (DGeom g : space.getGeoms()) {
 		}
 
 		// remove all contact joints

--- a/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
@@ -443,10 +443,8 @@ public class DemoMovingTrimesh extends dsFunctions {
 
 		if (!pause) world.quickStep(0.05);
 
-		for (int j = 0; j < space.getNumGeoms(); j++) {
-			space.getGeom(j);
+		for (DGeom g : space.getGeoms()) {
 		}
-
 		// remove all contact joints
 		contactgroup.empty ();
 

--- a/demo/src/main/java/org/ode4j/demo/DemoTracks.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTracks.java
@@ -518,9 +518,7 @@ public class DemoTracks extends dsFunctions {
         }
 
         // now we draw everything
-        int ngeoms = space.getNumGeoms();
-        for (int i=0; i<ngeoms; ++i) {
-            DGeom g = space.getGeom(i);
+		for (DGeom g : space.getGeoms()) {
 
             if (g == ground)
                 continue; // drawstuff is already drawing it for us

--- a/demo/src/main/java/org/ode4j/demo/DemoTransmission.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTransmission.java
@@ -280,9 +280,7 @@ public class DemoTransmission extends dsFunctions {
 //		#endif
 
 		// now we draw everything
-		int ngeoms = space.getNumGeoms();
-		for (int i=0; i<ngeoms; ++i) {
-			DGeom g = space.getGeom(i);
+		for (DGeom g : space.getGeoms()) {
 
 			drawGeom(g);
 		}

--- a/demo/src/main/java/org/ode4j/demo/ragdoll/DemoRagdoll.java
+++ b/demo/src/main/java/org/ode4j/demo/ragdoll/DemoRagdoll.java
@@ -186,9 +186,7 @@ public class DemoRagdoll extends dsFunctions {
 		contactgroup.empty();
 
 		// now we draw everything
-		int ngeoms = space.getNumGeoms();
-		for (int i=0; i<ngeoms; ++i) {
-			DGeom g = space.getGeom(i);
+		for (DGeom g : space.getGeoms()) {
 
 			drawGeom(g);
 		}

--- a/demo/src/test/java/org/ode4j/tests/SpacePerformanceTest.java
+++ b/demo/src/test/java/org/ode4j/tests/SpacePerformanceTest.java
@@ -8,6 +8,7 @@ import org.ode4j.ode.DGeom.DNearCallback;
 import org.ode4j.ode.DSapSpace.AXES;
 import org.ode4j.ode.DSpace;
 import org.ode4j.ode.OdeHelper;
+import org.ode4j.ode.internal.DxSAPSpace2;
 
 /*
  * Results (in microseconds):
@@ -46,8 +47,8 @@ public class SpacePerformanceTest {
         System.out.println("-=" + iterations + "   " + geomnum + " =-");
         DSpace space = OdeHelper.createSapSpace(AXES.XZY); 
         testSpace(space, iterations, geomnum);
-     //   DSpace spaceOld = DxSAPSpaceOld.dSweepAndPruneSpaceCreate(null, AXES.XZY.getCode());
-     //   testSpace(spaceOld, iterations, geomnum);
+        space = DxSAPSpace2.dSweepAndPruneSpaceCreate(null, AXES.XZY.getCode());
+        testSpace(space, iterations, geomnum);
     }
     
     private void testSpace(DSpace space, int iterations, int geomnum) {

--- a/demo/src/test/java/org/ode4j/tests/TestIssue0018_NpeInQuickstep.java
+++ b/demo/src/test/java/org/ode4j/tests/TestIssue0018_NpeInQuickstep.java
@@ -31,7 +31,6 @@ import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
 
 import org.junit.Test;
 import org.ode4j.drawstuff.DrawStuff;
-import org.ode4j.drawstuff.internal.DrawStuffNull;
 import org.ode4j.math.DMatrix3;
 import org.ode4j.math.DMatrix3C;
 import org.ode4j.math.DVector3;
@@ -100,9 +99,7 @@ public class TestIssue0018_NpeInQuickstep extends DrawStuff.dsFunctions {
 			}
 
 			// now we draw everything
-			int ngeoms = space.getNumGeoms();
-			for (int i = 0; i < ngeoms; ++i) {
-				DGeom g = space.getGeom(i);
+			for (DGeom g : space.getGeoms()) {
 				drawGeom(g);
 			}
 

--- a/demo/src/test/java/org/ode4j/tests/Test_DxSpace.java
+++ b/demo/src/test/java/org/ode4j/tests/Test_DxSpace.java
@@ -1,0 +1,138 @@
+package org.ode4j.tests;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.ode4j.ode.DBox;
+import org.ode4j.ode.DCapsule;
+import org.ode4j.ode.DGeom;
+import org.ode4j.ode.DGeom.DNearCallback;
+import org.ode4j.ode.DSimpleSpace;
+import org.ode4j.ode.DSphere;
+import org.ode4j.ode.OdeHelper;
+import org.ode4j.ode.internal.DxGeom;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class Test_DxSpace {
+
+	private DSimpleSpace space;
+	private DSphere sphere;
+	private DBox box;
+	private DCapsule capsule;
+
+	@Before
+	public void setUp() {
+		OdeHelper.initODE2(0);
+		space = OdeHelper.createSimpleSpace();
+		sphere = OdeHelper.createSphere(1);
+		box = OdeHelper.createBox(1, 2, 3);
+		capsule = OdeHelper.createCapsule(1, 2);
+	}
+
+	@Test
+	public void testCreateDestroy() {
+		space.add(sphere);
+		space.add(box);
+		space.add(capsule);
+		assertEquals(3, space.getNumGeoms());
+		assertTrue(contains(sphere));
+		assertTrue(contains(box));
+		assertTrue(contains(capsule));
+		space.destroy();
+		assertEquals(0, space.getNumGeoms());
+		assertFalse(contains(sphere));
+		assertFalse(contains(box));
+		assertFalse(contains(capsule));
+	}
+
+	@Test
+	public void testAddRemove() {
+		space.add(sphere);
+		assertEquals(1, space.getNumGeoms());
+		assertTrue(contains(sphere));
+		space.add(box);
+		space.add(capsule);
+		assertEquals(3, space.getNumGeoms());
+		assertTrue(contains(sphere));
+		assertTrue(contains(box));
+		assertTrue(contains(capsule));
+		space.remove(box);
+		assertEquals(2, space.getNumGeoms());
+		assertTrue(contains(sphere));
+		assertFalse(contains(box));
+		assertTrue(contains(capsule));
+		capsule.destroy();
+		assertEquals(1, space.getNumGeoms());
+		assertTrue(contains(sphere));
+		assertFalse(contains(box));
+		assertFalse(contains(capsule));
+		space.destroy();
+		assertEquals(0, space.getNumGeoms());
+		assertFalse(contains(sphere));
+		assertFalse(contains(box));
+		assertFalse(contains(capsule));
+	}
+
+	@Test
+	public void testAddRemoveCollide() {
+		space.add(sphere);
+		assertEquals(1, space.getNumGeoms());
+		assertTrue(contains(sphere));
+		space.add(box);
+		space.add(capsule);
+		assertEquals(3, space.getNumGeoms());
+		assertTrue(contains(sphere));
+		assertTrue(contains(box));
+		assertTrue(contains(capsule));
+		final AtomicInteger collisions = new AtomicInteger(0);
+		space.collide(null, new DNearCallback() {
+			@Override
+			public void call(Object data, DGeom o1, DGeom o2) {
+				collisions.incrementAndGet();
+			}
+		});
+		assertEquals(3, collisions.get());
+		space.remove(box);
+		assertEquals(2, space.getNumGeoms());
+		assertTrue(contains(sphere));
+		assertFalse(contains(box));
+		assertTrue(contains(capsule));
+		collisions.set(0);
+		space.collide(null, new DNearCallback() {
+			@Override
+			public void call(Object data, DGeom o1, DGeom o2) {
+				collisions.incrementAndGet();
+			}
+		});
+		assertEquals(1, collisions.get());
+		capsule.destroy();
+		assertEquals(1, space.getNumGeoms());
+		assertTrue(contains(sphere));
+		assertFalse(contains(box));
+		assertFalse(contains(capsule));
+		collisions.set(0);
+		space.collide(null, new DNearCallback() {
+			@Override
+			public void call(Object data, DGeom o1, DGeom o2) {
+				collisions.incrementAndGet();
+			}
+		});
+		assertEquals(0, collisions.get());
+		space.destroy();
+		assertEquals(0, space.getNumGeoms());
+		assertFalse(contains(sphere));
+		assertFalse(contains(box));
+		assertFalse(contains(capsule));
+	}
+
+	private boolean contains(DGeom geom) {
+		for (DxGeom g : space.getGeoms()) {
+			if (geom == g) {
+				return true;
+			}
+		}
+		return false;
+	}
+}


### PR DESCRIPTION
Hi,

This is a pure refactoring PR - an attempt to clean up the way geoms are stored within a space. 
It completely removes the custom linked list (_next, _prev fields in DxGeom), changes the collection in DxSpace from ArrayList to LinkedList for performance reasons (adding an element to ArrayList at index0 requires the whole array to be shifted) and replaces getGeom() with getGeoms() to provide access to geoms within a space.
Obviously the changes affect the API and they are not backward compatible, but I do not think retrieving particular geoms from space by index is something users of ode4j really use anyway.

This commit includes the following changes:
- change _geoms collection from ArrayList to LinkedList
- remove getGeom() from DxSpace and add getGeoms() to DxSpace instead
- remove fields that are no longer used from DxGeom and DxSpace
- add corresponding test - Test_DxSpace

Thanks,
Piotr
