### PR TITLE
Support for Apple Silicon/Retina

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -41,6 +41,18 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>lwjgl-natives-macos-aarch64</id>
+			<activation>
+				<os>
+					<family>mac</family>
+					<arch>aarch64</arch>
+				</os>
+			</activation>
+			<properties>
+				<lwjgl.natives>natives-macos-arm64</lwjgl.natives>
+			</properties>
+		</profile>
+		<profile>
 			<id>lwjgl-natives-windows-amd64</id>
 			<activation>
 				<os>

--- a/demo/src/main/java/org/ode4j/drawstuff/internal/LwJGL.java
+++ b/demo/src/main/java/org/ode4j/drawstuff/internal/LwJGL.java
@@ -169,11 +169,8 @@ abstract class LwJGL extends Internal implements DrawStuffApi {
 		glfwSetCursorPosCallback(window, (window, xpos, ypos) -> {
 			handleMouseMove(xpos, ypos);
 		});
-		glfwSetWindowSizeCallback(window, (window, width, height) -> {
-			this.width = width;
-			this.height = height;
-		});
 
+		float xScale, yScale;
 		// Get the thread stack and push a new frame
 		try ( MemoryStack stack = stackPush() ) {
 			IntBuffer pWidth = stack.mallocInt(1); // int*
@@ -191,7 +188,19 @@ abstract class LwJGL extends Internal implements DrawStuffApi {
 					(vidmode.width() - pWidth.get(0)) / 2,
 					(vidmode.height() - pHeight.get(0)) / 2
 			);
+
+			// Required for HiDPI monitors (i.e. Mac Retina)
+			FloatBuffer _xscale = stack.mallocFloat(1);
+			FloatBuffer _yscale = stack.mallocFloat(1);
+			glfwGetWindowContentScale(window, _xscale, _yscale);
+			xScale = _xscale.get();
+			yScale = _yscale.get();
 		} // the stack frame is popped automatically
+
+		glfwSetWindowSizeCallback(window, (window, width, height) -> {
+			this.width = (int) (width * xScale);
+			this.height = (int) (height * yScale);
+		});
 
 		// Make the OpenGL context current
 		glfwMakeContextCurrent(window);
@@ -232,8 +241,8 @@ abstract class LwJGL extends Internal implements DrawStuffApi {
 
 		// initialize variables
 		//  win = 0;
-		width = _width;
-		height = _height;
+		width = (int) (_width * xScale);
+		height = (int) (_width * yScale);
 		//  glx_context = 0;
 		last_key_pressed = 0;
 

--- a/demo/src/main/java/org/ode4j/drawstuff/internal/LwJGL.java
+++ b/demo/src/main/java/org/ode4j/drawstuff/internal/LwJGL.java
@@ -139,6 +139,7 @@ abstract class LwJGL extends Internal implements DrawStuffApi {
 		glfwDefaultWindowHints(); // optional, the current window hints are already the default
 		glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE); // the window will stay hidden after creation
 		glfwWindowHint(GLFW_RESIZABLE, GLFW_TRUE); // the window will be resizable
+		glfwWindowHint(GLFW_SCALE_TO_MONITOR, GLFW_TRUE); // For windows and linux - fix window size
 
 		// Create the window
 		window = glfwCreateWindow(_width, _height, "Simulation", NULL, NULL);


### PR DESCRIPTION
- Added support for HiDPI
- Added support for Apple Silicon

For HiDPI it is necessary to use glfwGetWindowContentScale parameter (i.e. https://github.com/jMonkeyEngine/jmonkeyengine/issues/893) 