### PR TITLE
Improve trimesh vs convex collisions for concave trimeshes

### DIFF
--- a/core/src/main/java/org/ode4j/ode/DTriMeshData.java
+++ b/core/src/main/java/org/ode4j/ode/DTriMeshData.java
@@ -137,7 +137,7 @@ public interface DTriMeshData {
 //
 //	/** Preprocess the trimesh data to remove mark unnecessary edges and vertices */
 //	//ODE_API 
-//	void preprocess(DTriMeshData g);
+	void preprocess();
 //	/** Get and set the internal preprocessed trimesh data buffer, for loading and saving */
 //	//ODE_API 
 //	//void dGeomTriMeshDataGetBuffer(dTriMeshData g, unsigned char** buf, int* bufLen) {

--- a/core/src/main/java/org/ode4j/ode/internal/CollideConvexTrimesh.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideConvexTrimesh.java
@@ -1,5 +1,7 @@
 package org.ode4j.ode.internal;
 
+import java.util.Arrays;
+
 import org.ode4j.ode.DAABBC;
 import org.ode4j.ode.DColliderFn;
 import org.ode4j.ode.DContactGeomBuffer;
@@ -30,7 +32,7 @@ public class CollideConvexTrimesh implements DColliderFn {
 		ptrimesh.getAabbSet().gim_aabbset_box_collision(test_aabb, collision_result);
 		int contactcount = 0;
 		if (collision_result.size() != 0) {
-			int[] boxesresult = collision_result.GIM_DYNARRAY_POINTER();
+			int[] boxesresult = Arrays.copyOf(collision_result.GIM_DYNARRAY_POINTER(), collision_result.size());
 			ptrimesh.gim_trimesh_locks_work_data();
 			CollideConvexTrimeshTrianglesCCD collideFn = new CollideConvexTrimeshTrianglesCCD();
 			contactcount = collideFn.collide(o1, o2, boxesresult, flags, contacts);

--- a/core/src/main/java/org/ode4j/ode/internal/DxGimpact.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxGimpact.java
@@ -393,4 +393,9 @@ public class DxGimpact extends DxTriMesh {
 	public void setTriMergeCallback(DTriTriMergeCallback Callback) {
 		dGeomTriMeshSetTriMergeCallback(Callback);
 	}
+
+	@Override
+	public float getEdgeAngle(int triangle, int edge) {
+		return _Data.getEdgeAngle(triangle, edge);
+	}
 }

--- a/core/src/main/java/org/ode4j/ode/internal/DxGimpactData.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxGimpactData.java
@@ -45,6 +45,7 @@ public class DxGimpactData extends DxTriMeshData {
 //	int m_TriangleCount;
 //	int m_TriStride;
 //	boolean m_single;
+	private float[] m_Angles;
 
     DxGimpactData()//dxTriMeshData()
 	{
@@ -119,7 +120,6 @@ public class DxGimpactData extends DxTriMeshData {
  		//TODO remove?
  		//check();
   	}
-    
 	void GetVertex(int i, DVector4 Out)
 	{
 		//TZ commented out, special treatment not required (?)
@@ -156,10 +156,8 @@ public class DxGimpactData extends DxTriMeshData {
 //#endif  // dTRIMESH_GIMPACT
 
 	@Override
-	void Preprocess() {
-//		void dxTriMeshData::Preprocess(){	// stub
-//		}
-		throw new UnsupportedOperationException(); //??????
+	public void preprocess() {
+		m_Angles = new GimpactDataPreprocessor(this).buildAngles();
 	}
 
 	@Override
@@ -286,11 +284,6 @@ public class DxGimpactData extends DxTriMeshData {
 //				null);//(const int*)NULL);
 //	}
 
-	//void dGeomTriMeshDataPreprocess(dTriMeshDataID g)
-	void dGeomTriMeshDataPreprocess()
-	{
-		Preprocess();
-	}
 
 	//void dGeomTriMeshDataGetBuffer(dTriMeshDataID g, unsigned char** buf, int* bufLen)
 	void dGeomTriMeshDataGetBuffer(Ref<Object> buf, RefInt bufLen)
@@ -404,6 +397,11 @@ public class DxGimpactData extends DxTriMeshData {
 			
 		}
 		System.out.println(nE);
+	}
+
+
+	public float getEdgeAngle(int triangle, int edge) {
+    	return (float) (m_Angles != null ? m_Angles[triangle * 3 + edge] : Math.PI * 2);
 	}
 	
 }

--- a/core/src/main/java/org/ode4j/ode/internal/DxTriMesh.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxTriMesh.java
@@ -81,5 +81,14 @@ public abstract class DxTriMesh extends DxGeom implements DTriMesh {
 	abstract public int FetchTriangleCount();
 
 	abstract public void FetchTransformedTriangle(int i, DVector3[] v);
+
+	/*
+	 * Returns the following values:
+	 * between -PI and 0 for concave edges
+	 * 0 for flat edges
+	 * between 0 and PI for convex edges 
+	 * > PI for boundary edges
+	 */
+	abstract public float getEdgeAngle(int triangle, int edge);
 }
 

--- a/core/src/main/java/org/ode4j/ode/internal/DxTriMeshData.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxTriMeshData.java
@@ -44,7 +44,7 @@ public abstract class DxTriMeshData implements DTriMeshData {
 //    };
 
     /* Setup the UseFlags array */
-    abstract void Preprocess();
+    public abstract void preprocess();
     /* For when app changes the vertices */
     abstract void UpdateData();
 

--- a/core/src/main/java/org/ode4j/ode/internal/DxTriMeshDisabled.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxTriMeshDisabled.java
@@ -33,7 +33,7 @@ class DxTriMeshDisabled extends DxTriMesh {
 
 	static class dxTriMeshDisabledData extends DxTriMeshData {
 		@Override
-		void Preprocess() {
+		public void preprocess() {
 			throw new UnsupportedOperationException();
 		}
 
@@ -187,6 +187,11 @@ class DxTriMeshDisabled extends DxTriMesh {
 	public void setTriMergeCallback(DTriTriMergeCallback Callback) {
 		// TODO Auto-generated method stub
 		
+	}
+
+	@Override
+	public float getEdgeAngle(int triangle, int edge) {
+		return (float) (Math.PI * 2);
 	}
 
 	//#endif // !dTRIMESH_ENABLED

--- a/core/src/main/java/org/ode4j/ode/internal/GimpactDataPreprocessor.java
+++ b/core/src/main/java/org/ode4j/ode/internal/GimpactDataPreprocessor.java
@@ -1,0 +1,110 @@
+package org.ode4j.ode.internal;
+
+import java.util.Arrays;
+
+import org.ode4j.math.DVector3;
+
+public class GimpactDataPreprocessor {
+
+	private final DxGimpactData data;
+
+	public GimpactDataPreprocessor(DxGimpactData data) {
+		this.data = data;
+	}
+
+	float[] buildAngles() {
+		int numVertices = data.getDataRef().length / 3;
+		int numIndices = data.getIndexRef().length;
+		// Distribute triangles to buckets based on indices of their vertices to
+		// speed up the search for neighbours
+		// Store counts in the first array and offsets in the second
+		int[][] triangleListInfo = new int[2][numVertices];
+		// 1. Find triangle count for each bucket
+		for (int i = 0; i < numIndices; i++) {
+			triangleListInfo[0][getVertexIndex(i)]++;
+		}
+		int startOffset = 0;
+		// 2. Set list offset for each bucket and reset triangle counts
+		for (int i = 0; i < numVertices; i++) {
+			triangleListInfo[1][i] = startOffset;
+			startOffset += triangleListInfo[0][i];
+			triangleListInfo[0][i] = 0;
+		}
+		// 3. Fill buckets with triangles
+		int[] triangleLists = new int[numIndices];
+		for (int i = 0; i < numIndices; i++) {
+			int triangle = i / 3;
+			int index = getVertexIndex(i);
+			triangleLists[triangleListInfo[1][index] + triangleListInfo[0][index]++] = triangle;
+		}
+		// 4. Search for neighbours and find the angles
+		float[] angles = new float[numIndices];
+		Arrays.fill(angles, (float)Math.PI * 2);
+		for (int i = 0; i < numIndices; i++) {
+			int triangle = i / 3;
+			int startIndex = getVertexIndex(i);
+			int endIndex = getVertexIndex(triangle * 3 + (i + 1) % 3);
+			int count = triangleListInfo[0][startIndex];
+			int offset = triangleListInfo[1][startIndex];
+			for (int j = 0; j < count; j++) {
+				int t = triangleLists[offset + j];
+				if (t != triangle && hasEdge(t, endIndex, startIndex)) {
+					angles[i] = getAngle(triangle, i % 3, t);
+					break;
+				}
+			}
+		}
+		return angles;
+	}
+
+	private boolean hasEdge(int triangle, int startIndex, int endIndex) {
+		for (int i = 0; i < 3; i++) {
+			int index1 = getVertexIndex(triangle * 3 + i);
+			int index2 = getVertexIndex(triangle * 3 + (i + 1) % 3);
+			if (index1 == startIndex && index2 == endIndex) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private int getVertexIndex(int index) {
+		return data.getIndexRef()[index];
+	}
+
+	private float getAngle(int triangle, int vertexIndex, int neighbourTriangle) {
+		DVector3 startVertex = getVertex(data.getIndexRef()[triangle * 3 + vertexIndex]);
+		DVector3 endVertex = getVertex(data.getIndexRef()[triangle * 3 + (vertexIndex + 1) % 3]);
+		DVector3 oppositeVertex = getVertex(data.getIndexRef()[triangle * 3 + (vertexIndex + 2) % 3]);
+		DVector3 edgeAxis = new DVector3(endVertex).sub(startVertex);
+		DVector3 secondEdge = new DVector3(oppositeVertex).sub(endVertex);
+		DVector3 normal = new DVector3();
+		normal.eqCross(edgeAxis, secondEdge);
+		DVector3 tangent = new DVector3();
+		tangent.eqCross(edgeAxis, normal);
+
+		DVector3 neighbourVertex1 = getVertex(data.getIndexRef()[neighbourTriangle * 3]);
+		DVector3 neighbourVertex2 = getVertex(data.getIndexRef()[neighbourTriangle * 3 + 1]);
+		DVector3 neighbourVertex3 = getVertex(data.getIndexRef()[neighbourTriangle * 3 + 2]);
+		DVector3 neighbourEdge1 = new DVector3(neighbourVertex2).sub(neighbourVertex1);
+		DVector3 neighbourEdge2 = new DVector3(neighbourVertex3).sub(neighbourVertex2);
+		DVector3 neighbourNormal = new DVector3();
+		neighbourNormal.eqCross(neighbourEdge1, neighbourEdge2);
+		
+		float angle = (float) Math.signum(tangent.dot(neighbourNormal));
+		double angleCos = normal.dot(neighbourNormal); 
+		double length = Math.sqrt(normal.lengthSquared() * neighbourNormal.lengthSquared());
+		if (length > Double.MIN_VALUE) {
+			angleCos /= length;
+		}
+		angleCos = Math.max(Math.min(1.0, angleCos), -1.0);
+		angle *= (float) Math.acos(angleCos);
+		return angle;
+	}
+
+	private DVector3 getVertex(int index) {
+		return new DVector3(data.getDataRef()[index * 3], data.getDataRef()[index * 3 + 1],
+				data.getDataRef()[index * 3 + 2]);
+	}
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/libccd/CCDVec3.java
+++ b/core/src/main/java/org/ode4j/ode/internal/libccd/CCDVec3.java
@@ -244,10 +244,14 @@ public class CCDVec3 {
 	/**
 	 * Normalizes given vector to unit length.
 	 */
-	public static final void ccdVec3Normalize(ccd_vec3_t d)
+	public static final boolean ccdVec3Normalize(ccd_vec3_t d)
 	{
-	    double k = CCD_ONE / CCD_SQRT(ccdVec3Len2(d));
-	    ccdVec3Scale(d, k);
+	    double len = CCD_SQRT(ccdVec3Len2(d));
+	    if (len > CCD_EPS) {
+		    ccdVec3Scale(d, CCD_ONE / len);
+		    return true;
+	    }
+	    return false;
 	}
 
 	/**
@@ -266,7 +270,7 @@ public class CCDVec3 {
 	/**
 	 * Cross product: d = a x b.
 	 */
-	static final void ccdVec3Cross(ccd_vec3_t d, final ccd_vec3_t a, final ccd_vec3_t b)
+	public static final void ccdVec3Cross(ccd_vec3_t d, final ccd_vec3_t a, final ccd_vec3_t b)
 	{
 	    d.v0 = (a.v1 * b.v2) - (a.v2 * b.v1);
 	    d.v1 = (a.v2 * b.v0) - (a.v0 * b.v2);

--- a/demo-cpp/src/test/java/org/ode4j/ode/internal/DxGimpactDataTest.java
+++ b/demo-cpp/src/test/java/org/ode4j/ode/internal/DxGimpactDataTest.java
@@ -1,0 +1,73 @@
+package org.ode4j.ode.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class DxGimpactDataTest {
+
+	static final float CUBE_POINTS[] = { 
+			0.25f, 0.25f, 0.25f, // point 0
+			-0.25f, 0.25f, 0.25f, // point 1
+			0.25f, -0.25f, 0.25f, // point 2
+			-0.25f, -0.25f, 0.25f, // point 3
+			0.25f, 0.25f, -0.25f, // point 4
+			-0.25f, 0.25f, -0.25f, // point 5
+			0.25f, -0.25f, -0.25f, // point 6
+			-0.25f, -0.25f, -0.25f,// point 7
+	};
+
+	static final int CUBE_INDICES[] = { 
+			0, 2, 6, // 0 
+			0, 6, 4, // 1
+			1, 0, 4, // 2
+			1, 4, 5, // 3
+			0, 1, 3, // 4
+			0, 3, 2, // 5
+			3, 1, 5, // 6
+			3, 5, 7, // 7
+			2, 3, 7, // 8
+			2, 7, 6, // 9 
+			5, 4, 6, // 10 
+			5, 6, 7  // 11 
+			};
+	
+	@Test
+	public void testCube() {
+		DxGimpactData data = new DxGimpactData();
+		data.build(CUBE_POINTS, CUBE_INDICES);
+		data.preprocess();
+		assertEquals(Math.PI * 0.5, data.getEdgeAngle(0, 0), 0.001);
+		assertEquals(Math.PI * 0.5, data.getEdgeAngle(0, 1), 0.001);
+		assertEquals(0, data.getEdgeAngle(0, 2), 0.001);
+		assertEquals(Math.PI * 0.5, data.getEdgeAngle(6, 0), 0.001);
+		assertEquals(Math.PI * 0.5, data.getEdgeAngle(6, 1), 0.001);
+		assertEquals(0.0, data.getEdgeAngle(6, 2), 0.001);
+	}
+
+	static final float QUAD_POINTS[] = { 
+			-1f, 0.0f, 0.0f, // point 0
+			0.0f, 0.0f, 1.0f, // point 1
+			0.0f, -0.0f, -1.0f, // point 2
+			1.0f, -1.0f, 0.0f, // point 3
+	};
+
+	static final int QUAD_INDICES[] = { 
+			0, 1, 2, // 0 
+			2, 1, 3, // 1
+			};
+	
+	@Test
+	public void testQuad() {
+		DxGimpactData data = new DxGimpactData();
+		data.build(QUAD_POINTS, QUAD_INDICES);
+		data.preprocess();
+		assertEquals(Math.PI * 2, data.getEdgeAngle(0, 0), 0.001);
+		assertEquals(Math.PI * 0.25, data.getEdgeAngle(0, 1), 0.001);
+		assertEquals(Math.PI * 2, data.getEdgeAngle(0, 2), 0.001);
+		assertEquals(Math.PI * 0.25, data.getEdgeAngle(1, 0), 0.001);
+		assertEquals(Math.PI * 2, data.getEdgeAngle(1, 1), 0.001);
+		assertEquals(Math.PI * 2, data.getEdgeAngle(1, 2), 0.001);
+	}
+
+}

--- a/demo/src/main/java/org/ode4j/demo/DemoBasketConvex.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBasketConvex.java
@@ -1,0 +1,293 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.demo;
+
+import org.ode4j.drawstuff.DrawStuff.dsFunctions;
+import org.ode4j.math.DMatrix3;
+import org.ode4j.math.DMatrix3C;
+import org.ode4j.math.DQuaternion;
+import org.ode4j.math.DVector3C;
+import org.ode4j.ode.DBody;
+import org.ode4j.ode.DBox;
+import org.ode4j.ode.DContact;
+import org.ode4j.ode.DContactBuffer;
+import org.ode4j.ode.DGeom;
+import org.ode4j.ode.DJoint;
+import org.ode4j.ode.DJointGroup;
+import org.ode4j.ode.DMass;
+import org.ode4j.ode.DSpace;
+import org.ode4j.ode.DSphere;
+import org.ode4j.ode.DTriMesh;
+import org.ode4j.ode.DTriMeshData;
+import org.ode4j.ode.DWorld;
+import org.ode4j.ode.OdeHelper;
+
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.ode.OdeMath.*;
+import static org.ode4j.demo.BasketGeom.*;
+
+/**
+ * Basket ball demo.
+ * Serves as a test for the sphere vs trimesh collider
+ * By Bram Stolk.
+ * Press the spacebar to reset the position of the ball.
+ */
+public class DemoBasketConvex extends dsFunctions {
+
+	// some constants
+
+	private static final double RADIUS = 0.3;
+
+	// dynamics and collision objects (chassis, 3 wheels, environment)
+
+	private static DWorld world;
+	private static DSpace space;
+
+	private static DBody sphbody;
+	private static DGeom sphgeom;
+
+	private static DJointGroup contactgroup;
+	private static DTriMesh world_mesh;
+
+
+	private DGeom.DNearCallback nearCallback = new DGeom.DNearCallback() {
+		@Override
+		public void call(Object data, DGeom o1, DGeom o2) {
+			nearCallback(data, o1, o2);
+		}
+	};
+
+
+	// this is called by dSpaceCollide when two objects in space are
+	// potentially colliding.
+
+	private void nearCallback (Object data, DGeom o1, DGeom o2)
+	{
+		assert(o1!=null);
+		assert(o2!=null);
+
+		if (o1 instanceof DSpace || o2 instanceof DSpace)
+		{
+			//fprintf(stderr,"testing space %p %p\n", o1,o2);
+			System.err.println("testing space " + o1 + " " + o2);
+			// colliding a space with something
+			OdeHelper.spaceCollide2(o1,o2,data,nearCallback);
+			// Note we do not want to test intersections within a space,
+			// only between spaces.
+			return;
+		}
+
+		//  fprintf(stderr,"testing geoms %p %p\n", o1, o2);
+
+		final int N = 32;
+		DContactBuffer contacts = new DContactBuffer(N);
+		int n = OdeHelper.collide (o1,o2,N,contacts.getGeomBuffer());
+		if (n > 0) 
+		{
+			for (int i=0; i<n; i++) 
+			{
+				DContact contact = contacts.get(i);
+				// Paranoia  <-- not working for some people, temporarily removed for 0.6
+				//dIASSERT(dVALIDVEC3(contact[i].geom.pos));
+				//dIASSERT(dVALIDVEC3(contact[i].geom.normal));
+				//dIASSERT(!dIsNan(contact[i].geom.depth));
+				contact.surface.slip1 = 0.7;
+				contact.surface.slip2 = 0.7;
+				contact.surface.mode = dContactSoftERP | dContactSoftCFM | dContactApprox1 | dContactSlip1 | dContactSlip2;
+				contact.surface.mu = 50.0; // was: dInfinity
+				contact.surface.soft_erp = 0.96;
+				contact.surface.soft_cfm = 0.04;
+				DJoint c = OdeHelper.createContactJoint (world,contactgroup,contact);
+				c.attach( contact.geom.g1.getBody(),
+						contact.geom.g2.getBody());
+			}
+		}
+	}
+
+
+	// start simulation - set viewpoint
+
+	@Override
+	public void start()
+	{
+		//dAllocateODEDataForThread(dAllocateMaskAll);
+
+		dsSetViewpoint (xyz,hpr);
+	}
+	private float[] xyz = {-8,0,5};
+	private float[] hpr = {0.0f,-29.5000f,0.0000f};
+
+
+
+	private void reset_ball()
+	{
+		float sx=0.0f, sy=2.973f, sz=7.51f;
+
+//		//#if defined(_MSC_VER) && defined(dDOUBLE) 
+//		//sy -= 0.01; // Cheat, to make it score under win32/double
+//		//#endif
+		sy += 0.033; // Windows 64 //TODO
+		//sy += 0.046;  //For 'double' on Linux 64bit. //TODO !!! 
+
+		DQuaternion q = new DQuaternion();
+		q.setIdentity();
+		sphbody.setPosition (sx, sy, sz);
+		sphbody.setQuaternion(q);
+		sphbody.setLinearVel (0,0,0);
+		sphbody.setAngularVel (0,0,0);
+	}
+
+
+	// called when a key pressed
+
+	@Override
+	public void command (char cmd)
+	{
+		switch (cmd) 
+		{
+		case ' ':
+			reset_ball();
+			break;
+		}
+	}
+
+
+	// simulation loop
+
+	@Override
+	public void step (boolean pause)
+	{
+		double simstep = 0.001; // 1ms simulation steps
+		double dt = dsElapsedTime();
+
+		int nrofsteps = (int) Math.ceil(dt/simstep);
+		//  fprintf(stderr, "dt=%f, nr of steps = %d\n", dt, nrofsteps);
+
+		for (int i=0; i<nrofsteps && !pause; i++)
+		{
+			OdeHelper.spaceCollide (space,0,nearCallback);
+			world.quickStep (simstep);
+			contactgroup.empty();
+		}
+
+		dsSetColor (1,1,1);
+		DVector3C spos = sphbody.getPosition();
+		DMatrix3C srot = sphbody.getRotation();
+		dsDrawSphere ( spos, srot, RADIUS );
+
+		// draw world trimesh
+		dsSetColor(0.4f,0.7f,0.9f);
+		dsSetTexture (DS_TEXTURE_NUMBER.DS_NONE);
+
+		DVector3C pos = world_mesh.getPosition();
+		//dIASSERT(dVALIDVEC3(Pos));
+
+		DMatrix3C rot = world_mesh.getRotation();
+		//dIASSERT(dVALIDMAT3(Rot));
+
+		int numi = world_indices.length;;
+
+		for (int i=0; i<numi; i+=3)
+		{
+			int i0 = world_indices[i+0]*3;
+			int i1 = world_indices[i+1]*3;
+			int i2 = world_indices[i+2]*3;
+			dsDrawTriangle(pos, rot, world_vertices, i0, i1, i2, true); // single precision draw
+		}
+	}
+
+
+	/**
+	 * @param args
+	 */
+	public static void main(final String[] args) {
+		new DemoBasketConvex().demo(args);
+	}
+
+	private void demo(String[] args)
+	{
+		DMass m = OdeHelper.createMass();
+		DMatrix3 R = new DMatrix3();
+
+		// create world
+		OdeHelper.initODE2(0);
+		world = OdeHelper.createWorld();
+		space = OdeHelper.createHashSpace(null);
+
+		contactgroup = OdeHelper.createJointGroup();
+		world.setGravity (0,0,-9.8);
+		world.setQuickStepNumIterations (64);
+
+		// Create a static world using a triangle mesh that we can collide with.
+		DTriMeshData Data = OdeHelper.createTriMeshData();
+
+		//  fprintf(stderr,"Building Single Precision Mesh\n");
+
+		Data.build( world_vertices, world_indices );
+		Data.preprocess();
+		world_mesh = OdeHelper.createTriMesh(space, Data, null, null, null);
+		world_mesh.enableTC(DSphere.class, false);
+		world_mesh.enableTC(DBox.class, false);
+		world_mesh.setPosition(0, 0, 0.5);
+		R.setIdentity();
+		//dIASSERT(dVALIDMAT3(R));
+
+		world_mesh.setRotation (R);
+
+		//float sx=0.0, sy=3.40, sz=6.80;
+		sphbody = OdeHelper.createBody(world);
+		m.setSphere (1,RADIUS);
+		sphbody.setMass (m);
+		sphgeom = OdeHelper.createConvex (null,
+				IcosahedronGeom.Sphere_planes,
+				IcosahedronGeom.Sphere_planecount,
+				IcosahedronGeom.Sphere_points,
+				IcosahedronGeom.Sphere_pointcount,
+				IcosahedronGeom.Sphere_polygons);
+		sphgeom.setBody (sphbody);
+		reset_ball();
+		space.add (sphgeom);
+
+		// run simulation
+		dsSimulationLoop (args,352,288,this);
+
+		// Causes segm violation? Why?
+		// (because dWorldDestroy() destroys body connected to geom; must call first!)
+		sphgeom.destroy();
+		world_mesh.destroy ();
+
+		contactgroup.empty ();
+		contactgroup.destroy ();
+		space.destroy ();
+		world.destroy ();
+		OdeHelper.closeODE();
+	}
+
+
+	@Override
+	public void stop() {
+		// Nothing
+	}
+}

--- a/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
@@ -530,8 +530,10 @@ public class DemoMovingTrimesh extends dsFunctions {
 		// note: can't share tridata if intending to trimesh-trimesh collide
 		TriData1 = OdeHelper.createTriMeshData();
 		TriData1.build(Vertices, Indices);
+		TriData1.preprocess();
 		TriData2 = OdeHelper.createTriMeshData();
 		TriData2.build(Vertices, Indices);
+		TriData2.preprocess();
 
 		TriMesh1 = OdeHelper.createTriMesh(space, TriData1, null, null, null);
 		TriMesh2 = OdeHelper.createTriMesh(space, TriData2, null, null, null);

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimesh.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimesh.java
@@ -476,7 +476,7 @@ class DemoTrimesh extends dsFunctions {
 		//		Data.build(Data, Vertices[0], 3,// * sizeof(float), 
 		//				VertexCount, Indices[0], IndexCount, 3);// * sizeof(dTriIndex));
 		Data.build(Vertices, Indices);// * sizeof(dTriIndex));
-
+		Data.preprocess();
 		TriMesh = OdeHelper.createTriMesh(space, Data, null, null, null);
 
 		//TriMesh.setPosition(0, 0, 1.0);


### PR DESCRIPTION
This PR contains the Java port of the changes suggested and discussed in https://bitbucket.org/odedevs/ode/pull-requests/10/improve-convex-vs-trimesh-collisions/diff. The changes got merged into ODE's codebase some time ago and they complete the implementation of the convex vs trimesh collision detection by adding proper support for concave meshes and improved handling of internal edges. 
The ideas were mostly taken from https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/bullet/GDC10_Coumans_Erwin_Contact.pdf. 
The implementation in Java follows the same principles yet I tried to simplify the code as much as possible. 
To enable the improved handling of internal edges the preprocess method needs to be called on the trimesh object to keep it consistent with the way it was implemented in ODE.
There is a simple test included along with a new demo called DemoBasketConvex. The demo can be used to compare the results before and after the patch is applied (the erroneous behaviour without the patch is also shown here: https://vimeo.com/163513398).