### PR TITLE
Fix trimesh vs capsule contact depth calculation

### DIFF
--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshCapsuleCollision.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshCapsuleCollision.java
@@ -198,7 +198,7 @@ public class GimTrimeshCapsuleCollision {
 	        //POST closest_points[0] and closest_points[1] are inside the triangle, if out_edge>2
 	        if(out_edge>2) // Over triangle
 	        {
-	            dis = VEC_DOT(closest_points[0],triangle.m_planes.m_planes[0]);
+	            dis = DISTANCE_PLANE_POINT(triangle.m_planes.m_planes[0],closest_points[0]);
 	            GimContact.GIM_PUSH_CONTACT(contacts,closest_points[0] ,triangle.m_planes.m_planes[0] ,dis,null,null, 0,0);
 	            GimContact.GIM_PUSH_CONTACT(contacts,closest_points[1] ,triangle.m_planes.m_planes[0] ,dis,null,null, 0,0);
 	            return;


### PR DESCRIPTION
Hi,
There seems to be a bug in gimpact when it comes to calculating contact depth between trimeshes and capsules. Apparently instead of finding the distance between triangle plane and closest point the coordinates of the closest point are projected onto the plane normal. The PR fixes the issue by calling DISTANCE_PLANE_POINT instead of VEC_DOT. The same fix submitted for ODE: https://bitbucket.org/odedevs/ode/pull-requests/12/