### PR TITLE
Cylinder collision error

### DIFF
--- a/demo/src/test/java/org/ode4j/tests/TestIssue0096_CylinderCollisionError.java
+++ b/demo/src/test/java/org/ode4j/tests/TestIssue0096_CylinderCollisionError.java
@@ -813,6 +813,8 @@ public class TestIssue0096_CylinderCollisionError {
 			DGeom g2 = trimesh();//createCylinder(1, 1);
 			g2.setPosition(0,0,-0.75);
 			collide(100);
+			g1.destroy();
+			g2.destroy();
 		}
 	}
 


### PR DESCRIPTION
Cylinder trimesh collision may fail with:
```
java.lang.RuntimeException
    at org.ode4j.ode.internal.Common.dIASSERT(Common.java:131)
    at org.ode4j.ode.internal.CollideCylinderTrimesh$sCylinderTrimeshColliderData.TestOneTriangleVsCylinder(CollideCylinderTrimesh.java:1002)
    at org.ode4j.ode.internal.CollideCylinderTrimesh$sCylinderTrimeshColliderData.TestCollisionForSingleTriangle(CollideCylinderTrimesh.java:1080)
    at org.ode4j.ode.internal.CollideCylinderTrimesh.dCollideCylinderTrimesh(CollideCylinderTrimesh.java:1301)
    at org.ode4j.ode.internal.CollideCylinderTrimesh.dColliderFn(CollideCylinderTrimesh.java:68)
    at org.ode4j.ode.internal.DxGeom.dCollide(DxGeom.java:1698)
    at org.ode4j.ode.OdeHelper.collide(OdeHelper.java:850)
```

This is currently not reproducible with tests.
