### PR TITLE
Add DxBVHSpace

### DIFF
--- a/core/src/main/java/org/ode4j/ode/DGeom.java
+++ b/core/src/main/java/org/ode4j/ode/DGeom.java
@@ -64,7 +64,8 @@ public interface DGeom {
 	public static final int   dHashSpaceClass = 11;
 	public static final int   dSweepAndPruneSpaceClass = 12;
 	public static final int   dQuadTreeSpaceClass = 13;
-	public static final int   dLastSpaceClass = dQuadTreeSpaceClass; //13
+	public static final int   dBVHSpaceClass = 14;
+	public static final int   dLastSpaceClass = dBVHSpaceClass; //14
 
 	/** 
 	 * ID of the first user defined class. 

--- a/core/src/main/java/org/ode4j/ode/internal/DxBVHSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxBVHSpace.java
@@ -1,0 +1,256 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine 4J                                               *
+ * Copyright (C) 2017 Piotr Piastucki, Tilmann Zaeschke                  *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal;
+
+import static org.ode4j.ode.OdeConstants.dInfinity;
+import static org.ode4j.ode.internal.Common.dAASSERT;
+import static org.ode4j.ode.internal.Common.dIASSERT;
+import static org.ode4j.ode.internal.Common.dUASSERT;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.ode4j.ode.DAABB;
+import org.ode4j.ode.DSpace;
+import org.ode4j.ode.internal.aabbtree.AABBTree;
+import org.ode4j.ode.internal.aabbtree.AABBTreeNodeCallback;
+import org.ode4j.ode.internal.aabbtree.AABBTreePairCallback;
+import org.ode4j.ode.internal.aabbtree.ExternalObjectHandler;
+
+public class DxBVHSpace extends DxSpace {
+
+	private final AABBTree<DxGeom> bvhTree;
+	private boolean dirtyGeoms;
+	private List<DxGeom> dirty = new ArrayList<DxGeom>();
+	// geoms with infinite AABBs
+	private List<DxGeom> infGeomList = new ArrayList<DxGeom>();
+
+	private class GeomSpatialIndexHandler implements ExternalObjectHandler<DxGeom> {
+
+	    private final long staticGeomCategoryMask;
+	    
+		public GeomSpatialIndexHandler(long staticGeomCategoryMask) {
+            this.staticGeomCategoryMask = staticGeomCategoryMask;
+        }
+
+        @Override
+		public void setSpatialIndex(DxGeom object, int index) {
+			object._sapIdxGeomEx = index;
+		}
+
+		@Override
+		public int getSpatialIndex(DxGeom object) {
+			return object._sapIdxGeomEx;
+		}
+
+		@Override
+		public boolean isEnabled(DxGeom object) {
+			return GEOM_ENABLED(object);
+		}
+
+        @Override
+        public boolean isStatic(DxGeom object) {
+            return (object.getCategoryBits() & staticGeomCategoryMask) != 0;
+        }
+
+	}
+
+	public static DxBVHSpace bvhSpaceCreate(DxSpace space, int nodesPerLeaf, boolean highQuality, double fatAabbMargin, long staticGeomCategoryMask) {
+		return new DxBVHSpace(space, nodesPerLeaf, highQuality, fatAabbMargin, staticGeomCategoryMask);
+	}
+
+	private DxBVHSpace(DxSpace space, int nodesPerLeaf, boolean highQuality, double fatAabbMargin, long staticGeomCategoryMask) {
+		super(space);
+		type = dBVHSpaceClass;
+		_aabb.set(-dInfinity, dInfinity, -dInfinity, dInfinity, -dInfinity, dInfinity);
+		bvhTree = new AABBTree<>(new GeomSpatialIndexHandler(staticGeomCategoryMask), nodesPerLeaf, highQuality, fatAabbMargin);
+	}
+
+	@Override
+	void add(DxGeom g) {
+		CHECK_NOT_LOCKED(this);
+		dAASSERT(g);
+		dUASSERT(g.parent_space == null, "geom is already in a space");
+		dirty.add(g);
+		dirtyGeoms = true;
+		g._sapIdxGeomEx = AABBTree.UNDEFINED_INDEX;
+		super.add(g);
+	}
+
+	@Override
+	void remove(DxGeom g) {
+		CHECK_NOT_LOCKED(this);
+		dAASSERT(g);
+		dUASSERT(g.parent_space == this, "object is not in this space");
+		infGeomList.remove(g);
+		dirty.remove(g);
+		bvhTree.remove(g);
+		dirtyGeoms = true;
+		super.remove(g);
+	}
+
+	@Override
+	void dirty(DxGeom g) {
+		dAASSERT(g);
+		dUASSERT(g.parent_space == this, "object is not in this space");
+		dirty.add(g);
+		dirtyGeoms = true;
+	}
+
+	@Override
+	public void cleanGeoms() {
+		lock_count++;
+		if (dirtyGeoms) {
+			for (DxGeom g : dirty) {
+				if (g instanceof DSpace) {
+					((DSpace) g).cleanGeoms();
+				}
+				g.recomputeAABB();
+				g.unsetFlagDirtyAndBad();
+				double[] extents = getExtents(g);
+				if (g._sapIdxGeomEx != AABBTree.UNDEFINED_INDEX) {
+					bvhTree.update(g, extents);
+				} else if (!isInfinite(g)) {
+					bvhTree.add(g, extents);
+				} else {
+					infGeomList.add(g);
+				}
+			}
+			dirty.clear();
+			dirtyGeoms = false;
+			bvhTree.finalizeUpdate();
+		}
+		lock_count--;
+	}
+
+	private double[] getExtents(DxGeom g) {
+		double[] extents = new double[6];
+		extents[0] = g.getAABB().getMin0();
+		extents[1] = g.getAABB().getMin1();
+		extents[2] = g.getAABB().getMin2();
+		extents[3] = g.getAABB().getMax0();
+		extents[4] = g.getAABB().getMax1();
+		extents[5] = g.getAABB().getMax2();
+		return extents;
+	}
+
+	private boolean isInfinite(DxGeom g) {
+		return g._aabb.getMax0() == dInfinity && g._aabb.getMax1() == dInfinity && g._aabb.getMax2() == dInfinity;
+	}
+
+	@Override
+	public void collide(final Object data, final DNearCallback callback) {
+		dAASSERT(callback);
+
+		lock_count++;
+
+		cleanGeoms();
+
+		// do BVH on normal AABBs
+		bvhTree.getOverlappingPairs(new AABBTreePairCallback<DxGeom>() {
+			@Override
+			public void overlap(DxGeom o1, DxGeom o2) {
+				collideGeomsNoAABBs(o1, o2, data, callback);
+			}
+		});
+
+		int infSize = infGeomList.size();
+
+		for (int m = 0; m < infSize; ++m) {
+			final DxGeom g1 = infGeomList.get(m);
+			if (!GEOM_ENABLED(g1))
+				continue;
+
+			// collide infinite ones
+			for (int n = m + 1; n < infSize; ++n) {
+				DxGeom g2 = infGeomList.get(n);
+				if (GEOM_ENABLED(g2)) {
+					collideGeomsNoAABBs(g1, g2, data, callback);
+				}
+			}
+
+			// collide infinite ones with normal ones
+			bvhTree.getOverlappingNodes(getExtents(g1), new AABBTreeNodeCallback<DxGeom>() {
+				@Override
+				public void overlap(DxGeom o) {
+					collideGeomsNoAABBs(g1, o, data, callback);
+				}
+			});
+		}
+
+		lock_count--;
+	}
+
+	void collideGeomsNoAABBs(DxGeom g1, DxGeom g2, Object data, DNearCallback callback) {
+		dIASSERT(!g1.hasFlagAabbBad());
+		dIASSERT(!g2.hasFlagAabbBad());
+
+		// no contacts if both geoms on the same body, and the body is not 0
+		if (g1.body == g2.body && g1.body != null)
+			return;
+
+		// test if the category and collide bitfields match
+		if (((g1.category_bits & g2.collide_bits) != 0 || (g2.category_bits & g1.collide_bits) != 0) == false) {
+			return;
+		}
+
+		DAABB bounds1 = g1._aabb;
+		DAABB bounds2 = g2._aabb;
+
+		// check if either object is able to prove that it doesn't intersect the
+		// AABB of the other
+		if (g1.AABBTest(g2, bounds2) == false)
+			return;
+		if (g2.AABBTest(g1, bounds1) == false)
+			return;
+
+		// the objects might actually intersect - call the space callback
+		// function
+		callback.call(data, g1, g2);
+	}
+
+	@Override
+	void collide2(final Object data, final DxGeom geom, final DNearCallback callback) {
+		dAASSERT(geom != null && callback != null);
+
+		lock_count++;
+		cleanGeoms();
+		geom.recomputeAABB();
+
+		bvhTree.getOverlappingNodes(getExtents(geom), new AABBTreeNodeCallback<DxGeom>() {
+			@Override
+			public void overlap(DxGeom o) {
+				collideGeomsNoAABBs(geom, o, data, callback);
+			}
+		});
+
+		for (DxGeom g : infGeomList) {
+			if (GEOM_ENABLED(g)) {
+				collideAABBs(g, geom, data, callback);
+			}
+		}
+		lock_count--;
+	}
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTree.java
+++ b/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTree.java
@@ -1,0 +1,573 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine 4J                                               *
+ * Copyright (C) 2017 Piotr Piastucki, Tilmann Zaeschke                  *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.aabbtree;
+
+import java.util.Arrays;
+
+/*
+ * Based on https://github.com/turbulenz/turbulenz_engine/blob/master/tslib/aabbtree.ts
+ */
+public class AABBTree<T> {
+
+    public static final int UNDEFINED_INDEX = -1;
+    private static final int FREE_NODES_POOL_SIZE = 100;
+
+    private final ExternalObjectHandler<T> externalObjectHandler;
+    private final int numNodesLeaf;
+    private final double fatAabbMargin;
+
+    private AABBTreeNode<T>[] nodes;
+    private int endNode;
+    private boolean needsRebuild;
+    private boolean needsRebound;
+    private int numAdds;
+    private int numUpdates;
+    private int numRemoves;
+    private int numExternalNodes;
+    private int startUpdate;
+    private int endUpdate;
+    private boolean highQuality;
+    private int nodesStack[];
+
+    @SuppressWarnings("unchecked")
+    public AABBTree(ExternalObjectHandler<T> externalObjectHandler, int numNodesLeaf, boolean highQuality, double fatAabbMargin) {
+        this.externalObjectHandler = externalObjectHandler;
+        this.numNodesLeaf = numNodesLeaf;
+        this.highQuality = highQuality;
+        this.fatAabbMargin = fatAabbMargin;
+        startUpdate = 0x7FFFFFFF;
+        endUpdate = -0x7FFFFFFF;
+        nodesStack = new int[32];
+        nodes = new AABBTreeNode[FREE_NODES_POOL_SIZE];
+    }
+
+    private void allocateNodes(int size) {
+        if (nodes.length < size + FREE_NODES_POOL_SIZE) {
+            nodes = Arrays.copyOf(nodes, size + FREE_NODES_POOL_SIZE);
+        }
+    }
+
+    private void ensureNodes(int size) {
+        if (nodes.length <= size) {
+            allocateNodes(size);
+        }
+    }
+
+    AABBTreeNode<T> allocateNode(double minX, double minY, double minZ, double maxX, double maxY, double maxZ,
+            int escapeNodeOffset, T externalNode, boolean isStatic) {
+        return new AABBTreeNode<T>(minX, minY, minZ, maxX, maxY, maxZ, escapeNodeOffset, externalNode, isStatic);
+    }
+
+    public void add(T object, double[] extents) {
+        AABBTreeNode<T> node = allocateNode(extents[0], extents[1], extents[2], extents[3], extents[4], extents[5], 1,
+                object, externalObjectHandler.isStatic(object));
+        externalObjectHandler.setSpatialIndex(object, endNode);
+        ensureNodes(endNode);
+        nodes[endNode] = node;
+        endNode++;
+        needsRebuild = true;
+        numAdds++;
+        numExternalNodes++;
+    }
+
+    public void remove(T object) {
+        int index = externalObjectHandler.getSpatialIndex(object);
+        if (index != UNDEFINED_INDEX) {
+            numRemoves++;
+            if (numExternalNodes > 1) {
+                // assert(nodes.get(index).externalNode == externalNode);
+                nodes[index].clear();
+                if ((index + 1) >= endNode) {
+                    while (!nodes[endNode - 1].isLeaf()) {
+                        endNode--;
+                    }
+                } else {
+                    needsRebuild = true;
+                }
+                numExternalNodes--;
+            } else {
+                clear();
+            }
+            externalObjectHandler.setSpatialIndex(object, UNDEFINED_INDEX);
+        }
+    }
+
+    private AABBTreeNode<T> findParent(int nodeIndex) {
+        int parentIndex = nodeIndex;
+        int nodeDist = 0;
+        AABBTreeNode<T> parent;
+        do {
+            parentIndex -= 1;
+            nodeDist += 1;
+            parent = nodes[parentIndex];
+        } while (parent.escapeNodeOffset <= nodeDist);
+        return parent;
+    }
+
+    public void update(T object, double[] extents) {
+
+        int index = externalObjectHandler.getSpatialIndex(object);
+        if (index != UNDEFINED_INDEX) {
+            double min0 = extents[0];
+            double min1 = extents[1];
+            double min2 = extents[2];
+            double max0 = extents[3];
+            double max1 = extents[4];
+            double max2 = extents[5];
+
+            AABBTreeNode<T> node = nodes[index];
+
+            boolean doUpdate = (needsRebuild || needsRebound || node.minX > min0 || node.minY > min1 || node.minZ > min2
+                    || node.maxX < max0 || node.maxY < max1 || node.maxZ < max2);
+
+            if (doUpdate) {
+                node.bounds(min0, min1, min2, max0, max1, max2);
+                if (!needsRebuild && endNode > 1) {
+                    numUpdates++;
+                    if (!needsRebound) {
+                        // force a rebound when things change too much
+                        if ((2 * numUpdates) > numExternalNodes) {
+                            needsRebound = true;
+                        } else {
+                            AABBTreeNode<T> parent = findParent(index);
+                            if (parent.minX > min0 || parent.minY > min1 || parent.minZ > min2 || parent.maxX < max0
+                                    || parent.maxY < max1 || parent.maxZ < max2) {
+                                needsRebound = true;
+                            }
+                        }
+                    } else {
+                        // force a rebuild when things change too much
+                        if (numUpdates > (3 * numExternalNodes)) {
+                            needsRebuild = true;
+                            numAdds = numUpdates;
+                        }
+                    }
+                    if (needsRebound) {
+                        if (startUpdate > index) {
+                            startUpdate = index;
+                        }
+                        if (endUpdate < index) {
+                            endUpdate = index;
+                        }
+                        // force a rebuild when things change too much
+                        if (2 * (endUpdate - startUpdate) > endNode) {
+                            needsRebuild = true;
+                        }
+                    }
+                }
+            }
+        } else {
+            add(object, extents);
+        }
+    }
+
+    boolean needsFinalize() {
+        return needsRebuild || needsRebound;
+    }
+
+    public boolean finalizeUpdate() {
+        boolean b = needsRebuild;
+        if (needsRebuild) {
+            rebuild();
+        } else if (needsRebound) {
+            rebound();
+        }
+        return b;
+    }
+
+    private void rebound() {
+        if (endNode > 1) {
+            int startUpdateNodeIndex = startUpdate;
+            int endUpdateNodeIndex = endUpdate;
+
+            int numNodesStack = 0;
+            int topNodeIndex = 0;
+            for (;;) {
+                AABBTreeNode<T> topNode = nodes[topNodeIndex];
+                int currentNodeIndex = topNodeIndex;
+                int currentEscapeNodeIndex = (topNodeIndex + topNode.escapeNodeOffset);
+                int nodeIndex = (topNodeIndex + 1); // First child
+                do {
+                    AABBTreeNode<T> node = nodes[nodeIndex];
+                    int escapeNodeIndex = (nodeIndex + node.escapeNodeOffset);
+                    if (nodeIndex < endUpdateNodeIndex) {
+                        if (!node.isLeaf()) {
+                            if (escapeNodeIndex > startUpdateNodeIndex) {
+                                nodesStack[numNodesStack] = topNodeIndex;
+                                numNodesStack++;
+                                topNodeIndex = nodeIndex;
+                            }
+                        }
+                    } else {
+                        break;
+                    }
+                    nodeIndex = escapeNodeIndex;
+                } while (nodeIndex < currentEscapeNodeIndex);
+
+                if (topNodeIndex == currentNodeIndex) {
+                    nodeIndex = (topNodeIndex + 1); // First child
+                    AABBTreeNode<T> node = nodes[nodeIndex];
+
+                    double minX = node.minX;
+                    double minY = node.minY;
+                    double minZ = node.minZ;
+                    double maxX = node.maxX;
+                    double maxY = node.maxY;
+                    double maxZ = node.maxZ;
+
+                    nodeIndex = (nodeIndex + node.escapeNodeOffset);
+                    while (nodeIndex < currentEscapeNodeIndex) {
+                        node = nodes[nodeIndex];
+                        if (minX > node.minX) {
+                            minX = node.minX;
+                        }
+                        if (minY > node.minY) {
+                            minY = node.minY;
+                        }
+                        if (minZ > node.minZ) {
+                            minZ = node.minZ;
+                        }
+                        if (maxX < node.maxX) {
+                            maxX = node.maxX;
+                        }
+                        if (maxY < node.maxY) {
+                            maxY = node.maxY;
+                        }
+                        if (maxZ < node.maxZ) {
+                            maxZ = node.maxZ;
+                        }
+                        nodeIndex = (nodeIndex + node.escapeNodeOffset);
+                    }
+
+                    topNode.bounds(minX, minY, minZ, maxX, maxY, maxZ);
+
+                    endUpdateNodeIndex = topNodeIndex;
+
+                    if (numNodesStack > 0) {
+                        numNodesStack--;
+                        topNodeIndex = nodesStack[numNodesStack];
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+
+        needsRebuild = false;
+        needsRebound = false;
+        numAdds = 0;
+        // numUpdates = 0;
+        startUpdate = 0x7FFFFFFF;
+        endUpdate = -0x7FFFFFFF;
+    }
+
+    @SuppressWarnings("unchecked")
+    void rebuild() {
+        if (numExternalNodes > 0) {
+            int numBuildNodes = 0;
+            AABBTreeNode<T>[] buildNodes;
+            if (numExternalNodes == endNode) {
+                buildNodes = nodes;
+                numBuildNodes = endNode;
+                nodes = new AABBTreeNode[0];
+            } else {
+                buildNodes = new AABBTreeNode[numExternalNodes];
+                int endNodeIndex = endNode;
+                for (int n = 0; n < endNodeIndex; n++) {
+                    AABBTreeNode<T> currentNode = nodes[n];
+                    if (currentNode.isLeaf()) {
+                        nodes[n] = null;
+                        buildNodes[numBuildNodes++] = currentNode;
+                    }
+                }
+            }
+
+            if (numBuildNodes > 1) {
+                if (numBuildNodes > numNodesLeaf && numAdds > 0) {
+                    if (highQuality) {
+                        HQSort.INSTANCE.sortNodes(buildNodes, numBuildNodes, numNodesLeaf);
+                    } else {
+                        LQSort.INSTANCE.sortNodes(buildNodes, numBuildNodes, numNodesLeaf);
+                    }
+                }
+                int predictedNumNodes = predictNumNodes(0, numBuildNodes, 0);
+                allocateNodes(predictedNumNodes);
+                recursiveBuild(buildNodes, 0, numBuildNodes, 0);
+                endNode = nodes[0].escapeNodeOffset;
+            } else {
+                AABBTreeNode<T> rootNode = buildNodes[0];
+                externalObjectHandler.setSpatialIndex(rootNode.externalObject, 0);
+                nodes[0] = rootNode;
+                endNode = 1;
+            }
+        }
+
+        needsRebuild = false;
+        needsRebound = false;
+        numAdds = 0;
+        numUpdates = 0;
+        numRemoves = 0;
+        startUpdate = 0x7FFFFFFF;
+        endUpdate = -0x7FFFFFFF;
+    }
+
+    void recursiveBuild(AABBTreeNode<T>[] buildNodes, int startIndex, int endIndex, int lastNodeIndex) {
+
+        int nodeIndex = lastNodeIndex;
+        lastNodeIndex++;
+
+        boolean isStatic;
+        double minX, minY, minZ, maxX, maxY, maxZ;
+
+        AABBTreeNode<T> lastNode;
+        if ((startIndex + numNodesLeaf) >= endIndex) {
+            AABBTreeNode<T> buildNode = buildNodes[startIndex];
+            minX = buildNode.minX;
+            minY = buildNode.minY;
+            minZ = buildNode.minZ;
+            maxX = buildNode.maxX;
+            maxY = buildNode.maxY;
+            maxZ = buildNode.maxZ;
+            isStatic = buildNode.isStatic;
+
+            externalObjectHandler.setSpatialIndex(buildNode.externalObject, lastNodeIndex);
+
+            nodes[lastNodeIndex] = buildNode; // replaceNode
+
+            for (int n = (startIndex + 1); n < endIndex; n += 1) {
+                buildNode = buildNodes[n];
+                if (minX > buildNode.minX) {
+                    minX = buildNode.minX;
+                }
+                if (minY > buildNode.minY) {
+                    minY = buildNode.minY;
+                }
+                if (minZ > buildNode.minZ) {
+                    minZ = buildNode.minZ;
+                }
+                if (maxX < buildNode.maxX) {
+                    maxX = buildNode.maxX;
+                }
+                if (maxY < buildNode.maxY) {
+                    maxY = buildNode.maxY;
+                }
+                if (maxZ < buildNode.maxZ) {
+                    maxZ = buildNode.maxZ;
+                }
+                isStatic = isStatic && buildNode.isStatic;
+                lastNodeIndex++;
+                externalObjectHandler.setSpatialIndex(buildNode.externalObject, lastNodeIndex);
+                nodes[lastNodeIndex] = buildNode; // replaceNode
+            }
+            minX -= fatAabbMargin;
+            minY -= fatAabbMargin;
+            minZ -= fatAabbMargin;
+            maxX += fatAabbMargin;
+            maxY += fatAabbMargin;
+            maxZ += fatAabbMargin;
+            lastNode = nodes[lastNodeIndex];
+        } else {
+            int splitPosIndex = ((startIndex + endIndex) >> 1);
+            if ((startIndex + 1) >= splitPosIndex) {
+                AABBTreeNode<T> buildNode = buildNodes[startIndex];
+                externalObjectHandler.setSpatialIndex(buildNode.externalObject, lastNodeIndex);
+                nodes[lastNodeIndex] = buildNode; // replaceNode
+            } else {
+                recursiveBuild(buildNodes, startIndex, splitPosIndex, lastNodeIndex);
+            }
+            lastNode = nodes[lastNodeIndex];
+            minX = lastNode.minX;
+            minY = lastNode.minY;
+            minZ = lastNode.minZ;
+            maxX = lastNode.maxX;
+            maxY = lastNode.maxY;
+            maxZ = lastNode.maxZ;
+            isStatic = lastNode.isStatic;
+
+            lastNodeIndex = (lastNodeIndex + lastNode.escapeNodeOffset);
+
+            if ((splitPosIndex + 1) >= endIndex) {
+                AABBTreeNode<T> buildNode = buildNodes[splitPosIndex];
+                externalObjectHandler.setSpatialIndex(buildNode.externalObject, lastNodeIndex);
+                nodes[lastNodeIndex] = buildNode; // replaceNode
+            } else {
+                recursiveBuild(buildNodes, splitPosIndex, endIndex, lastNodeIndex);
+            }
+
+            lastNode = nodes[lastNodeIndex];
+            if (minX > lastNode.minX) {
+                minX = lastNode.minX;
+            }
+            if (minY > lastNode.minY) {
+                minY = lastNode.minY;
+            }
+            if (minZ > lastNode.minZ) {
+                minZ = lastNode.minZ;
+            }
+            if (maxX < lastNode.maxX) {
+                maxX = lastNode.maxX;
+            }
+            if (maxY < lastNode.maxY) {
+                maxY = lastNode.maxY;
+            }
+            if (maxZ < lastNode.maxZ) {
+                maxZ = lastNode.maxZ;
+            }
+            isStatic = isStatic && lastNode.isStatic;
+        }
+        if (nodes[nodeIndex] == null) {
+            nodes[nodeIndex] = allocateNode(minX, minY, minZ, maxX, maxY, maxZ,
+                    (lastNodeIndex + lastNode.escapeNodeOffset - nodeIndex), null, isStatic);
+        } else {
+            nodes[nodeIndex].reset(minX, minY, minZ, maxX, maxY, maxZ,
+                    (lastNodeIndex + lastNode.escapeNodeOffset - nodeIndex), null, isStatic);
+        }
+    }
+
+    private int predictNumNodes(int startIndex, int endIndex, int lastNodeIndex) {
+        lastNodeIndex++;
+        if ((startIndex + numNodesLeaf) >= endIndex) {
+            lastNodeIndex += (endIndex - startIndex);
+        } else {
+            int splitPosIndex = ((startIndex + endIndex) >> 1);
+            if ((startIndex + 1) >= splitPosIndex) {
+                lastNodeIndex++;
+            } else {
+                lastNodeIndex = predictNumNodes(startIndex, splitPosIndex, lastNodeIndex);
+            }
+            if ((splitPosIndex + 1) >= endIndex) {
+                lastNodeIndex++;
+            } else {
+                lastNodeIndex = predictNumNodes(splitPosIndex, endIndex, lastNodeIndex);
+            }
+        }
+        return lastNodeIndex;
+    }
+
+    @SuppressWarnings("unchecked")
+    void clear() {
+        nodes = new AABBTreeNode[0];
+        needsRebuild = false;
+        needsRebound = false;
+        numAdds = 0;
+        numUpdates = 0;
+        numExternalNodes = 0;
+        endNode = 0;
+        startUpdate = 0x7FFFFFFF;
+        endUpdate = -0x7FFFFFFF;
+    }
+
+    public void getOverlappingPairs(AABBTreePairCallback<T> callback) {
+        if (numExternalNodes > 1) {
+            for (int currentNodeIndex = 0; currentNodeIndex < endNode; currentNodeIndex++) {
+                while (!nodes[currentNodeIndex].isLeaf()) {
+                    currentNodeIndex++;
+                }
+                AABBTreeNode<T> currentNode = nodes[currentNodeIndex];
+                if (!externalObjectHandler.isEnabled(currentNode.externalObject)) {
+                    continue;
+                }
+                double minX = currentNode.minX;
+                double minY = currentNode.minY;
+                double minZ = currentNode.minZ;
+                double maxX = currentNode.maxX;
+                double maxY = currentNode.maxY;
+                double maxZ = currentNode.maxZ;
+
+                for (int nodeIndex = currentNodeIndex + 1; nodeIndex < endNode;) {
+                    AABBTreeNode<T> node = nodes[nodeIndex];
+                    if ((!currentNode.isStatic || !node.isStatic) && minX <= node.maxX && minY <= node.maxY
+                            && minZ <= node.maxZ && maxX >= node.minX && maxY >= node.minY && maxZ >= node.minZ) {
+                        nodeIndex++;
+                        if (node.isLeaf()) {
+                            if (externalObjectHandler.isEnabled(node.externalObject)) {
+                                callback.overlap(currentNode.externalObject, node.externalObject);
+                            }
+                        }
+                    } else {
+                        nodeIndex += node.escapeNodeOffset;
+                    }
+                }
+            }
+        }
+    }
+
+    public void getOverlappingNodes(double[] queryExtents, AABBTreeNodeCallback<T> callback) {
+        if (numExternalNodes > 0) {
+            double queryMinX = queryExtents[0];
+            double queryMinY = queryExtents[1];
+            double queryMinZ = queryExtents[2];
+            double queryMaxX = queryExtents[3];
+            double queryMaxY = queryExtents[4];
+            double queryMaxZ = queryExtents[5];
+            int endNodeIndex = endNode;
+            int nodeIndex = 0;
+            for (;;) {
+                AABBTreeNode<T> node = nodes[nodeIndex];
+                double minX = node.minX;
+                double minY = node.minY;
+                double minZ = node.minZ;
+                double maxX = node.maxX;
+                double maxY = node.maxY;
+                double maxZ = node.maxZ;
+                if (queryMinX <= maxX && queryMinY <= maxY && queryMinZ <= maxZ && queryMaxX >= minX
+                        && queryMaxY >= minY && queryMaxZ >= minZ) {
+                    if (node.isLeaf()) {
+                        if (externalObjectHandler.isEnabled(node.externalObject)) {
+                            callback.overlap(node.externalObject);
+                        }
+                        nodeIndex++;
+                        if (nodeIndex >= endNodeIndex) {
+                            break;
+                        }
+                    } else {
+                        if (queryMaxX >= maxX && queryMaxY >= maxY && queryMaxZ >= maxZ && queryMinX <= minX
+                                && queryMinY <= minY && queryMinZ <= minZ) {
+                            int endChildren = (nodeIndex + node.escapeNodeOffset);
+                            nodeIndex++;
+                            do {
+                                node = nodes[nodeIndex];
+                                if (node.isLeaf() && externalObjectHandler.isEnabled(node.externalObject)) {
+                                    callback.overlap(node.externalObject);
+                                }
+                                nodeIndex++;
+                            } while (nodeIndex < endChildren);
+                            if (nodeIndex >= endNodeIndex) {
+                                break;
+                            }
+                        } else {
+                            nodeIndex++;
+                        }
+                    }
+                } else {
+                    nodeIndex += node.escapeNodeOffset;
+                    if (nodeIndex >= endNodeIndex) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTreeNode.java
+++ b/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTreeNode.java
@@ -1,0 +1,67 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine 4J                                               *
+ * Copyright (C) 2017 Piotr Piastucki, Tilmann Zaeschke                  *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.aabbtree;
+
+public class AABBTreeNode<T> {
+
+	int escapeNodeOffset;
+	T externalObject;
+	boolean isStatic;
+	double minX, minY, minZ, maxX, maxY, maxZ;
+
+	AABBTreeNode(double minX, double minY, double minZ, double maxX, double maxY, double maxZ, int escapeNodeOffset,
+			T externalNode, boolean isStatic) {
+	    reset(minX, minY, minZ, maxX, maxY, maxZ, escapeNodeOffset, externalNode, isStatic);
+	}
+
+	void reset(double minX, double minY, double minZ, double maxX, double maxY, double maxZ, int escapeNodeOffset,
+			T externalNode, boolean isStatic) {
+		this.escapeNodeOffset = escapeNodeOffset;
+		this.externalObject = externalNode;
+        this.isStatic = isStatic;
+        bounds(minX, minY, minZ, maxX, maxY, maxZ);
+	}
+
+    void bounds(double minX, double minY, double minZ, double maxX, double maxY, double maxZ) {
+        this.minX = minX;
+        this.minY = minY;
+        this.minZ = minZ;
+        this.maxX = maxX;
+        this.maxY = maxY;
+        this.maxZ = maxZ;
+    }
+
+	boolean isLeaf() {
+        return this.externalObject != null;
+    }
+
+	void clear() {
+		escapeNodeOffset = 1;
+		externalObject = null;
+		isStatic = false;
+		minX = minY = minZ = Double.MAX_VALUE;
+		maxX = maxY = maxZ =-Double.MAX_VALUE; 
+	}
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTreeNodeCallback.java
+++ b/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTreeNodeCallback.java
@@ -1,0 +1,30 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine 4J                                               *
+ * Copyright (C) 2017 Piotr Piastucki, Tilmann Zaeschke                  *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.aabbtree;
+
+public interface AABBTreeNodeCallback<T> {
+
+	void overlap(T o);
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTreePairCallback.java
+++ b/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTreePairCallback.java
@@ -1,0 +1,29 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine 4J                                               *
+ * Copyright (C) 2017 Piotr Piastucki, Tilmann Zaeschke                  *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.aabbtree;
+
+public interface AABBTreePairCallback<T> {
+
+	void overlap(T o1, T o2);
+}

--- a/core/src/main/java/org/ode4j/ode/internal/aabbtree/ExternalObjectHandler.java
+++ b/core/src/main/java/org/ode4j/ode/internal/aabbtree/ExternalObjectHandler.java
@@ -1,0 +1,35 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine 4J                                               *
+ * Copyright (C) 2017 Piotr Piastucki, Tilmann Zaeschke                  *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.aabbtree;
+
+public interface ExternalObjectHandler<T> {
+
+	void setSpatialIndex(T object, int index);
+
+	int getSpatialIndex(T object);
+
+	boolean isEnabled(T object);
+
+	boolean isStatic(T object);
+}

--- a/core/src/main/java/org/ode4j/ode/internal/aabbtree/HQSort.java
+++ b/core/src/main/java/org/ode4j/ode/internal/aabbtree/HQSort.java
@@ -1,0 +1,103 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine 4J                                               *
+ * Copyright (C) 2017 Piotr Piastucki, Tilmann Zaeschke                  *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.aabbtree;
+
+/*
+ * Based on https://github.com/turbulenz/turbulenz_engine/blob/master/tslib/aabbtree.ts
+ */
+public class HQSort extends Sort {
+
+	final static HQSort INSTANCE = new HQSort();
+	
+	void sortNodes(AABBTreeNode<?>[] nodes, int numNodes, int numNodesLeaf) {
+		sortNodesRecursive(nodes, 0, numNodes, false, numNodesLeaf);
+	}
+
+	void sortNodesRecursive(AABBTreeNode<?>[] nodes, int startIndex, int endIndex, boolean reverse,
+			int numNodesLeaf) {
+		int splitNodeIndex = ((startIndex + endIndex) >> 1);
+
+		nthElement(nodes, startIndex, splitNodeIndex, endIndex, 0, false);
+		double sahX = (calculateSAH(nodes, startIndex, splitNodeIndex) + calculateSAH(nodes, splitNodeIndex, endIndex));
+
+		nthElement(nodes, startIndex, splitNodeIndex, endIndex, 1, false);
+		double sahY = (calculateSAH(nodes, startIndex, splitNodeIndex) + calculateSAH(nodes, splitNodeIndex, endIndex));
+
+		nthElement(nodes, startIndex, splitNodeIndex, endIndex, 2, false);
+		double sahZ = (calculateSAH(nodes, startIndex, splitNodeIndex) + calculateSAH(nodes, splitNodeIndex, endIndex));
+
+		nthElement(nodes, startIndex, splitNodeIndex, endIndex, 3, false);
+		double sahXZ = (calculateSAH(nodes, startIndex, splitNodeIndex)
+				+ calculateSAH(nodes, splitNodeIndex, endIndex));
+
+		nthElement(nodes, startIndex, splitNodeIndex, endIndex, 4, false);
+		double sahZX = (calculateSAH(nodes, startIndex, splitNodeIndex)
+				+ calculateSAH(nodes, splitNodeIndex, endIndex));
+
+		int axis;
+		if (sahX <= sahY && sahX <= sahZ && sahX <= sahXZ && sahX <= sahZX) {
+			axis = 0;
+		} else if (sahZ <= sahY && sahZ <= sahXZ && sahZ <= sahZX) {
+			axis = 2;
+		} else if (sahY <= sahXZ && sahY <= sahZX) {
+			axis = 1;
+		} else if (sahXZ <= sahZX) {
+			axis = 3;
+		} else {
+			axis = 4;
+		}
+
+		nthElement(nodes, startIndex, splitNodeIndex, endIndex, axis, reverse);
+		reverse = !reverse;
+		if ((startIndex + numNodesLeaf) < splitNodeIndex) {
+			sortNodesRecursive(nodes, startIndex, splitNodeIndex, reverse, numNodesLeaf);
+		}
+		if ((splitNodeIndex + numNodesLeaf) < endIndex) {
+			sortNodesRecursive(nodes, splitNodeIndex, endIndex, reverse, numNodesLeaf);
+		}
+	}
+
+	protected double getkey(AABBTreeNode<?> node, int axis, boolean reverse) {
+		double v;
+		switch (axis) {
+		case 0:
+            v = node.minX + node.maxX;
+		    break;
+		case 1:
+            v = node.minY + node.maxY;
+            break;
+        case 2:
+            v = node.minZ + node.maxZ;
+            break;
+        case 3:
+            v = node.minX + node.maxX + node.minZ + node.maxZ;
+            break;
+        default:
+            v = node.minX - node.maxX + node.minZ - node.maxZ;
+            break;
+		}
+		return reverse ? -v : v;
+	}
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/aabbtree/LQSort.java
+++ b/core/src/main/java/org/ode4j/ode/internal/aabbtree/LQSort.java
@@ -1,0 +1,71 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine 4J                                               *
+ * Copyright (C) 2017 Piotr Piastucki, Tilmann Zaeschke                  *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.aabbtree;
+
+/*
+ * Based on https://github.com/turbulenz/turbulenz_engine/blob/master/tslib/aabbtree.ts
+ */
+public class LQSort extends Sort {
+
+	final static LQSort INSTANCE = new LQSort();
+
+	void sortNodes(AABBTreeNode<?>[] nodes, int numNodes, int numNodesLeaf) {
+		sortNodesRecursive(nodes, 0, numNodes, 0, false, numNodesLeaf);
+	}
+
+	void sortNodesRecursive(AABBTreeNode<?>[] nodes, int startIndex, int endIndex, int axis, boolean reverse,
+			int numNodesLeaf) {
+		int splitNodeIndex = ((startIndex + endIndex) >> 1);
+		nthElement(nodes, startIndex, splitNodeIndex, endIndex, axis, reverse);
+		axis = (axis + 2) % 3;
+		reverse = !reverse;
+		if ((startIndex + numNodesLeaf) < splitNodeIndex) {
+			sortNodesRecursive(nodes, startIndex, splitNodeIndex, axis, reverse, numNodesLeaf);
+		}
+		if ((splitNodeIndex + numNodesLeaf) < endIndex) {
+			sortNodesRecursive(nodes, splitNodeIndex, endIndex, axis, reverse, numNodesLeaf);
+		}
+	}
+
+	/**
+	 * @param axis
+	 *            0 = X, 1 = Y, 2 = Z
+	 */
+    protected double getkey(AABBTreeNode<?> node, int axis, boolean reverse) {
+        double v;
+        switch (axis) {
+        case 0:
+            v = node.minX + node.maxX;
+            break;
+        case 1:
+            v = node.minY + node.maxY;
+            break;
+        default:
+            v = node.minZ + node.maxZ;
+            break;
+        }
+        return reverse ? -v : v;
+    }
+
+}

--- a/core/src/main/java/org/ode4j/ode/internal/aabbtree/Sort.java
+++ b/core/src/main/java/org/ode4j/ode/internal/aabbtree/Sort.java
@@ -1,0 +1,143 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine 4J                                               *
+ * Copyright (C) 2017 Piotr Piastucki, Tilmann Zaeschke                  *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.ode.internal.aabbtree;
+
+/*
+ * Based on https://github.com/turbulenz/turbulenz_engine/blob/master/tslib/aabbtree.ts
+ */
+public abstract class Sort {
+
+	protected void nthElement(AABBTreeNode<?>[] nodes, int first, int nth, int last, int axis, boolean reverse) {
+		while ((last - first) > 3) {
+			double midValue = medianFn(getkey(nodes[first], axis, reverse),
+					getkey(nodes[first + ((last - first) >> 1)], axis, reverse),
+					getkey(nodes[last - 1], axis, reverse));
+
+			int firstPos = first;
+			int lastPos = last;
+			for (;;) {
+				while (getkey(nodes[firstPos], axis, reverse) < midValue) {
+					firstPos++;
+				}
+				do {
+					lastPos--;
+				} while (midValue < getkey(nodes[lastPos], axis, reverse));
+
+				if (firstPos >= lastPos) {
+					break;
+				}
+				AABBTreeNode<?> temp = nodes[firstPos];
+				nodes[firstPos] = nodes[lastPos];
+				nodes[lastPos] = temp;
+				firstPos++;
+			}
+			if (firstPos <= nth) {
+				first = firstPos;
+			} else {
+				last = firstPos;
+			}
+		}
+		insertionSort(nodes, first, last, axis, reverse);
+	}
+
+	void insertionSort(AABBTreeNode<?>[] nodes, int first, int last, int axis, boolean reverse) {
+		int sorted = first + 1;
+		while (sorted != last) {
+			AABBTreeNode<?> tempNode = nodes[sorted];
+			double tempKey = getkey(tempNode, axis, reverse);
+
+			int next = sorted;
+			int current = sorted - 1;
+
+			while (next != first && tempKey < getkey(nodes[current], axis, reverse)) {
+				nodes[next] = nodes[current];
+				next--;
+				current--;
+			}
+
+			if (next != sorted) {
+				nodes[next] = tempNode;
+			}
+
+			sorted++;
+		}
+	}
+
+	protected abstract double getkey(AABBTreeNode<?> tempNode, int axis, boolean reverse);
+
+	static double medianFn(double a, double b, double c) {
+		if (a < b) {
+			if (b < c) {
+				return b;
+			} else if (a < c) {
+				return c;
+			} else {
+				return a;
+			}
+		} else if (a < c) {
+			return a;
+		} else if (b < c) {
+			return c;
+		}
+		return b;
+	}
+
+	static double calculateSAH(AABBTreeNode<?>[] buildNodes, int startIndex, int endIndex) {
+		AABBTreeNode<?> buildNode = buildNodes[startIndex];
+        double minX = buildNode.minX;
+        double minY = buildNode.minY;
+        double minZ = buildNode.minZ;
+        double maxX = buildNode.maxX;
+        double maxY = buildNode.maxY;
+        double maxZ = buildNode.maxZ;
+
+		for (int n = startIndex + 1; n < endIndex; n++) {
+			buildNode = buildNodes[n];
+			if (minX > buildNode.minX) {
+				minX = buildNode.minX;
+			}
+			if (minY > buildNode.minY) {
+				minY = buildNode.minY;
+			}
+			if (minZ > buildNode.minZ) {
+				minZ = buildNode.minZ;
+			}
+			if (maxX < buildNode.maxX) {
+				maxX = buildNode.maxX;
+			}
+			if (maxY < buildNode.maxY) {
+				maxY = buildNode.maxY;
+			}
+			if (maxZ < buildNode.maxZ) {
+				maxZ = buildNode.maxZ;
+			}
+		}
+		double x = maxX - minX;
+		double y = maxY - minY;
+		double z = maxZ - minZ;
+		// return x * y * z;
+		return x * y + x * z + y * z;
+	}
+
+}


### PR DESCRIPTION
This PR adds a new space based on a dynamic AABB tree.
Even though the existing DxSAPSpace2 works quite well for small and medium-sized worlds (up to roughly 1500-2000 geoms), it does not scale well when the worlds grow beyond that. The attached graphs were created based on the output of SpacePerformanceTest and clearly show the issue.
On the other hand, BVH space seems to address the scalability issue much better. 
I tried to keep the implementation as simple as possible. I have found a neat dynamic stackless AABB tree implementation in Turbulenz Engine (https://github.com/turbulenz/turbulenz_engine/blob/master/tslib/aabbtree.ts) which is licensed under the MIT license and I ported it to Java. 
The implementation tends to rebuild the tree quite often, but the rebuild process is relatively fast and the data structures quite efficient. There are also a few minor improvements introduced by me compared to the original implementation in Typescript. 
![bvh_full_rebuild](https://user-images.githubusercontent.com/9357697/33902174-7b9b5b50-df74-11e7-94c4-59174bad7217.png)

![no_bvh_rebuild](https://user-images.githubusercontent.com/9357697/33902033-fe708a38-df73-11e7-80c4-fde978a6f7af.png)
