### PR TITLE
Angular velocity javadoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Fix DVector3.cross() returning always 0. [#128](https://github.com/tzaeschke/ode4j/issues/128)
 - Fix JUnit test lint. [#130](https://github.com/tzaeschke/ode4j/pull/130)
 - Fix Demo window size to minimum 640x480. [#131](https://github.com/tzaeschke/ode4j/pull/131)
+- Add javadoc to dindicate that angular velocity is given in radians. [#132](https://github.com/tzaeschke/ode4j/pull/132)
 
 ## 0.5.1 - 2023-09-17
 - Support for HiDPI screens / Apple Silicon/Retina. Contribution by valb3r,

--- a/core/src/main/java/org/ode4j/ode/DBody.java
+++ b/core/src/main/java/org/ode4j/ode/DBody.java
@@ -167,13 +167,16 @@ public interface DBody {
 
 	/**
 	 * Set the angular velocity of a body.
+	 * The velocity must be provided in radians/timeunit.
 	 * @param x x
 	 * @param y y
 	 * @param z z
 	 */
 	void setAngularVel (double x, double y, double z);
+
 	/**
 	 * Set the angular velocity of a body.
+	 * The velocity must be provided in radians/timeunit.
 	 * @param v v
 	 */
 	void setAngularVel (DVector3C v);


### PR DESCRIPTION
Add javadoc indicating that angular velocity must be provided in radians/time unit.