### PR TITLE
Enable OSGi support

### DIFF
--- a/core-cpp/pom.xml
+++ b/core-cpp/pom.xml
@@ -1,42 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.ode4j</groupId>
+		<artifactId>parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>core-cpp</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>${project.parent.groupId}</groupId>
+			<artifactId>core</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+	</dependencies>
+
 	<build>
 		<plugins>
+
+			<!-- Produce an OSGi manifest -->
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
 				<configuration>
-					<source>7</source>
-					<target>7</target>
+					<bnd><![CDATA[
+						Bundle-SymbolicName: org.ode4j.core-cpp
+						Export-Package: org.ode4j.*
+]]></bnd>
 				</configuration>
 			</plugin>
 		</plugins>
 	</build>
-
-	<parent>
-        <groupId>org.ode4j</groupId>
-        <artifactId>parent</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
-    </parent>
-
-    <artifactId>core-cpp</artifactId>
-    <packaging>jar</packaging>
-
-    <dependencies>
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>core</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-    </dependencies>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,18 +4,6 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>7</source>
-					<target>7</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 
 	<parent>
 		<groupId>org.ode4j</groupId>
@@ -32,5 +20,22 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+
+			<!-- Produce an OSGi manifest -->
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<configuration>
+					<bnd><![CDATA[
+						Bundle-SymbolicName: org.ode4j.core
+						Export-Package: org.ode4j.*
+]]></bnd>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/demo-cpp/pom.xml
+++ b/demo-cpp/pom.xml
@@ -1,50 +1,62 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.ode4j</groupId>
-        <artifactId>parent</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>org.ode4j</groupId>
+		<artifactId>parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
 
-    <artifactId>demo-cpp</artifactId>
-    <packaging>jar</packaging>
+	<artifactId>demo-cpp</artifactId>
+	<packaging>jar</packaging>
 
-    <dependencies>
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>demo</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>${project.parent.groupId}</groupId>
+			<artifactId>demo</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
 
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>core-cpp</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
+		<dependency>
+			<groupId>${project.parent.groupId}</groupId>
+			<artifactId>core-cpp</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+	</dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.googlecode.mavennatives</groupId>
-                <artifactId>maven-nativedependencies-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.mavennatives</groupId>
+				<artifactId>maven-nativedependencies-plugin</artifactId>
+			</plugin>
+
+			<!-- Produce an OSGi manifest -->
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<configuration>
+					<bnd><![CDATA[
+						Bundle-SymbolicName: org.ode4j.demo-cpp
+						Export-Package: org.ode4j.*
+]]></bnd>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 </project>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -1,45 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.ode4j</groupId>
-        <artifactId>parent</artifactId>
-        <version>0.4.0-SNAPSHOT</version>
-    </parent>
+	<parent>
+		<groupId>org.ode4j</groupId>
+		<artifactId>parent</artifactId>
+		<version>0.4.0-SNAPSHOT</version>
+	</parent>
 
-    <artifactId>demo</artifactId>
-    <packaging>jar</packaging>
+	<artifactId>demo</artifactId>
+	<packaging>jar</packaging>
 
-    <dependencies>
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>core</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
+	<dependencies>
+		<dependency>
+			<groupId>${project.parent.groupId}</groupId>
+			<artifactId>core</artifactId>
+			<version>${project.parent.version}</version>
+		</dependency>
 
-        <dependency>
-            <groupId>org.lwjgl.lwjgl</groupId>
-            <artifactId>lwjgl_util</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>org.lwjgl.lwjgl</groupId>
+			<artifactId>lwjgl_util</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
 
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-    </dependencies>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+	</dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.googlecode.mavennatives</groupId>
-                <artifactId>maven-nativedependencies-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.mavennatives</groupId>
+				<artifactId>maven-nativedependencies-plugin</artifactId>
+			</plugin>
+
+			<!-- Produce an OSGi manifest -->
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<configuration>
+					<bnd><![CDATA[
+						Bundle-SymbolicName: org.ode4j.demo
+						Export-Package: org.ode4j.*
+]]></bnd>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,21 +26,23 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<ode4j.maven-clean-plugin.version>3.0.0</ode4j.maven-clean-plugin.version>
-		<ode4j.maven-resources-plugin.version>3.0.0</ode4j.maven-resources-plugin.version>
-		<ode4j.maven-deploy-plugin.version>2.8.2</ode4j.maven-deploy-plugin.version>
-		<ode4j.maven-install-plugin.version>2.5.2</ode4j.maven-install-plugin.version>
-		<ode4j.maven-compiler-plugin.version>3.7.0</ode4j.maven-compiler-plugin.version>
-		<ode4j.maven-surefire-plugin.version>2.19.1</ode4j.maven-surefire-plugin.version>
-		<ode4j.maven-source-plugin.version>3.0.1</ode4j.maven-source-plugin.version>
+		<ode4j.bnd-maven-plugin.version>4.0.0</ode4j.bnd-maven-plugin.version>
+		<ode4j.build-helper-maven-plugin.version>3.0.0</ode4j.build-helper-maven-plugin.version>
 		<ode4j.maven-bundle-plugin.version>3.3.0</ode4j.maven-bundle-plugin.version>
-		<ode4j.maven-javadoc-plugin.version>3.0.0-M1</ode4j.maven-javadoc-plugin.version>
-		<ode4j.nexus-staging-maven-plugin.version>1.6.8</ode4j.nexus-staging-maven-plugin.version>
-		<ode4j.maven-gpg-plugin.version>1.6</ode4j.maven-gpg-plugin.version>
+		<ode4j.maven-clean-plugin.version>3.0.0</ode4j.maven-clean-plugin.version>
+		<ode4j.maven-compiler-plugin.version>3.7.0</ode4j.maven-compiler-plugin.version>
+		<ode4j.maven-deploy-plugin.version>2.8.2</ode4j.maven-deploy-plugin.version>
 		<ode4j.maven-enforcer-plugin.version>3.0.0-M1</ode4j.maven-enforcer-plugin.version>
+		<ode4j.maven-gpg-plugin.version>1.6</ode4j.maven-gpg-plugin.version>
+		<ode4j.maven-install-plugin.version>2.5.2</ode4j.maven-install-plugin.version>
+		<ode4j.maven-jar-plugin.version>3.1.0</ode4j.maven-jar-plugin.version>
+		<ode4j.maven-javadoc-plugin.version>3.0.0-M1</ode4j.maven-javadoc-plugin.version>
 		<ode4j.maven-nativedependencies-plugin.version>0.0.7</ode4j.maven-nativedependencies-plugin.version>
 		<ode4j.maven-plugin-plugin.version>3.2</ode4j.maven-plugin-plugin.version>
-		<ode4j.build-helper-maven-plugin.version>3.0.0</ode4j.build-helper-maven-plugin.version>
+		<ode4j.maven-resources-plugin.version>3.0.0</ode4j.maven-resources-plugin.version>
+		<ode4j.maven-source-plugin.version>3.0.1</ode4j.maven-source-plugin.version>
+		<ode4j.maven-surefire-plugin.version>2.19.1</ode4j.maven-surefire-plugin.version>
+		<ode4j.nexus-staging-maven-plugin.version>1.6.8</ode4j.nexus-staging-maven-plugin.version>
 	</properties>
 
 	<prerequisites>
@@ -246,6 +248,53 @@
 						</excludes>
 					</configuration>
 				</plugin>
+
+				<!--
+				  Bnd Maven Plugin
+				  Produces OSGi manifests
+
+				  https://github.com/bndtools/bnd
+				-->
+				<plugin>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-maven-plugin</artifactId>
+					<version>${ode4j.bnd-maven-plugin.version}</version>
+					<configuration>
+						<bnd><![CDATA[
+							Bundle-DocURL: ${project.url}
+							Bundle-Name: ${project.name} ${project.version} - ${project.description}
+							Bundle-Description: ${project.description}
+							Bundle-SCM: ${project.scm.url}
+							Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=7.0))"
+]]></bnd>
+					</configuration>
+				</plugin>
+
+				<!--
+				  Maven Jar plugin
+
+				  https://maven.apache.org/plugins/maven-jar-plugin/index.html
+				-->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>${ode4j.maven-jar-plugin.version}</version>
+					<executions>
+
+						<!-- Produce jar file with custom manifest -->
+						<execution>
+							<id>default-jar</id>
+							<configuration>
+								<archive>
+									<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+								</archive>
+							</configuration>
+							<goals>
+								<goal>jar</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -284,6 +333,23 @@
 					<source>1.7</source>
 					<target>1.7</target>
 				</configuration>
+			</plugin>
+
+			<!--
+			  Produce an OSGi manifest
+			-->
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate-osgi-manifest</id>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+						<phase>process-classes</phase>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,8 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<ode4j.bnd-maven-plugin.version>4.0.0</ode4j.bnd-maven-plugin.version>
+		<ode4j.bnd-maven-plugin.version>3.5.0</ode4j.bnd-maven-plugin.version>
 		<ode4j.build-helper-maven-plugin.version>3.0.0</ode4j.build-helper-maven-plugin.version>
-		<ode4j.maven-bundle-plugin.version>3.3.0</ode4j.maven-bundle-plugin.version>
 		<ode4j.maven-clean-plugin.version>3.0.0</ode4j.maven-clean-plugin.version>
 		<ode4j.maven-compiler-plugin.version>3.7.0</ode4j.maven-compiler-plugin.version>
 		<ode4j.maven-deploy-plugin.version>2.8.2</ode4j.maven-deploy-plugin.version>


### PR DESCRIPTION
This adds the relevant plugin configurations to make ode4j compatible
with the OSGi module system [0]. These are solely updates to the Jar
file manifests and therefore pose no compatibility issues. Manifest
generation is achieved via the bnd-maven-plugin [1] due to this plugin
having slightly better support across all of the major IDEs than other
plugins such as the maven-bundle-plugin [2].

In the process, it removes a couple of spurious compiler executions
from submodules.

[0] https://en.wikipedia.org/wiki/OSGi
[1] https://github.com/bndtools/bnd/tree/master/maven/bnd-maven-plugin
[2] https://felix.apache.org/documentation/subprojects/apache-felix-maven-bundle-plugin-bnd.html