### PR TITLE
Fix AABBTree::rebuild() crashing when the tree contains a single geom

### DIFF
--- a/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTree.java
+++ b/core/src/main/java/org/ode4j/ode/internal/aabbtree/AABBTree.java
@@ -290,7 +290,7 @@ public class AABBTree<T> {
             if (numExternalNodes == endNode) {
                 buildNodes = nodes;
                 numBuildNodes = endNode;
-                nodes = new AABBTreeNode[0];
+                nodes = new AABBTreeNode[FREE_NODES_POOL_SIZE];
             } else {
                 buildNodes = new AABBTreeNode[numExternalNodes];
                 int endNodeIndex = endNode;


### PR DESCRIPTION
The new array should be allocated with a proper length rather than 0 as it leads to ArrayIndexOutOfBoundsException when the tree contains just 1 geom.