### PR TITLE
Modularize modernize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+
+jdk:
+  - oraclejdk9
+
+install: true
+
+script:
+  - mvn --errors clean package
+

--- a/core-cpp/pom.xml
+++ b/core-cpp/pom.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -24,12 +27,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/core-cpp/pom.xml
+++ b/core-cpp/pom.xml
@@ -4,8 +4,20 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>9</source>
+					<target>9</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
-    <parent>
+	<parent>
         <groupId>org.ode4j</groupId>
         <artifactId>parent</artifactId>
         <version>0.4.0-SNAPSHOT</version>

--- a/core-cpp/src/main/java/module-info.java
+++ b/core-cpp/src/main/java/module-info.java
@@ -1,0 +1,28 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file LICENSE-BSD.TXT.                                       *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT and LICENSE-BSD.TXT for more details.                     *
+ *                                                                       *
+ *************************************************************************/
+
+module ord.ode4j.cpp {
+    requires org.ode4j;
+
+    exports org.ode4j.cpp.internal;
+    exports org.ode4j.cpp;
+}

--- a/core-cpp/src/main/java/module-info.java
+++ b/core-cpp/src/main/java/module-info.java
@@ -20,7 +20,8 @@
  *                                                                       *
  *************************************************************************/
 
-module org.ode4j.cpp {
+module org.ode4j.cpp
+{
     requires transitive org.ode4j;
 
     exports org.ode4j.cpp.internal;

--- a/core-cpp/src/main/java/module-info.java
+++ b/core-cpp/src/main/java/module-info.java
@@ -20,7 +20,7 @@
  *                                                                       *
  *************************************************************************/
 
-module ord.ode4j.cpp {
+module org.ode4j.cpp {
     requires transitive org.ode4j;
 
     exports org.ode4j.cpp.internal;

--- a/core-cpp/src/main/java/module-info.java
+++ b/core-cpp/src/main/java/module-info.java
@@ -21,7 +21,7 @@
  *************************************************************************/
 
 module ord.ode4j.cpp {
-    requires org.ode4j;
+    requires transitive org.ode4j;
 
     exports org.ode4j.cpp.internal;
     exports org.ode4j.cpp;

--- a/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppCollisionTrimesh.java
+++ b/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppCollisionTrimesh.java
@@ -68,7 +68,8 @@ public class ApiCppCollisionTrimesh extends ApiCppTimer {
 
 
 	/** @deprecated TZ: find a better name. */
-	enum TRIMESH1 { TRIMESH_FACE_NORMALS };
+    @Deprecated
+    enum TRIMESH1 { TRIMESH_FACE_NORMALS };
 	//ODE_API 
 	void dGeomTriMeshDataSet(DTriMeshData g, int data_id, Object in_data) {
 		throw new UnsupportedOperationException();

--- a/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppMathRotation.java
+++ b/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppMathRotation.java
@@ -99,7 +99,8 @@ public abstract class ApiCppMathRotation extends ApiCppMathMisc {
 		OdeMath.dRfromQ(R, q);
 	}
 	/** @deprecated */
-	public static void dQtoR (final DQuaternion q, DMatrix3 R) {
+	@Deprecated
+    public static void dQtoR (final DQuaternion q, DMatrix3 R) {
 		OdeMath.dRfromQ(R, q);
 	}
 	//ODE_API 

--- a/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppOdeInit.java
+++ b/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppOdeInit.java
@@ -86,7 +86,8 @@ public abstract class ApiCppOdeInit extends ApiCppExportDIF {
 	 * @deprecated Please use dInitOde2() instead.
 	 */
 	//ODE_API 
-	public static void dInitODE() {
+	@Deprecated
+    public static void dInitODE() {
 		OdeHelper.initODE();
 	}
 
@@ -170,7 +171,8 @@ public abstract class ApiCppOdeInit extends ApiCppExportDIF {
 //	 * @see #dCleanupODEAllDataForThread
 	//ODE_API 
 	//	int dAllocateODEDataForThread(unsigned int uiAllocateFlags) {
-	public static int dAllocateODEDataForThread(int uiAllocateFlags) {
+	@Deprecated
+    public static int dAllocateODEDataForThread(int uiAllocateFlags) {
 		return OdeHelper.allocateODEDataForThread(uiAllocateFlags);
 	}
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,30 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <parent>
-        <groupId>org.ode4j</groupId>
-        <artifactId>parent</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
-    </parent>
+	<modelVersion>4.0.0</modelVersion>
 
-    <artifactId>core</artifactId>
-    <packaging>jar</packaging>
+	<parent>
+		<groupId>org.ode4j</groupId>
+		<artifactId>parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
 
-    <dependencies>
+	<artifactId>core</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.12</version>
-		</dependency>   
+		</dependency>
 	</dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,6 +4,18 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>9</source>
+					<target>9</target>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<parent>
 		<groupId>org.ode4j</groupId>

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -1,0 +1,45 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ * Open Dynamics Engine 4J, Copyright (C) 2009-2014 Tilmann Zaeschke     *
+ * All rights reserved.  Email: ode4j@gmx.de   Web: www.ode4j.org        *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT.         *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT, ODE-LICENSE-BSD.TXT and ODE4J-LICENSE-BSD.TXT for more   *
+ * details.                                                              *
+ *                                                                       *
+ *************************************************************************/
+
+module org.ode4j
+{
+    requires org.slf4j;
+
+    exports org.ode4j.math;
+    exports org.ode4j.ode.internal.aabbtree;
+    exports org.ode4j.ode.internal.cpp4j.java;
+    exports org.ode4j.ode.internal.cpp4j;
+    exports org.ode4j.ode.internal.gimpact;
+    exports org.ode4j.ode.internal.joints;
+    exports org.ode4j.ode.internal.libccd;
+    exports org.ode4j.ode.internal.processmem;
+    exports org.ode4j.ode.internal.ragdoll;
+    exports org.ode4j.ode.internal.stuff;
+    exports org.ode4j.ode.internal;
+    exports org.ode4j.ode.ragdoll;
+    exports org.ode4j.ode.threading.task;
+    exports org.ode4j.ode.threading;
+    exports org.ode4j.ode;
+}

--- a/core/src/main/java/org/ode4j/math/DMatrix3.java
+++ b/core/src/main/java/org/ode4j/math/DMatrix3.java
@@ -37,9 +37,10 @@ public final class DMatrix3 implements DMatrix3C {
 	public static final DMatrix3C ZERO = new DMatrix3();
 
 	/** @deprecated */
-	public DMatrix3(double d, double e, double f,
-			double g, double h, double i, double j, double k, double l,
-			double m, double n, double o) {
+	@Deprecated
+    public DMatrix3(double d, double e, double f,
+                    double g, double h, double i, double j, double k, double l,
+                    double m, double n, double o) {
 		this();
 		v[0] = d; v[1] = e; v[2] = f; v[3] = g;
 		v[4] = h; v[5] = i; v[6] = j; v[7] = k;

--- a/core/src/main/java/org/ode4j/math/DMatrixN.java
+++ b/core/src/main/java/org/ode4j/math/DMatrixN.java
@@ -373,7 +373,8 @@ public class DMatrixN {
 	 * @param n
 	 * @param msg
 	 */
-	private void dDebug(int n, String msg) {
+	@Deprecated
+    private void dDebug(int n, String msg) {
 		throw new IllegalStateException(msg);
 	}
 }

--- a/core/src/main/java/org/ode4j/ode/DBody.java
+++ b/core/src/main/java/org/ode4j/ode/DBody.java
@@ -715,7 +715,8 @@ public interface DBody {
 	 * @return the first geom attached to this body, or 0.
 	 * @deprecated May be replaced by a more Java-like API.
 	 */
-	DGeom getFirstGeom ();
+    @Deprecated
+    DGeom getFirstGeom ();
 
 
 	/**
@@ -725,7 +726,8 @@ public interface DBody {
 	 * @see DBody#getFirstGeom()
 	 * @deprecated May be replaced by a more Java-like API.
 	 */
-	DGeom getNextGeom (DGeom geom);
+    @Deprecated
+    DGeom getNextGeom (DGeom geom);
 
 
 }

--- a/core/src/main/java/org/ode4j/ode/OdeConstants.java
+++ b/core/src/main/java/org/ode4j/ode/OdeConstants.java
@@ -77,5 +77,6 @@ public class OdeConstants {
 	 * or will be defined in the future.
 	 * @deprecated TZ: probably not required. 
 	 */
-	public static final int dAllocateMaskAll = 0xFFFFFFFF; //~0U,
+	@Deprecated
+    public static final int dAllocateMaskAll = 0xFFFFFFFF; //~0U,
 }

--- a/core/src/main/java/org/ode4j/ode/OdeHelper.java
+++ b/core/src/main/java/org/ode4j/ode/OdeHelper.java
@@ -875,7 +875,8 @@ public abstract class OdeHelper {
 	 * @param string
 	 * @deprecated TZ: Currently not implemented.
 	 */
-	public static void worldExportDIF(DWorld world, File f, String string) {
+	@Deprecated
+    public static void worldExportDIF(DWorld world, File f, String string) {
 		throw new UnsupportedOperationException(); //TODO
 	}
 
@@ -903,7 +904,8 @@ public abstract class OdeHelper {
 	 */
 //	 * @see #dAllocateODEDataFlags
 //	 * @see #dCleanupODEAllDataForThread
-	public static int allocateODEDataForThread(int uiAllocateFlags) {
+	@Deprecated
+    public static int allocateODEDataForThread(int uiAllocateFlags) {
 		return OdeInit.dAllocateODEDataForThread(uiAllocateFlags) ? 1 : 0;
 	}
 

--- a/core/src/main/java/org/ode4j/ode/OdeMath.java
+++ b/core/src/main/java/org/ode4j/ode/OdeMath.java
@@ -467,6 +467,7 @@ public class OdeMath extends DRotation {
 	/**
 	 * @deprecated Use dCalcVetorCross3, dAddVectorCross3 or  dSubtractVectorCross3.
 	 */
+    @Deprecated
     public static void dCROSS(DVector3 a, OP op, DVector3C b, DVector3C c) {
         if (op == OP.EQ) {
             dCalcVectorCross3(a, b, c);
@@ -664,7 +665,8 @@ public class OdeMath extends DRotation {
      * For +1/-1 use dSetCrossMatrixPlus(), for -1/+1 use dSetCrossMatrixMinus().
      * @deprecated
      */
-	public static void dCROSSMAT(DMatrix3 A, DVector3C a, int skip, int plus, int minus) {
+	@Deprecated
+    public static void dCROSSMAT(DMatrix3 A, DVector3C a, int skip, int plus, int minus) {
 		A.set01( minus * a.get2() ); 
 		A.set02( plus  * a.get1() ); 
 		A.set10( plus  * a.get2() ); 

--- a/core/src/main/java/org/ode4j/ode/internal/Common.java
+++ b/core/src/main/java/org/ode4j/ode/internal/Common.java
@@ -106,7 +106,8 @@ public class Common extends OdeConstants {
 //From config-defaults.h
 	//TODO ???
 	/** @deprecated TZ this can be removed? */
-	public static final boolean  dATOMICS_ENABLED = false;
+	@Deprecated
+    public static final boolean  dATOMICS_ENABLED = false;
 	public static final boolean  dTRIMESH_16BIT_INDICES = false;
 
 	public static final boolean  dTRIMESH_OPCODE_USE_OLD_TRIMESH_TRIMESH_COLLIDER = false;

--- a/core/src/main/java/org/ode4j/ode/internal/DxBody.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxBody.java
@@ -1518,14 +1518,16 @@ public class DxBody extends DObject implements DBody, Cloneable {
 	}
 
 	/** @deprecated */
-	@Override
+	@Deprecated
+    @Override
 	public DGeom getFirstGeom() {
 		return dBodyGetFirstGeom();
 	}
 
 
 	/** @deprecated */
-	@Override
+	@Deprecated
+    @Override
 	public DGeom getNextGeom(DGeom geom) {
 		return dBodyGetNextGeom((DxGeom) geom);
 	}

--- a/core/src/main/java/org/ode4j/ode/internal/DxCollisionUtil.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxCollisionUtil.java
@@ -261,7 +261,8 @@ public class DxCollisionUtil {
 
 	//inline void dMatrix3Copy(final double* source,dMatrix3& dest)
 	/** @deprecated TZ Use dVector instead */
-	static void dMatrix3Copy(final DMatrix3C source,DMatrix3 dest)
+	@Deprecated
+    static void dMatrix3Copy(final DMatrix3C source, DMatrix3 dest)
 	{
 		//		dest.v[0]	=	source[0];
 		//		dest.v[1]	=	source[1];

--- a/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxGeom.java
@@ -1410,7 +1410,8 @@ public abstract class DxGeom extends DBase implements DGeom {
 	 * Frees memory ?
 	 * @deprecated
 	 */
-	private void dFreePosr(DxPosR oldPosR) {
+	@Deprecated
+    private void dFreePosr(DxPosR oldPosR) {
 		//TODO see collision_kernel.h:73
 		//#if dATOMICS_ENABLED
 		//		if (!AtomicCompareExchangePointer(&s_cachedPosR, NULL, (atomicptr)oldPosR))

--- a/core/src/main/java/org/ode4j/ode/internal/DxSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxSpace.java
@@ -417,6 +417,7 @@ public abstract class DxSpace extends DxGeom implements DSpace {
 	// the dirty geoms are numbered 0..k, the clean geoms are numbered k+1..count-1
 
 	/** @deprecated 2016-01-17 */
+	@Deprecated
 	@Override
 	public DGeom getGeom (int i)
 	{

--- a/core/src/main/java/org/ode4j/ode/internal/DxWorld.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxWorld.java
@@ -1149,7 +1149,8 @@ public class DxWorld extends DBase implements DWorld {
 //	* @see DWorld#setStepMemoryManager(DWorldStepMemoryFunctionsInfo)
 	* @deprecated Do not use ! (TZ)
 	*/
-	public static class DWorldStepMemoryFunctionsInfo 
+	@Deprecated
+    public static class DWorldStepMemoryFunctionsInfo
 	{
 	    public int struct_size;
 	    //TODO, already in DxUtil (TZ) -> Should not be public in Java.

--- a/core/src/main/java/org/ode4j/ode/internal/FastDot.java
+++ b/core/src/main/java/org/ode4j/ode/internal/FastDot.java
@@ -44,7 +44,8 @@ public class FastDot extends Misc {
 	 * @return xxx
 	 * @deprecated use other method
 	 */
-	public static double dDot (final double[] a, int aOfs, final double[] b, int n)
+	@Deprecated
+    public static double dDot (final double[] a, int aOfs, final double[] b, int n)
 	{  
 		double p0,q0,m0,p1,q1,m1,sum;
 		int aPos = aOfs, bPos = 0;

--- a/core/src/main/java/org/ode4j/ode/internal/Rotation.java
+++ b/core/src/main/java/org/ode4j/ode/internal/Rotation.java
@@ -41,7 +41,8 @@ import org.ode4j.ode.OdeMath;
 public class Rotation extends Matrix {
 
 	/** @deprecated Use DMatrix.setIdentity() instead. */
-	public static void dRSetIdentity (DMatrix3 R)
+	@Deprecated
+    public static void dRSetIdentity (DMatrix3 R)
 	{
 		//dAASSERT (R); 
 		//SET_3x3_IDENTITY;
@@ -98,8 +99,9 @@ public class Rotation extends Matrix {
 	}
 	
 	/** @deprecated (TZ) */
-	public static void dRFrom2Axes (DMatrix3 R, double ax, double ay, double az,
-			double bx, double by, double bz)
+	@Deprecated
+    public static void dRFrom2Axes (DMatrix3 R, double ax, double ay, double az,
+                                    double bx, double by, double bz)
 	{
 		double l,k;
 		//dAASSERT (R);
@@ -185,7 +187,8 @@ public class Rotation extends Matrix {
 	}
 
 	/** @deprecated */
-	public static void dQSetIdentity (DQuaternion q)
+	@Deprecated
+    public static void dQSetIdentity (DQuaternion q)
 	{
 		//dAASSERT (q);
 		q.setIdentity();
@@ -309,7 +312,8 @@ public class Rotation extends Matrix {
 	 * @param q
 	 * @param R
 	 */
-	public static void dQtoR(final DQuaternionC q, DMatrix3 R) {
+	@Deprecated
+    public static void dQtoR(final DQuaternionC q, DMatrix3 R) {
 		dRfromQ(R, q);
 	}
 
@@ -318,7 +322,8 @@ public class Rotation extends Matrix {
 	 * @param q
 	 * @param R
 	 */
-	public static void dRtoQ(final DMatrix3C R, DQuaternion q) {
+	@Deprecated
+    public static void dRtoQ(final DMatrix3C R, DQuaternion q) {
 		dQfromR(q, R);
 	}
 
@@ -393,7 +398,8 @@ public class Rotation extends Matrix {
 	 * @param dq
 	 * @deprecated
 	 */
-	public static void dWtoDQ(final DVector3C w, final DQuaternionC q, DQuaternion dq)
+	@Deprecated
+    public static void dWtoDQ(final DVector3C w, final DQuaternionC q, DQuaternion dq)
 	{
 		dDQfromW(dq, w, q);
 	}

--- a/core/src/main/java/org/ode4j/ode/internal/cpp4j/Cstring.java
+++ b/core/src/main/java/org/ode4j/ode/internal/cpp4j/Cstring.java
@@ -50,7 +50,8 @@ public class Cstring extends Ctime {
 	 * @param l number of values to set
 	 * @deprecated Do not user for c=0
 	 */
-	public static void memset(int[] data, int c, int l) {
+	@Deprecated
+    public static void memset(int[] data, int c, int l) {
 		for (int i = 0; i < l; i++) {
 			data[i] = c;
 		}

--- a/core/src/main/java/org/ode4j/ode/internal/cpp4j/Ctime.java
+++ b/core/src/main/java/org/ode4j/ode/internal/cpp4j/Ctime.java
@@ -43,7 +43,8 @@ public class Ctime extends Ctype {
 	 * @author Tilmann Zaeschke
 	 * @deprecated In Java, simply use 'long'.
 	 */
-	public static class time_t {
+	@Deprecated
+    public static class time_t {
 		/** Current time */
 		public long seconds;
 

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimBufferArray.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimBufferArray.java
@@ -104,7 +104,8 @@ public class GimBufferArray<T> implements GimConstants { //formerly GBUFFER_ARRA
 //	  final GBUFFER_ID<vec3f> m_buffer_id = new GBUFFER_ID<vec3f>(this);
 	  Object[] m_buffer_data;//{new vec3f()};  //TODO make final ? TZ  //TODO Why init? Was pointer!!??? TZ
 		/** @deprecated TZ remove */
-	  int m_byte_stride = 1;
+        @Deprecated
+        int m_byte_stride = 1;
 	  int m_byte_offset = 0;
 	  /** GUINT m_element_count; */
 	  int m_element_count;

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimBufferArrayFloat.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimBufferArrayFloat.java
@@ -106,7 +106,8 @@ public class GimBufferArrayFloat implements GimConstants { //formerly GBUFFER_AR
 //	  final GBUFFER_ID<vec3f> m_buffer_id = new GBUFFER_ID<vec3f>(this);
 	  private vec3f[] m_buffer_data = {new vec3f()};  //TODO make final ? TZ  //TODO Why init? Was pointer!!??? TZ
 		/** @deprecated TZ remove */
-	  private int m_byte_stride = 1;
+	  @Deprecated
+      private int m_byte_stride = 1;
 	  private int m_byte_offset = 0;
 	  /** GUINT m_element_count; */
 	  private int m_element_count;

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimBufferArrayInt.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimBufferArrayInt.java
@@ -106,7 +106,8 @@ public class GimBufferArrayInt implements GimConstants { //formerly GBUFFER_ARRA
 //	  final GBUFFER_ID<vec3f> m_buffer_id = new GBUFFER_ID<vec3f>(this);
 	  private int[] m_buffer_data; //= {new vec3f()};  //TODO make final ? TZ  //TODO Why init? Was pointer!!??? TZ
 		/** @deprecated TZ remove */
-	  private final int m_byte_stride = 1;
+	  @Deprecated
+      private final int m_byte_stride = 1;
 	  //private final int m_byte_offset = 0;
 	  /** GUINT m_element_count; */
 	  private int m_element_count;

--- a/demo-cpp/pom.xml
+++ b/demo-cpp/pom.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -29,23 +32,19 @@
             <artifactId>junit</artifactId>
         </dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<version>1.7.12</version>
-		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>com.googlecode.mavennatives</groupId>
                 <artifactId>maven-nativedependencies-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -28,19 +28,14 @@
             <artifactId>junit</artifactId>
         </dependency>
 
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-jdk14</artifactId>
-			<version>1.7.12</version>
-		</dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>com.googlecode.mavennatives</groupId>
                 <artifactId>maven-nativedependencies-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,168 +1,307 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <!--
-    mvn clean
-    mvn compile
-    mvn deploy -Psonatype-oss-release
-    -->
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.ode4j</groupId>
-    <artifactId>parent</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
-    <packaging>pom</packaging>
+	<!--
+	mvn clean
+	mvn compile
+	mvn deploy -Psonatype-oss-release
+	-->
 
-    <modules>
-        <module>core</module>
-        <module>core-cpp</module>
-        <module>demo</module>
-        <module>demo-cpp</module>
-    </modules>
+	<groupId>org.ode4j</groupId>
+	<artifactId>parent</artifactId>
+	<version>0.4.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-    <prerequisites>
-        <maven>3.3.3</maven>
-    </prerequisites>
+	<modules>
+		<module>core</module>
+		<module>core-cpp</module>
+		<module>demo</module>
+		<module>demo-cpp</module>
+	</modules>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
-    <name>ODE for Java</name>
-    <description>Java 3D Physics Engine and Library.</description>
-    <url>https://github.com/tzaeschke/ode4j</url>
-    <licenses>
-        <license>
-            <name>GNU Lesser General Public License</name>
-            <url>http://www.gnu.org/licenses/lgpl.html</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
-    <scm>
-        <url>https://github.com/tzaeschke/ode4j</url>
-        <connection>scm:git:git@github.com:tzaeschke/ode4j.git</connection>
-        <developerConnection>scm:git:git@github.com:tzaeschke/ode4j.git</developerConnection>
-    </scm>
-    <developers>
-        <developer>
-            <name>Tilmann Zäschke</name>
-            <id>tzaeschke</id>
-            <email>zoodb@gmx.de</email>
-        </developer>
-    </developers>
-    <issueManagement>
-        <system>github</system>
-        <url>https://github.com/tzaeschke/ode4j/issues</url>
-    </issueManagement>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <repositories>
-        <repository>
-            <id>sonatype-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
+		<ode4j.maven-clean-plugin.version>3.0.0</ode4j.maven-clean-plugin.version>
+		<ode4j.maven-resources-plugin.version>3.0.0</ode4j.maven-resources-plugin.version>
+		<ode4j.maven-deploy-plugin.version>2.8.2</ode4j.maven-deploy-plugin.version>
+		<ode4j.maven-install-plugin.version>2.5.2</ode4j.maven-install-plugin.version>
+		<ode4j.maven-compiler-plugin.version>3.7.0</ode4j.maven-compiler-plugin.version>
+		<ode4j.maven-surefire-plugin.version>2.19.1</ode4j.maven-surefire-plugin.version>
+		<ode4j.maven-source-plugin.version>3.0.1</ode4j.maven-source-plugin.version>
+		<ode4j.maven-bundle-plugin.version>3.3.0</ode4j.maven-bundle-plugin.version>
+		<ode4j.maven-javadoc-plugin.version>3.0.0-M1</ode4j.maven-javadoc-plugin.version>
+		<ode4j.nexus-staging-maven-plugin.version>1.6.8</ode4j.nexus-staging-maven-plugin.version>
+		<ode4j.maven-gpg-plugin.version>1.6</ode4j.maven-gpg-plugin.version>
+		<ode4j.maven-enforcer-plugin.version>3.0.0-M1</ode4j.maven-enforcer-plugin.version>
+		<ode4j.maven-nativedependencies-plugin.version>0.0.7</ode4j.maven-nativedependencies-plugin.version>
+		<ode4j.maven-plugin-plugin.version>3.2</ode4j.maven-plugin-plugin.version>
+	</properties>
 
-    <!-- mvn versions:display-dependency-updates -->
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.lwjgl.lwjgl</groupId>
-                <artifactId>lwjgl_util</artifactId>
-                <version>2.9.3</version>
-            </dependency>
+	<prerequisites>
+		<maven>3.3.3</maven>
+	</prerequisites>
 
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
 
-    <!-- mvn versions:display-plugin-updates -->
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
-                    <executions>
-                        <execution>
-                            <id>sign-artifacts</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>sign</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.1</version>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+	<name>ODE for Java</name>
+	<description>Java 3D Physics Engine and Library.</description>
+	<url>https://github.com/tzaeschke/ode4j</url>
+
+	<licenses>
+		<license>
+			<name>GNU Lesser General Public License</name>
+			<url>http://www.gnu.org/licenses/lgpl.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<scm>
+		<url>https://github.com/tzaeschke/ode4j</url>
+		<connection>scm:git:git@github.com:tzaeschke/ode4j.git</connection>
+		<developerConnection>scm:git:git@github.com:tzaeschke/ode4j.git</developerConnection>
+	</scm>
+
+	<developers>
+		<developer>
+			<name>Tilmann Zäschke</name>
+			<id>tzaeschke</id>
+			<email>zoodb@gmx.de</email>
+		</developer>
+	</developers>
+
+	<issueManagement>
+		<system>github</system>
+		<url>https://github.com/tzaeschke/ode4j/issues</url>
+	</issueManagement>
+
+	<repositories>
+		<repository>
+			<id>sonatype-snapshots</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<!-- mvn versions:display-dependency-updates -->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.lwjgl.lwjgl</groupId>
+				<artifactId>lwjgl_util</artifactId>
+				<version>2.9.3</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>1.7.12</version>
+			</dependency>
+
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>4.12</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<!-- mvn versions:display-plugin-updates -->
+	<build>
+		<pluginManagement>
+			<plugins>
+
+				<!--
+				  Well-known core plugins used everywhere.
+				-->
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>${ode4j.maven-clean-plugin.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>${ode4j.maven-deploy-plugin.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>${ode4j.maven-install-plugin.version}</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>${ode4j.maven-resources-plugin.version}</version>
+				</plugin>
+
+				<!--
+					Enforcer plugin.
+					https://maven.apache.org/enforcer/maven-enforcer-plugin/
+				-->
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>${ode4j.maven-enforcer-plugin.version}</version>
+				</plugin>
+
+				<!--
+					Maven GPG plugin.
+					https://maven.apache.org/plugins/maven-gpg-plugin/
+				-->
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>${ode4j.maven-gpg-plugin.version}</version>
+					<executions>
+						<execution>
+							<id>sign-artifacts</id>
+							<phase>verify</phase>
+							<goals>
+								<goal>sign</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+
+				<!--
+					Maven Compiler plugin.
+					https://maven.apache.org/plugins/maven-compiler-plugin/
+				-->
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>${ode4j.maven-compiler-plugin.version}</version>
+					<executions>
+
+						<!--
+						  Compile everything as JDK 9 bytecode: This ensures
+						  that we get decent compilation errors such as
+						  missing "requires" directives in the module
+						  descriptor.
+						-->
+
+						<execution>
+							<id>default-compile</id>
+							<configuration>
+								<release>9</release>
+							</configuration>
+						</execution>
+
+						<!--
+						  Recompile everything except for the module
+						  descriptor as JDK 7 bytecode.
+						-->
+
+						<execution>
+							<id>compile-7</id>
+							<goals>
+								<goal>compile</goal>
+							</goals>
+							<configuration>
+								<excludes>
+									<exclude>module-info.java</exclude>
+								</excludes>
+							</configuration>
+						</execution>
+					</executions>
+
+					<!-- These are the default settings for all executions. -->
+					<configuration>
+						<release>7</release>
 						<compilerArgument>-Xlint:all</compilerArgument>
 						<showWarnings>true</showWarnings>
 						<showDeprecation>true</showDeprecation>
-		                <compilerArgument>-Werror </compilerArgument>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.2</version>
-                </plugin>
-                <plugin>
-                    <!-- mvn nativedependencies:copy -->
-                    <groupId>com.googlecode.mavennatives</groupId>
-                    <artifactId>maven-nativedependencies-plugin</artifactId>
-                    <version>0.0.7</version>
-                    <executions>
-                        <execution>
-                            <id>unpacknatives</id>
-                            <phase>generate-resources</phase>
-                            <goals>
-                                <goal>copy</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
+					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-plugin-plugin</artifactId>
+					<version>${ode4j.maven-plugin-plugin.version}</version>
+				</plugin>
+
+				<plugin>
+					<!-- mvn nativedependencies:copy -->
+					<groupId>com.googlecode.mavennatives</groupId>
+					<artifactId>maven-nativedependencies-plugin</artifactId>
+					<version>${ode4j.maven-nativedependencies-plugin.version}</version>
+					<executions>
+						<execution>
+							<id>unpacknatives</id>
+							<phase>generate-resources</phase>
+							<goals>
+								<goal>copy</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.15</version>
-        			<configuration>
-    					<printSummary>true</printSummary>
-                      	<skipTests>false</skipTests>
+					<version>${ode4j.maven-surefire-plugin.version}</version>
+					<configuration>
+						<printSummary>true</printSummary>
+						<skipTests>false</skipTests>
 						<includes>
-		                    <!-- include ALL tests -->
-	            			<include>**/*.java</include>
-	          			</includes>
-	          			<excludes>
-		                    <!-- exclude tests that currently fail -->
-	          				<exclude>**/tests/JavaMultiThreadTest.java</exclude>
-	          				<exclude>**/tests/bugs/Test_Bug0019_OdeRayToCylinder.java</exclude>
-	          				<exclude>**/tests/CollisionTest.java</exclude>
-	          				<exclude>**/tests/TestIssue0018_NpeInQuickstep.java</exclude>
-	          			</excludes>
-        			</configuration>
-			   	</plugin>
- 	        </plugins>
-        </pluginManagement>
-    </build>
+							<!-- include ALL tests -->
+							<include>**/*.java</include>
+						</includes>
+						<excludes>
+							<!-- exclude tests that currently fail -->
+							<exclude>**/tests/JavaMultiThreadTest.java</exclude>
+							<exclude>**/tests/bugs/Test_Bug0019_OdeRayToCylinder.java</exclude>
+							<exclude>**/tests/CollisionTest.java</exclude>
+							<exclude>**/tests/TestIssue0018_NpeInQuickstep.java</exclude>
+						</excludes>
+					</configuration>
+				</plugin>
+
+			</plugins>
+		</pluginManagement>
+
+		<plugins>
+			<!-- Check various preconditions for building. -->
+			<plugin>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-rules</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<!-- Require JDK 9+ -->
+								<requireJavaVersion>
+									<version>[9,)</version>
+								</requireJavaVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
-				<version>1.7.12</version>
+				<version>1.8.0-beta1</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
Hello!

I'm not sure if you'll be interested in this, but I want to use `ode4j` in a Java 9 modular project. I've been assisting a lot of other projects with transitioning to a modular world, so I thought I'd give modularizing `ode4j` a try.

It actually went very well: You have very few dependencies and a well defined package hierarchy. The commits below do the following:

1. Clean up the POM structure slightly. This moves all version numbers to a central location so that they can be updated once. It moves all plugin versions to properties so that they can be updated with the Maven Versions plugin (for some reason the plugin doesn't support updating plugin versions, but it does support updating properties and can therefore update plugins that way). I reformatted the POMs using your existing layout settings.

2. Start requiring JDK 9 to _build_ the code. Don't panic: The code produced is still Java 7 compatible. In fact, it's actually guaranteed to be Java 7 compatible in a way that it wasn't before: The JDK 9 compiler comes with a new `--release` flag that guarantees both bytecode and API compatibility with the specified release version (previously `javac` could only guarantee bytecode compatibility). I've added an Enforcer plugin execution to give users a nice error message if they try to compile the code with a version of the JDK that's too old. I had to remove `-Werror` from the compiler options as the newer compiler seems to emit warnings that the old compiler didn't and I didn't want to modify the code to fix them without knowing what I was doing. One exception to this: I added `@Deprecated` annotations to methods that were marked via JavaDoc as `@deprecated` but lacked a corresponding `@Deprecated` annotation. This squashed a good 50-60 warnings.

3. Add module descriptors. This is what makes the project a modular project. The descriptors explicitly state which modules are required and which packages are exported. I exported everything, but perhaps you'd want to review this as maybe some of the "internal" packages shouldn't be exported. I don't know the API well enough yet to say.

4. Add a `.travis.yml` config file to build the code on [Travis CI](https://travis-ci.org/io7m/ode4j). You don't have to keep this if you don't want Travis. The config file will sit there doing nothing until you either delete it or enable Travis for your Github account. The code builds correctly and all tests pass.