### PR TITLE
Fix Require-Capability Header for osgi.ee version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
 							Bundle-Name: ${project.name} ${project.version} - ${project.description}
 							Bundle-Description: ${project.description}
 							Bundle-SCM: ${project.scm.url}
-							Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=7.0))"
+							Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=1.7))"
 ]]></bnd>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
From org.eclipse.osgi system.bundle the valid JavaSE versions are ... 

```
org.osgi.framework.system.capabilities = \
 osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0, 1.1, 1.2",\
 osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0, 1.1",\
 osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7"
osgi.java.profile.name = JavaSE-1.7
```