### PR TITLE
Update to 0.16.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@
 
 ## 0.5.4 - in progress
 
-- Port updates until 0.16.6 (previous: 0.16.2/.3). This includes:
+TODO 
+- rename createBHVSpace to BVH!
+- Add PH-Tree space???
+
+- Port updates until 0.16.6 (previous: 0.16.2/.3) ([#147](https://github.com/tzaeschke/ode4j/pull/147)). This includes:
   - New box-plane collider
   - new DemoTrimeshCollision
   - new API method in DPUJoint: `void addTorques (double torque1, double torque2);`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@
     - DemoFeedback has changed parameters.
     - Fix? DxHeightfield.dCollideHeightfieldZone() cleaned up
     - Fix? DLCP swapping updated
+  - Skipped:
+    - quickstep.cpp / dxQuickStepIsland (allowedThreads != 1)
+    - threading_impl*, threading_pool*
+TODO verify
+    - Should dxQuickStepIsland_Stage4LCP_IterationStartSingleThread()
+    - get the same updates as dxQuickStepIsland_Stage4LCP_IterationStart()?
+    - ThrsafeDecrement
+    - Multithrading: verify calculateThreadingLimitedThreadCount()
+
+MAYBE BROKEN:
+- sizeint is "long"!!!!
 
 ## 0.5.3 - 2024-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ TODO
 - Add PH-Tree space???
 
 - Port updates until 0.16.6 (previous: 0.16.2/.3) ([#147](https://github.com/tzaeschke/ode4j/pull/147)). This includes:
+  - Fixed porting bug in `dxQuickStepIsland_Stage4LCP_IterationStep`:
+    `fc_ptr2P = b2 * CFE__MAX;` was declared `int` and thus overwrote
+    the existing variable.
   - New box-plane collider
   - new DemoTrimeshCollision
   - new API method in DPUJoint: `void addTorques (double torque1, double torque2);`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 
 ## 0.5.4 - in progress
 
+Known Bugs: TrimeshHeightfield and LayeredTrimeshHeightfield don't work with Convex
+
 TODO 
 - rename createBHVSpace to BVH!
 - Add PH-Tree space???

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@
 
 --> See TODO.txt
 
+## 0.5.4 - in progress
+
+- Port updates until 0.16.6 (previous: 0.16.2/.3). This includes:
+  - New box-plane collider
+  - new DemoTrimeshCollision
+  - Cleanup:
+    - Lots of typos fixed
+    - Demos have new default window size and some a new default view position
+    - DemoFeedback has changed parameters.
+
 ## 0.5.3 - 2024-04-28
 
 - Fix INTERNAL ERROR in `FastLSolve.solveL1Straight()` caused by bug in `DLCP.solve1()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Port updates until 0.16.6 (previous: 0.16.2/.3). This includes:
   - New box-plane collider
   - new DemoTrimeshCollision
+  - new API method in DPUJoint: `void addTorques (double torque1, double torque2);`
   - Cleanup:
     - Lots of typos fixed
     - Demos have new default window size and some a new default view position

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
     - Lots of typos fixed
     - Demos have new default window size and some a new default view position
     - DemoFeedback has changed parameters.
+    - Fix? DxHeightfield.dCollideHeightfieldZone() cleaned up
+    - Fix? DLCP swapping updated
 
 ## 0.5.3 - 2024-04-28
 

--- a/LIB_CCD_README
+++ b/LIB_CCD_README
@@ -27,7 +27,7 @@ Compile And Install
 Simply type 'make' and 'make install' in src/ directory.
 
 Library libccd is by default compiled in double precision of floating point
-numbers - you can controll this by options USE_SINGLE/USE_DOUBLE, i.e.:
+numbers - you can control this by options USE_SINGLE/USE_DOUBLE, i.e.:
     $ make USE_SINGLE=yes
 will compile library in single precision.
 

--- a/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppCollision.java
+++ b/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppCollision.java
@@ -461,7 +461,7 @@ public abstract class ApiCppCollision extends ApiCppCollisionSpace {
 	 * the enabled state.
 	 *
 	 * @param geom   the geom to disable
-	 * @see #dGeomDisable(DGeom)
+	 * @see #dGeomEnable(DGeom)
 	 * @see #dGeomIsEnabled(DGeom)
 	 */
 	//ODE_API 
@@ -480,7 +480,7 @@ public abstract class ApiCppCollision extends ApiCppCollisionSpace {
 	 * @param geom   the geom to query
 	 * @return Non-zero if the geom is enabled, zero otherwise.
 	 * @see #dGeomDisable(DGeom)
-	 * @see #dGeomIsEnabled(DGeom)
+	 * @see #dGeomEnable(DGeom)
 	 */
 	//ODE_API 
 	public static boolean dGeomIsEnabled (DGeom geom) {
@@ -950,7 +950,7 @@ public abstract class ApiCppCollision extends ApiCppCollisionSpace {
 
 
 	/**
-	 * Calculate the depth of the a given point within a sphere.
+	 * Calculate the depth of the given point within a sphere.
 	 *
 	 * @param sphere  the sphere to query.
 	 * @param x       the X coordinate of the point.

--- a/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppCollisionTrimesh.java
+++ b/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppCollisionTrimesh.java
@@ -39,7 +39,7 @@ import org.ode4j.ode.internal.cpp4j.java.RefInt;
  * Trimesh data.
  * This is where the actual vertexdata (pointers), and BV tree is stored.
  * Vertices should be single precision!
- * This should be more sophisticated, so that the user can easyly implement
+ * This should be more sophisticated, so that the user can easily implement
  * another collision library, but this is a lot of work, and also costs some
  * performance because some data has to be copied.
  */

--- a/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppJoint.java
+++ b/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppJoint.java
@@ -1269,9 +1269,9 @@ public abstract class ApiCppJoint extends ApiCppOther {
 //	 * @param x The x component of the axis
 //	 * @param y The y component of the axis
 //	 * @param z The z component of the axis
-//	 * @param dx The Initial position of the prismatic join in the x direction
-//	 * @param dy The Initial position of the prismatic join in the y direction
-//	 * @param dz The Initial position of the prismatic join in the z direction
+//	 * @param dx The Initial position of the prismatic joint in the x direction
+//	 * @param dy The Initial position of the prismatic joint in the y direction
+//	 * @param dz The Initial position of the prismatic joint in the z direction
 //	 * @deprecated TZ
 //	 */
 //	//ODE_API_DEPRECATED ODE_API 

--- a/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppOdeInit.java
+++ b/core-cpp/src/main/java/org/ode4j/cpp/internal/ApiCppOdeInit.java
@@ -29,7 +29,7 @@ import org.ode4j.ode.internal.OdeInit;
  * Library Initialization
  *
  * Library initialization functions prepare ODE internal data structures for use
- * and release allocated resources after ODE is not needed any more.
+ * and release allocated resources after ODE is not needed anymore.
  */
 public abstract class ApiCppOdeInit extends ApiCppExportDIF {
 
@@ -130,7 +130,7 @@ public abstract class ApiCppOdeInit extends ApiCppExportDIF {
 //	 * in advance. If collision detection is not going to be used, it is not necessary
 //	 * to specify this flag.
 //	 *
-//	 * @c dAllocateMaskAll is a mask that can be used for for allocating all possible
+//	 * @c dAllocateMaskAll is a mask that can be used for allocating all possible
 //	 * data in cases when it is not known what exactly features of ODE will be used.
 //	 * The mask may not be used in combination with other flags. It is guaranteed to
 //	 * include all the current and future legal allocation flags. However, mature
@@ -207,9 +207,9 @@ public abstract class ApiCppOdeInit extends ApiCppExportDIF {
 
 
 	/**
-	 * Close ODE after it is not needed any more.
+	 * Close ODE after it is not needed anymore.
 	 *
-	 * The function is required to be called when program does not need ODE features any more.
+	 * The function is required to be called when program does not need ODE features anymore.
 	 * The call to {@code dCloseODE} releases all the resources allocated for library
 	 * including all the thread local data that might be allocated for all the threads
 	 * that were using ODE.

--- a/core-cpp/src/test/java/org/ode4j/tests/CollisionPointDepthTest.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/CollisionPointDepthTest.java
@@ -1,0 +1,226 @@
+package org.ode4j.tests;
+
+import org.junit.Test;
+import org.ode4j.ode.DBox;
+import org.ode4j.ode.DSphere;
+
+import static org.ode4j.cpp.internal.ApiCppCollision.*;
+import static org.ode4j.tests.UnitTestPlusPlus.CheckMacros.*;
+
+public class CollisionPointDepthTest {
+
+    //    #ifdef dSINGLE
+    //        #define PROXIMITY_TOLERANCE     REAL(1e-7)
+    //    #else
+    //        #define PROXIMITY_TOLERANCE     REAL(1e-12)
+    private static final double PROXIMITY_TOLERANCE = 1e-12;
+    //    #endif
+
+
+    //TEST(test_collision_sphere_point_depth)
+    @Test
+    public void test_collision_sphere_point_depth() {
+        // Test case: sphere at the origin.
+        final double radius = 1;
+        DSphere sphere = dCreateSphere(null, radius);
+
+        dGeomSetPosition(sphere, 0, 0, 0);
+
+        // depth at center should equal radius
+        CHECK_EQUAL(radius, dGeomSpherePointDepth(sphere, 0, 0, 0));
+
+        // half-radius depth
+        CHECK_EQUAL((0.5) * radius, dGeomSpherePointDepth(sphere, 0.5, 0, 0));
+        CHECK_EQUAL((0.5) * radius, dGeomSpherePointDepth(sphere, 0, 0.5, 0));
+        CHECK_EQUAL((0.5) * radius, dGeomSpherePointDepth(sphere, 0, 0, 0.5));
+        CHECK_EQUAL((0.5) * radius, dGeomSpherePointDepth(sphere, -0.5, 0, 0));
+        CHECK_EQUAL((0.5) * radius, dGeomSpherePointDepth(sphere, 0, -0.5, 0));
+        CHECK_EQUAL((0.5) * radius, dGeomSpherePointDepth(sphere, 0, 0, -0.5));
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, 0.3, 0.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, 0, 0.3, 0.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, 0.4, 0, 0.3), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, -0.3, 0.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, 0, -0.3, 0.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, 0.4, 0, -0.3), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, 0.3, -0.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, 0, 0.3, -0.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, -0.4, 0, 0.3), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, -0.3, -0.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, 0, -0.3, -0.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.5) * radius, dGeomSpherePointDepth(sphere, -0.4, 0, -0.3), PROXIMITY_TOLERANCE);
+
+        // 0.1 radius depth
+        CHECK_CLOSE((0.1) * radius, dGeomSpherePointDepth(sphere, 0.9, 0, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * radius, dGeomSpherePointDepth(sphere, 0, 0.9, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * radius, dGeomSpherePointDepth(sphere, 0, 0, 0.9), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * radius, dGeomSpherePointDepth(sphere, -0.9, 0, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * radius, dGeomSpherePointDepth(sphere, 0, -0.9, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * radius, dGeomSpherePointDepth(sphere, 0, 0, -0.9), PROXIMITY_TOLERANCE);
+
+        // on surface (zero depth)
+        CHECK_EQUAL(0.0, dGeomSpherePointDepth(sphere, 1.0, 0, 0));
+        CHECK_EQUAL(0.0, dGeomSpherePointDepth(sphere, 0, 1.0, 0));
+        CHECK_EQUAL(0.0, dGeomSpherePointDepth(sphere, 0, 0, 1.0));
+        CHECK_EQUAL(0.0, dGeomSpherePointDepth(sphere, -1.0, 0, 0));
+        CHECK_EQUAL(0.0, dGeomSpherePointDepth(sphere, 0, -1.0, 0));
+        CHECK_EQUAL(0.0, dGeomSpherePointDepth(sphere, 0, 0, -1.0));
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, 0.6, 0.8, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, 0, 0.6, 0.8), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, 0.8, 0, 0.6), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, -0.6, 0.8, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, 0, -0.6, 0.8), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, 0.8, 0, -0.6), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, 0.6, -0.8, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, 0, 0.6, -0.8), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, -0.8, 0, 0.6), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, -0.6, -0.8, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, 0, -0.6, -0.8), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(0.0, dGeomSpherePointDepth(sphere, -0.8, 0, -0.6), PROXIMITY_TOLERANCE);
+
+        // 0.1 radius from surface (negative depth)
+        CHECK_CLOSE(-(0.1) * radius, dGeomSpherePointDepth(sphere, 1.1, 0, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * radius, dGeomSpherePointDepth(sphere, 0, 1.1, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * radius, dGeomSpherePointDepth(sphere, 0, 0, 1.1), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * radius, dGeomSpherePointDepth(sphere, -1.1, 0, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * radius, dGeomSpherePointDepth(sphere, 0, -1.1, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * radius, dGeomSpherePointDepth(sphere, 0, 0, -1.1), PROXIMITY_TOLERANCE);
+
+        // half-radius from surface (negative depth)
+        CHECK_EQUAL(-(0.5) * radius, dGeomSpherePointDepth(sphere, 1.5, 0, 0));
+        CHECK_EQUAL(-(0.5) * radius, dGeomSpherePointDepth(sphere, 0, 1.5, 0));
+        CHECK_EQUAL(-(0.5) * radius, dGeomSpherePointDepth(sphere, 0, 0, 1.5));
+        CHECK_EQUAL(-(0.5) * radius, dGeomSpherePointDepth(sphere, -1.5, 0, 0));
+        CHECK_EQUAL(-(0.5) * radius, dGeomSpherePointDepth(sphere, 0, -1.5, 0));
+        CHECK_EQUAL(-(0.5) * radius, dGeomSpherePointDepth(sphere, 0, 0, -1.5));
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, 0.9, 1.2, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, 0, 0.9, 1.2), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, 1.2, 0, 0.9), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, -0.9, 1.2, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, 0, -0.9, 1.2), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, 1.2, 0, -0.9), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, 0.9, -1.2, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, 0, 0.9, -1.2), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, -1.2, 0, 0.9), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, -0.9, -1.2, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, 0, -0.9, -1.2), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5), dGeomSpherePointDepth(sphere, -1.2, 0, -0.9), PROXIMITY_TOLERANCE);
+    }
+
+    // TEST(test_collision_box_point_depth)
+    @Test
+    public void test_collision_box_point_depth() {
+        // Test case: cube at the origin.
+
+        final double length = 1;
+        DBox cube = dCreateBox(null, 2 * length, 2 * length, 2 * length);
+
+        dGeomSetPosition(cube, 0, 0, 0);
+
+        // depth at center should equal half length
+        CHECK_EQUAL(length, dGeomBoxPointDepth(cube, 0, 0, 0));
+
+        // half-length depth
+        CHECK_EQUAL((0.5) * length, dGeomBoxPointDepth(cube, 0.5, 0, 0));
+        CHECK_EQUAL((0.5) * length, dGeomBoxPointDepth(cube, 0, 0.5, 0));
+        CHECK_EQUAL((0.5) * length, dGeomBoxPointDepth(cube, 0, 0, 0.5));
+        CHECK_EQUAL((0.5) * length, dGeomBoxPointDepth(cube, -0.5, 0, 0));
+        CHECK_EQUAL((0.5) * length, dGeomBoxPointDepth(cube, 0, -0.5, 0));
+        CHECK_EQUAL((0.5) * length, dGeomBoxPointDepth(cube, 0, 0, -0.5));
+
+        // closest point 0.6 * length
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, 0.3, 0.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, 0, 0.3, 0.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, 0.4, 0, 0.3), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, -0.3, 0.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, 0, -0.3, 0.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, 0.4, 0, -0.3), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, 0.3, -0.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, 0, 0.3, -0.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, -0.4, 0, 0.3), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, -0.3, -0.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, 0, -0.3, -0.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.6) * length, dGeomBoxPointDepth(cube, -0.4, 0, -0.3), PROXIMITY_TOLERANCE);
+
+        // 0.1 length depth
+        CHECK_CLOSE((0.1) * length, dGeomBoxPointDepth(cube, 0.9, 0, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * length, dGeomBoxPointDepth(cube, 0, 0.9, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * length, dGeomBoxPointDepth(cube, 0, 0, 0.9), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * length, dGeomBoxPointDepth(cube, -0.9, 0, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * length, dGeomBoxPointDepth(cube, 0, -0.9, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE((0.1) * length, dGeomBoxPointDepth(cube, 0, 0, -0.9), PROXIMITY_TOLERANCE);
+
+        // on surface (zero depth)
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 1.0, 0, 0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0, 1.0, 0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0, 0, 1.0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, -1.0, 0, 0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0, -1.0, 0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0, 0, -1.0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0.3, 1.0, 0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0, 0.3, 1.0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 1.0, 0, 0.3));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, -0.3, 1.0, 0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0, -0.3, 1.0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 1.0, 0, -0.3));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0.3, -1.0, 0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0, 0.3, -1.0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, -1.0, 0, 0.3));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, -0.3, -1.0, 0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, 0, -0.3, -1.0));
+        CHECK_EQUAL(0.0, dGeomBoxPointDepth(cube, -1.0, 0, -0.3));
+
+        // 0.1 length from surface (negative depth)
+        CHECK_CLOSE(-(0.1) * length, dGeomBoxPointDepth(cube, 1.1, 0, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * length, dGeomBoxPointDepth(cube, 0, 1.1, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * length, dGeomBoxPointDepth(cube, 0, 0, 1.1), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * length, dGeomBoxPointDepth(cube, -1.1, 0, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * length, dGeomBoxPointDepth(cube, 0, -1.1, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.1) * length, dGeomBoxPointDepth(cube, 0, 0, -1.1), PROXIMITY_TOLERANCE);
+
+        // half-length from surface face (negative depth)
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 1.5, 0, 0));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0, 1.5, 0));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0, 0, 1.5));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, -1.5, 0, 0));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0, -1.5, 0));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0, 0, -1.5));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0.3, 1.5, 0));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0, 0.3, 1.5));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 1.5, 0, 0.3));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, -0.3, 1.5, 0));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0, -0.3, 1.5));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 1.5, 0, -0.3));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0.3, -1.5, 0));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0, 0.3, -1.5));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, -1.5, 0, 0.3));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, -0.3, -1.5, 0));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, 0, -0.3, -1.5));
+        CHECK_EQUAL(-(0.5) * length, dGeomBoxPointDepth(cube, -1.5, 0, -0.3));
+        // half-length from surface edge (negative depth)
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, 1.3, 1.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, 0, 1.3, 1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, 1.4, 0, 1.3), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, -1.3, 1.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, 0, -1.3, 1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, 1.4, 0, -1.3), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, 1.3, -1.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, 0, 1.3, -1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, -1.4, 0, 1.3), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, -1.3, -1.4, 0), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, 0, -1.3, -1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.5) * length, dGeomBoxPointDepth(cube, -1.4, 0, -1.3), PROXIMITY_TOLERANCE);
+        // 0.6 length from corner (negative depth)
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, 1.2, 1.4, 1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, 1.4, 1.2, 1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, 1.4, 1.4, 1.2), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, -1.2, 1.4, 1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, 1.4, -1.2, 1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, 1.4, 1.4, -1.2), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, 1.2, -1.4, 1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, 1.4, 1.2, -1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, -1.4, 1.4, 1.2), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, -1.2, -1.4, 1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, 1.4, -1.2, -1.4), PROXIMITY_TOLERANCE);
+        CHECK_CLOSE(-(0.6) * length, dGeomBoxPointDepth(cube, -1.4, 1.4, -1.2), PROXIMITY_TOLERANCE);
+    }
+}

--- a/core-cpp/src/test/java/org/ode4j/tests/FrictionJointContact.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/FrictionJointContact.java
@@ -47,7 +47,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 //        1         2         3         4         5         6         7
 
 ////////////////////////////////////////////////////////////////////////////////
-// This file create unit test for some of the functions found in:
+// This file creates unit tests for some of the functions found in:
 // ode/src/joint.cpp
 //
 //
@@ -181,7 +181,7 @@ public class FrictionJointContact extends TestSuperClass
 
 
         /*
-         * Now try with no frictino in the second direction. The Jacobian should look like:
+         * Now try with no friction in the second direction. The Jacobian should look like:
          * J[1] = [  0  1  0    0  0  1    0 -1  0    0  0  1 ]
          */
         // try again, with zero mu2

--- a/core-cpp/src/test/java/org/ode4j/tests/PRGetInfo1_Fixture_3.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/PRGetInfo1_Fixture_3.java
@@ -57,7 +57,7 @@ import org.ode4j.ode.internal.joints.DxJointPR;
 //   |         |--------(_)----|-----|           |  ----->Y
 //   +---------+                -    +-----------+
 //
-// N.B. X is comming out of the page
+// N.B. X is coming out of the page
 ////////////////////////////////////////////////////////////////////////////////
 public class PRGetInfo1_Fixture_3  {
 	public PRGetInfo1_Fixture_3() {

--- a/core-cpp/src/test/java/org/ode4j/tests/PRGetInfo1_Fixture_4.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/PRGetInfo1_Fixture_4.java
@@ -72,7 +72,7 @@ import org.ode4j.ode.internal.joints.DxJointPR;
 //                      (_)----|-----|           |  ----->Y
 //                              -    +-----------+
 //
-// N.B. X is comming out of the page
+// N.B. X is coming out of the page
 ////////////////////////////////////////////////////////////////////////////////
 public class PRGetInfo1_Fixture_4  {
 	public PRGetInfo1_Fixture_4() {

--- a/core-cpp/src/test/java/org/ode4j/tests/UniversalGetInfo1_Fixture_1.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/UniversalGetInfo1_Fixture_1.java
@@ -52,7 +52,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJoint;
 import org.ode4j.ode.internal.joints.DxJointUniversal;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joint.cpp
 public class UniversalGetInfo1_Fixture_1  {
 	public UniversalGetInfo1_Fixture_1() {

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointAMotor.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointAMotor.java
@@ -37,7 +37,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 //        1         2         3         4         5         6         7
 
 ////////////////////////////////////////////////////////////////////////////////
-// This file create unit test for some of the functions found in:
+// This file creates unit tests for some of the functions found in:
 // ode/src/joinst/fixed.cpp
 //
 //

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointBall_Fixture_B1_and_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointBall_Fixture_B1_and_B2_At_Zero_Axis_Along_X.java
@@ -53,7 +53,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
- * This file create unit test for some of the functions found in:
+ * This file creates unit tests for some of the functions found in:
  * ode/src/joinst/ball.cpp
  */
 public class DxJointBall_Fixture_B1_and_B2_At_Zero_Axis_Along_X extends TestSuperClass {

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointFixed_Fixture_1.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointFixed_Fixture_1.java
@@ -47,7 +47,7 @@ import org.ode4j.tests.UnitTestPlusPlus.CheckMacros;
 
 /**
  *
- * This file create unit test for some of the functions found in:
+ * This file creates unit tests for some of the functions found in:
  * ode/src/joinst/fixed.cpp
  */
 public class DxJointFixed_Fixture_1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointHinge2_Fixture_B1_and_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointHinge2_Fixture_B1_and_B2_At_Zero_Axis_Along_X.java
@@ -50,8 +50,8 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
- * The 2 bodies are positionned at (-1, -2, -3),  and (11, 22, 33)
- * The bodis have rotation of 27deg around some axis.
+ * The 2 bodies are positioned at (-1, -2, -3), and (11, 22, 33)
+ * The bodies have rotation of 27deg around some axis.
  * The joint is a Hinge2 Joint
  * Axis is along the X axis
  * Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointHinge_Fixture_B1_and_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointHinge_Fixture_B1_and_B2_At_Zero_Axis_Along_X.java
@@ -57,7 +57,7 @@ import org.ode4j.ode.internal.joints.DxJointHinge;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
- * This file create unit test for some of the functions found in:
+ * This file creates unit tests for some of the functions found in:
  * ode/src/joinst/hinge.cpp
  * @author Tilmann Zaeschke
  */

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointHinge_Test_Initialization.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointHinge_Test_Initialization.java
@@ -57,7 +57,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
  * Create 2 bodies attached by a Hinge joint
-// Axis is along the X axis (Default value
+// Axis is along the X axis (Default value)
 // Anchor at (0, 0, 0)      (Default value)
 //
 //       ^Y

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointPR_Test_Initialization.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointPR_Test_Initialization.java
@@ -58,7 +58,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Create 2 bodies attached by a PR joint
-// Axis is along the X axis (Default value
+// Axis is along the X axis (Default value)
 // Anchor at (0, 0, 0)      (Default value)
 //
 //       ^Y

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointPiston_Test_Initialization.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointPiston_Test_Initialization.java
@@ -56,7 +56,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
  *  Create 2 bodies attached by a Piston joint
-// Axis is along the X axis (Default value
+// Axis is along the X axis (Default value)
 // Anchor at (0, 0, 0)      (Default value)
 //
 //       ^Y

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointSlider_Fixture_1.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointSlider_Fixture_1.java
@@ -45,7 +45,7 @@ import org.ode4j.ode.DSliderJoint;
 import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointSlider;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joinst/slider.cpp
 public class DxJointSlider_Fixture_1
     {

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointSlider_Test_Initialization.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointSlider_Test_Initialization.java
@@ -55,7 +55,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Create 2 bodies attached by a Slider joint
-// Axis is along the X axis (Default value
+// Axis is along the X axis (Default value)
 // Anchor at (0, 0, 0)      (Default value)
 //
 //       ^Y

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointUniversal_Test_Initialization.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/DxJointUniversal_Test_Initialization.java
@@ -62,7 +62,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Create 2 bodies attached by a Universal joint
-// Axis is along the X axis (Default value
+// Axis is along the X axis (Default value)
 // Anchor at (0, 0, 0)      (Default value)
 //
 //       ^Y

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B1_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B1_At_Zero_Axis_Along_X.java
@@ -46,7 +46,7 @@ import org.ode4j.ode.internal.joints.DxJointPR;
 
 /**
  * Only body 1
- * The body are positioned at (0, 0, 0), with no rotation
+ * The body is positioned at (0, 0, 0), with no rotation
  * The joint is a PR Joint
  * Axis is along the X axis
  * Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B1_At_Zero_Axis_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B1_At_Zero_Axis_Inverse_of_X.java
@@ -46,7 +46,7 @@ import org.ode4j.ode.internal.joints.DxJointPR;
 
 // Compare only one body to 2 bodies with one fixed.
 //
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a PR Joint
 // Axis is along the X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B1_and_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B1_and_B2_At_Zero_Axis_Along_X.java
@@ -45,7 +45,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointPR;
 
 /**
- * The 2 bodies are positionned at (0, 0, 0), with no rotation
+ * The 2 bodies are positioned at (0, 0, 0) with no rotation
  * The joint is a PR Joint
  * Axis is along the X axis
  * Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B1_and_B2_Random_Orientation_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B1_and_B2_Random_Orientation_At_Zero_Axis_Along_X.java
@@ -48,8 +48,8 @@ import org.ode4j.ode.DPRJoint;
 import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointPR;
 
-// The 2 bodies are positionned at (0, 0, 0),  and (0, 0, 0)
-// The bodis have rotation of 27deg around some axis.
+// The 2 bodies are positioned at (0, 0, 0)  and (0, 0, 0)
+// The bodies have rotation of 27deg around some axis.
 // The joint is a PR Joint
 // Axis is along the X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B2_At_Zero_Axis_Along_X.java
@@ -45,7 +45,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointPR;
 
 // Only body 2
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a PR Joint
 // Axis is along the X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B2_At_Zero_Axis_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_B2_At_Zero_Axis_Inverse_of_X.java
@@ -45,7 +45,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointPR;
 
 // Only body 2
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a PR Joint
 // Axis is in the opposite X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_Compare_Body_At_Zero_AxisP_Along_Y.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPR_Compare_Body_At_Zero_AxisP_Along_Y.java
@@ -59,7 +59,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Compare only one body to 2 bodies with one fixed.
 //
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a PR Joint
 // Axis is along the X axis
 // Anchor at (0, 0, 0)
@@ -158,11 +158,11 @@ public class Fixture_dxJointPR_Compare_Body_At_Zero_AxisP_Along_Y extends TestSu
         CHECK_CLOSE(dJointGetPRPositionRate(jId_12), dJointGetPRPositionRate(jId), 1e-2);
         CHECK_CLOSE(dJointGetPRAngleRate(jId_12), dJointGetPRAngleRate(jId), 1e-2);
     }
-    // This test compare the result of a slider with 2 bodies where body body 2 is
+    // This test compares the result of a slider with 2 bodies where body 2 is
     // fixed to the world to a slider with only one body at position 1.
     //
-    // Test the limits [-1, 0.25] when only one body at is attached to the joint
-    // using dJointAttache(jId, bId, 0);
+    // Test the limits [-1, 0.25] when only one body is attached to the joint
+    // using dJointAttach(jId, bId, 0);
     //
     //TEST_FIXTURE(Fixture_dxJointPR_Compare_Body_At_Zero_AxisP_Along_Y,
     @Test public void test_Limit_minus1_025_One_Body_on_left()
@@ -206,11 +206,11 @@ public class Fixture_dxJointPR_Compare_Body_At_Zero_AxisP_Along_Y extends TestSu
 
 
 
-    // This test compare the result of a slider with 2 bodies where body body 1 is
+    // This test compares the result of a slider with 2 bodies where body 1 is
     // fixed to the world to a slider with only one body at position 2.
     //
-    // Test the limits [-1, 0.25] when only one body at is attached to the joint
-    // using dJointAttache(jId, 0, bId);
+    // Test the limits [-1, 0.25] when only one body is attached to the joint
+    // using dJointAttach(jId, 0, bId);
     //
     //TEST_FIXTURE(Fixture_dxJointPR_Compare_Body_At_Zero_AxisP_Along_Y,
     @Test public void test_Limit_minus1_025_One_Body_on_right()
@@ -255,11 +255,11 @@ public class Fixture_dxJointPR_Compare_Body_At_Zero_AxisP_Along_Y extends TestSu
 
 
 
-    // This test compare the result of a slider with 2 bodies where body body 2 is
+    // This test compares the result of a slider with 2 bodies where body 2 is
     // fixed to the world to a slider with only one body at position 1.
     //
-    // Test the limits [0, 0] when only one body at is attached to the joint
-    // using dJointAttache(jId, bId, 0);
+    // Test the limits [0, 0] when only one body is attached to the joint
+    // using dJointAttach(jId, bId, 0);
     //
     // The body should not move since their is no room between the two limits
     //
@@ -310,11 +310,11 @@ public class Fixture_dxJointPR_Compare_Body_At_Zero_AxisP_Along_Y extends TestSu
     }
 
 
-    // This test compare the result of a slider with 2 bodies where body body 1 is
+    // This test compares the result of a slider with 2 bodies where body 1 is
     // fixed to the world to a slider with only one body at position 2.
     //
-    // Test the limits [0, 0] when only one body at is attached to the joint
-    // using dJointAttache(jId, 0, bId);
+    // Test the limits [0, 0] when only one body is attached to the joint
+    // using dJointAttach(jId, 0, bId);
     //
     // The body should not move since their is no room between the two limits
     //

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPU_B1_and_B2_At_Zero.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPU_B1_and_B2_At_Zero.java
@@ -242,7 +242,7 @@ public class Fixture_dxJointPU_B1_and_B2_At_Zero
         CHECK_CLOSE (0.0, dJointGetPUPosition (jId), 1e-4);
     }
 
-    // Attache only one body at position 1 to the joint dJointAttach (jId, bId, 0)
+    // Attach only one body at position 1 to the joint dJointAttach (jId, bId, 0)
     // Move 1st body offset unit in the opposite X direction
     //
     //  X------->          X---------> Axis -->
@@ -275,7 +275,7 @@ public class Fixture_dxJointPU_B1_and_B2_At_Zero
 
 
 
-    // Attache only one body at position 2 to the joint dJointAttach (jId, 0, bId)
+    // Attach only one body at position 2 to the joint dJointAttach (jId, 0, bId)
     // Move 1st body offset unit in the X direction
     //
     //  X------->       X---------> Axis -->
@@ -306,7 +306,7 @@ public class Fixture_dxJointPU_B1_and_B2_At_Zero
         CHECK_CLOSE (0.0, dJointGetPUPosition (jId), 1e-4);
     }
 
-    // Attache only one body at position 2 to the joint dJointAttach (jId, 0, bId)
+    // Attach only one body at position 2 to the joint dJointAttach (jId, 0, bId)
     // Move 1st body offset unit in the opposite X direction
     //
     //  X------->          X---------> Axis -->

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPU_B1_and_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPU_B1_and_B2_At_Zero_Axis_Along_X.java
@@ -49,7 +49,7 @@ import org.ode4j.ode.DPUJoint;
 import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointPU;
 
-// The 2 bodies are positionned at (0, 0, 0),  and (0, 0, 0)
+// The 2 bodies are positioned at (0, 0, 0) and (0, 0, 0)
 // The second body has a rotation of 27deg around X axis.
 // The joint is a PU Joint
 // Axis is along the X axis

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPU_Compare_One_Body_To_Two_Bodies_At_Zero.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPU_Compare_One_Body_To_Two_Bodies_At_Zero.java
@@ -60,7 +60,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Compare only one body to 2 bodies with one fixed.
 //
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a PU Joint with default values
 public class Fixture_dxJointPU_Compare_One_Body_To_Two_Bodies_At_Zero extends TestSuperClass
     {
@@ -168,8 +168,8 @@ public class Fixture_dxJointPU_Compare_One_Body_To_Two_Bodies_At_Zero extends Te
     // This test compare the result of a pu joint with 2 bodies where body body 2 is
     // fixed to the world to a pu joint with only one body at position 1.
     //
-    // Test the limits [-1, 0.25] when only one body at is attached to the joint
-    // using dJointAttache(jId, bId, 0);
+    // Test the limits [-1, 0.25] when only one body is attached to the joint
+    // using dJointAttach(jId, bId, 0);
     //
     //TEST_FIXTURE(Fixture_dxJointPU_Compare_One_Body_To_Two_Bodies_At_Zero,
     @Test public void test_Limit_minus1_025_One_Body_on_left()
@@ -223,8 +223,8 @@ public class Fixture_dxJointPU_Compare_One_Body_To_Two_Bodies_At_Zero extends Te
     // This test compare the result of a pu joint with 2 bodies where body body 1 is
     // fixed to the world to a pu joint with only one body at position 2.
     //
-    // Test the limits [-1, 0.25] when only one body at is attached to the joint
-    // using dJointAttache(jId, 0, bId);
+    // Test the limits [-1, 0.25] when only one body is attached to the joint
+    // using dJointAttach(jId, 0, bId);
     //
     //TEST_FIXTURE(Fixture_dxJointPU_Compare_One_Body_To_Two_Bodies_At_Zero,
     @Test public void test_Limit_minus1_025_One_Body_on_right()
@@ -279,8 +279,8 @@ public class Fixture_dxJointPU_Compare_One_Body_To_Two_Bodies_At_Zero extends Te
     // This test compare the result of a pu joint with 2 bodies where body 2 is
     // fixed to the world to a pu joint with only one body at position 1.
     //
-    // Test the limits [0, 0] when only one body at is attached to the joint
-    // using dJointAttache(jId, bId, 0);
+    // Test the limits [0, 0] when only one body is attached to the joint
+    // using dJointAttach(jId, bId, 0);
     //
     // The body should not move since their is no room between the two limits
     //
@@ -333,8 +333,8 @@ public class Fixture_dxJointPU_Compare_One_Body_To_Two_Bodies_At_Zero extends Te
     // This test compare the result of a pu joint with 2 bodies where body body 1 is
     // fixed to the world to a pu joint with only one body at position 2.
     //
-    // Test the limits [0, 0] when only one body at is attached to the joint
-    // using dJointAttache(jId, 0, bId);
+    // Test the limits [0, 0] when only one body is attached to the joint
+    // using dJointAttach(jId, 0, bId);
     //
     // The body should not move since their is no room between the two limits
     //

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPU_One_Body_At_Zero_Axis_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPU_One_Body_At_Zero_Axis_Inverse_of_X.java
@@ -45,7 +45,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointPU;
 
 // Only one body
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a PU Joint
 // Axis is in the oppsite X axis
 // Anchor at (0, 0, 0)
@@ -159,7 +159,7 @@ public class Fixture_dxJointPU_One_Body_At_Zero_Axis_Inverse_of_X
     @Test public void test_dJointSetPUAxisOffset_B2_OffsetUnit()
     {
         // By default it is attached to position 1
-        // Now attach the body at positiojn 2
+        // Now attach the body at position 2
         dJointAttach(jId, null, bId);
 
         CHECK_CLOSE (0.0, dJointGetPUPosition (jId), 1e-4);
@@ -189,7 +189,7 @@ public class Fixture_dxJointPU_One_Body_At_Zero_Axis_Inverse_of_X
     @Test public void test_dJointSetPUAxisOffset_B2_Minus_OffsetUnit()
     {
         // By default it is attached to position 1
-        // Now attach the body at positiojn 2
+        // Now attach the body at position 2
         dJointAttach(jId, null, bId);
 
         CHECK_CLOSE (0.0, dJointGetPUPosition (jId), 1e-4);

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B1_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B1_At_Zero_Axis_Along_X.java
@@ -51,7 +51,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
  * Only body 1
- * The body are positionned at (0, 0, 0), with no rotation
+ * The body is positioned at (0, 0, 0) with no rotation
  * The joint is a Piston Joint
  * Axis is along the X axis
  * Anchor at (0, 0, 0)
@@ -156,7 +156,7 @@ public class Fixture_dxJointPiston_B1_At_Zero_Axis_Along_X extends TestSuperClas
 	// Test Position Rate
 	// ==========================================================================
 
-	// Apply force on 1st body in the X direction also the Axis direction
+	// Apply force on 1st body in the X direction that also is the axis direction
 	//
 	//  X------->       X---------> Axis -->
 	//  B1  F->      =>     B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B1_At_Zero_Axis_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B1_At_Zero_Axis_Inverse_of_X.java
@@ -51,7 +51,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
  * Only body 1
- * The body are positionned at (0, 0, 0), with no rotation
+ * The body is positioned at (0, 0, 0) with no rotation
  * The joint is a Piston Joint
  * Axis is in the oppsite X axis
  * Anchor at (0, 0, 0)
@@ -156,7 +156,7 @@ public class Fixture_dxJointPiston_B1_At_Zero_Axis_Inverse_of_X extends TestSupe
 	// Test Position Rate
 	// ==========================================================================
 
-	// Apply force on 1st body in the X direction also the Axis direction
+	// Apply force on 1st body in the X direction that also is the axis direction
 	//
 	//  X------->       X---------> <-- Axis
 	//  B1  F->      =>     B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B1_and_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B1_and_B2_At_Zero_Axis_Along_X.java
@@ -50,7 +50,7 @@ import org.ode4j.ode.internal.joints.DxJointPiston;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
- * The 2 bodies are positionned at (0, 0, 0), with no rotation
+ * The 2 bodies are positioned at (0, 0, 0) with no rotation
  * The joint is a Piston Joint
  * Axis is along the X axis
  * Anchor at (0, 0, 0)
@@ -229,7 +229,7 @@ public class Fixture_dxJointPiston_B1_and_B2_At_Zero_Axis_Along_X extends TestSu
 	// Test Position Rate
 	// ==========================================================================
 
-	// Apply force on 1st body in the X direction also the Axis direction
+	// Apply force on 1st body in the X direction that also is the axis direction
 	//
 	//  X------->       X---------> Axis -->
 	//  B1  F->      =>     B1
@@ -264,7 +264,7 @@ public class Fixture_dxJointPiston_B1_and_B2_At_Zero_Axis_Along_X extends TestSu
 	}
 
 
-	// Apply force on 1st body in the X direction also the Axis direction
+	// Apply force on 1st body in the X direction that also is the axis direction
 	//
 	//  X------->       X---------> Axis -->
 	//  B1          =>  B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B1_and_B2_At_Zero_Axis_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B1_and_B2_At_Zero_Axis_Inverse_of_X.java
@@ -224,7 +224,7 @@ public class Fixture_dxJointPiston_B1_and_B2_At_Zero_Axis_Inverse_of_X extends T
 	// Test Position Rate
 	// ==========================================================================
 
-	// Apply force on 1st body in the X direction also the Axis direction
+	// Apply force on 1st body in the X direction that also is the axis direction
 	//
 	//  X------->       X---------> <-- Axis
 	//  B1  F->      =>     B1
@@ -258,7 +258,7 @@ public class Fixture_dxJointPiston_B1_and_B2_At_Zero_Axis_Inverse_of_X extends T
 		CHECK_CLOSE (1, dJointGetPistonPositionRate (jId), 1e-4);
 	}
 
-	// Apply force on 1st body in the X direction also the Axis direction
+	// Apply force on 1st body in the X direction that also is the axis direction
 	//
 	//  X------->       X---------> <-- Axis
 	//  B1          =>  B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B2_At_Zero_Axis_Along_X.java
@@ -51,7 +51,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
  * Only body 2
- * The body are positionned at (0, 0, 0), with no rotation
+ * The body is positioned at (0, 0, 0) with no rotation
  * The joint is a Piston Joint
  * Axis is along the X axis
  * Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B2_At_Zero_Axis_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_B2_At_Zero_Axis_Inverse_of_X.java
@@ -51,7 +51,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 /**
  * Only body 2
- * The body are positionned at (0, 0, 0), with no rotation
+ * The body is positioned at (0, 0, 0) with no rotation
  * The joint is a Piston Joint
  * Axis is in the opposite X axis
  * Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_Compare_Body_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointPiston_Compare_Body_At_Zero_Axis_Along_X.java
@@ -55,7 +55,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 /**
  * Compare only one body to 2 bodies with one fixed.
  * 
- * The body are positionned at (0, 0, 0), with no rotation
+ * The body is positioned at (0, 0, 0) with no rotation
  * The joint is a Piston Joint
  * Axis is along the X axis
  * Anchor at (0, 0, 0)
@@ -111,11 +111,11 @@ public class Fixture_dxJointPiston_Compare_Body_At_Zero_Axis_Along_X extends Tes
 	private DPistonJoint jId;    // Joint with one body
 	//    };
 
-	// This test compare the result of a slider with 2 bodies where body body 2 is
+	// This test compares the result of a slider with 2 bodies where body 2 is
 	// fixed to the world to a slider with only one body at position 1.
 	//
-	// Test the limits [-1, 0.25] when only one body at is attached to the joint
-	// using dJointAttache(jId, bId, 0);
+	// Test the limits [-1, 0.25] when only one body is attached to the joint
+	// using dJointAttach(jId, bId, 0);
 	//
 	//TEST_FIXTURE(Fixture_dxJointPiston_Compare_Body_At_Zero_Axis_Along_X,
 	@Test public void test_Limit_minus1_025_One_Body_on_left()
@@ -156,11 +156,11 @@ public class Fixture_dxJointPiston_Compare_Body_At_Zero_Axis_Along_X extends Tes
 
 
 
-	// This test compare the result of a slider with 2 bodies where body body 1 is
+	// This test compares the result of a slider with 2 bodies where body 1 is
 	// fixed to the world to a slider with only one body at position 2.
 	//
-	// Test the limits [-1, 0.25] when only one body at is attached to the joint
-	// using dJointAttache(jId, 0, bId);
+	// Test the limits [-1, 0.25] when only one body is attached to the joint
+	// using dJointAttach(jId, 0, bId);
 	//
 	//TEST_FIXTURE(Fixture_dxJointPiston_Compare_Body_At_Zero_Axis_Along_X,
 	@Test public void test_Limit_minus1_025_One_Body_on_right()
@@ -202,11 +202,11 @@ public class Fixture_dxJointPiston_Compare_Body_At_Zero_Axis_Along_X extends Tes
 
 
 
-	// This test compare the result of a slider with 2 bodies where body body 2 is
+	// This test compares the result of a slider with 2 bodies where body 2 is
 	// fixed to the world to a slider with only one body at position 1.
 	//
-	// Test the limits [0, 0] when only one body at is attached to the joint
-	// using dJointAttache(jId, bId, 0);
+	// Test the limits [0, 0] when only one body is attached to the joint
+	// using dJointAttach(jId, bId, 0);
 	//
 	// The body should not move since their is no room between the two limits
 	//
@@ -253,11 +253,11 @@ public class Fixture_dxJointPiston_Compare_Body_At_Zero_Axis_Along_X extends Tes
 	}
 
 
-	// This test compare the result of a slider with 2 bodies where body body 1 is
+	// This test compares the result of a slider with 2 bodies where body 1 is
 	// fixed to the world to a slider with only one body at position 2.
 	//
-	// Test the limits [0, 0] when only one body at is attached to the joint
-	// using dJointAttache(jId, 0, bId);
+	// Test the limits [0, 0] when only one body is attached to the joint
+	// using dJointAttach(jId, 0, bId);
 	//
 	// The body should not move since their is no room between the two limits
 	//

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_At_Zero_Axis_Along_X.java
@@ -44,7 +44,7 @@ import org.ode4j.ode.internal.joints.DxJointSlider;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Only body 1
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a Slider Joint
 // Axis is along the X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_At_Zero_Axis_Along_X2.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_At_Zero_Axis_Along_X2.java
@@ -32,11 +32,11 @@ import static org.ode4j.tests.UnitTestPlusPlus.CheckMacros.CHECK_CLOSE;
 
 import org.junit.Test;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joinst/slider.cpp
 public class Fixture_dxJointSlider_B1_At_Zero_Axis_Along_X2
   extends Fixture_dxJointSlider_B1_At_Zero_Axis_Along_X {
-  // Apply force on 1st body in the X direction also the Axis direction
+  // Apply force on 1st body in the X direction that also is the axis direction
   //
   //  X------->       X---------> Axis -->
   //  B1  F->      =>     B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_At_Zero_Axis_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_At_Zero_Axis_Inverse_of_X.java
@@ -44,7 +44,7 @@ import org.ode4j.ode.internal.joints.DxJointSlider;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Only body 1
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a Slider Joint
 // Axis is in the oppsite X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_At_Zero_Axis_Inverse_of_X2.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_At_Zero_Axis_Inverse_of_X2.java
@@ -32,11 +32,11 @@ import static org.ode4j.tests.UnitTestPlusPlus.CheckMacros.CHECK_CLOSE;
 
 import org.junit.Test;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joinst/slider.cpp
 public class Fixture_dxJointSlider_B1_At_Zero_Axis_Inverse_of_X2
   extends Fixture_dxJointSlider_B1_At_Zero_Axis_Inverse_of_X {
-  // Apply force on 1st body in the X direction also the Axis direction
+  // Apply force on 1st body in the X direction that also is the axis direction
   //
   //  X------->       X---------> <-- Axis
   //  B1  F->      =>     B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X.java
@@ -43,7 +43,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointSlider;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
-// The 2 bodies are positionned at (0, 0, 0), with no rotation
+// The 2 bodies are positioned at (0, 0, 0) with no rotation
 // The joint is a Slider Joint
 // Axis is along the X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X2.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X2.java
@@ -32,11 +32,11 @@ import static org.ode4j.tests.UnitTestPlusPlus.CheckMacros.CHECK_CLOSE;
 
 import org.junit.Test;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joinst/slider.cpp
 public class Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X2
   extends Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X {
-  // Apply force on 1st body in the X direction also the Axis direction
+  // Apply force on 1st body in the X direction that also is the axis direction
   //
   //  X------->       X---------> Axis -->
   //  B1  F->      =>     B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X3.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X3.java
@@ -32,11 +32,11 @@ import static org.ode4j.tests.UnitTestPlusPlus.CheckMacros.CHECK_CLOSE;
 
 import org.junit.Test;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joinst/slider.cpp
 public class Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X3
   extends Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Along_X {
-  // Apply force on 1st body in the X direction also the Axis direction
+  // Apply force on 1st body in the X direction that also is the axis direction
   //
   //  X------->       X---------> Axis -->
   //  B1          =>  B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X.java
@@ -43,7 +43,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointSlider;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
-// The 2 bodies are positionned at (0, 0, 0), with no rotation
+// The 2 bodies are positioned at (0, 0, 0) with no rotation
 // The joint is a Slider Joint
 // Axis is the opposite of the X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X2.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X2.java
@@ -32,12 +32,12 @@ import static org.ode4j.tests.UnitTestPlusPlus.CheckMacros.CHECK_CLOSE;
 
 import org.junit.Test;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joinst/slider.cpp
 public class Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X2
   extends Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X {
 
-  // Apply force on 1st body in the X direction also the Axis direction
+  // Apply force on 1st body in the X direction that also is the axis direction
   //
   //  X------->       X---------> <-- Axis
   //  B1  F->      =>     B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X3.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X3.java
@@ -32,11 +32,11 @@ import static org.ode4j.tests.UnitTestPlusPlus.CheckMacros.CHECK_CLOSE;
 
 import org.junit.Test;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joinst/slider.cpp
 public class Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X3
   extends Fixture_dxJointSlider_B1_and_B2_At_Zero_Axis_Inverse_of_X {
-  // Apply force on 1st body in the X direction also the Axis direction
+  // Apply force on 1st body in the X direction that also is the axis direction
   //
   //  X------->       X---------> <-- Axis
   //  B1          =>  B1

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B2_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B2_At_Zero_Axis_Along_X.java
@@ -44,7 +44,7 @@ import org.ode4j.ode.internal.joints.DxJointSlider;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Only body 2
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a Slider Joint
 // Axis is along the X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B2_At_Zero_Axis_Along_X2.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B2_At_Zero_Axis_Along_X2.java
@@ -32,7 +32,7 @@ import static org.ode4j.tests.UnitTestPlusPlus.CheckMacros.CHECK_CLOSE;
 
 import org.junit.Test;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joinst/slider.cpp
 public class Fixture_dxJointSlider_B2_At_Zero_Axis_Along_X2
   extends Fixture_dxJointSlider_B2_At_Zero_Axis_Along_X {

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B2_At_Zero_Axis_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B2_At_Zero_Axis_Inverse_of_X.java
@@ -44,7 +44,7 @@ import org.ode4j.ode.internal.joints.DxJointSlider;
 import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Only body 2
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a Slider Joint
 // Axis is in the oppsite X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B2_At_Zero_Axis_Inverse_of_X2.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_B2_At_Zero_Axis_Inverse_of_X2.java
@@ -32,7 +32,7 @@ import static org.ode4j.tests.UnitTestPlusPlus.CheckMacros.CHECK_CLOSE;
 
 import org.junit.Test;
 
-//This file create unit test for some of the functions found in:
+//This file creates unit tests for some of the functions found in:
 //ode/src/joinst/slider.cpp
 public class Fixture_dxJointSlider_B2_At_Zero_Axis_Inverse_of_X2
   extends Fixture_dxJointSlider_B2_At_Zero_Axis_Inverse_of_X {

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_Compare_Body_At_Zero_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointSlider_Compare_Body_At_Zero_Axis_Along_X.java
@@ -52,7 +52,7 @@ import org.ode4j.tests.UnitTestPlusPlus.TestSuperClass;
 
 // Compare Only body 1 to 2 bodies with one fixed.
 //
-// The body are positionned at (0, 0, 0), with no rotation
+// The body is positioned at (0, 0, 0) with no rotation
 // The joint is a Slider Joint
 // Axis is along the X axis
 // Anchor at (0, 0, 0)
@@ -107,11 +107,11 @@ public class Fixture_dxJointSlider_Compare_Body_At_Zero_Axis_Along_X extends Tes
       private DSliderJoint jId;    // Joint with one body
 //  };
 
-  // This test compare the result of a slider with 2 bodies where body body 2 is
+  // This test compares the result of a slider with 2 bodies where body 2 is
   // fixed to the world to a slider with only one body at position 1.
   //
-  // Test the limits [-1, 0.25] when only one body at is attached to the joint
-  // using dJointAttache(jId, bId, 0);
+  // Test the limits [-1, 0.25] when only one body is attached to the joint
+  // using dJointAttach(jId, bId, 0);
   //
   //TEST_FIXTURE(Fixture_dxJointSlider_Compare_Body_At_Zero_Axis_Along_X,
   @Test public void test_Limit_minus1_025_One_Body_on_left()
@@ -145,11 +145,11 @@ public class Fixture_dxJointSlider_Compare_Body_At_Zero_Axis_Along_X extends Tes
 
 
 
-  // This test compare the result of a slider with 2 bodies where body body 1 is
+  // This test compares the result of a slider with 2 bodies where body 1 is
   // fixed to the world to a slider with only one body at position 2.
   //
-  // Test the limits [-1, 0.25] when only one body at is attached to the joint
-  // using dJointAttache(jId, 0, bId);
+  // Test the limits [-1, 0.25] when only one body is attached to the joint
+  // using dJointAttach(jId, 0, bId);
   //
   //TEST_FIXTURE(Fixture_dxJointSlider_Compare_Body_At_Zero_Axis_Along_X,
   @Test public void test_Limit_minus1_025_One_Body_on_right()
@@ -185,11 +185,11 @@ public class Fixture_dxJointSlider_Compare_Body_At_Zero_Axis_Along_X extends Tes
 
 
 
-  // This test compare the result of a slider with 2 bodies where body body 2 is
+  // This test compares the result of a slider with 2 bodies where body 2 is
   // fixed to the world to a slider with only one body at position 1.
   //
-  // Test the limits [0, 0] when only one body at is attached to the joint
-  // using dJointAttache(jId, bId, 0);
+  // Test the limits [0, 0] when only one body is attached to the joint
+  // using dJointAttach(jId, bId, 0);
   //
   // The body should not move since their is no room between the two limits
   //
@@ -228,11 +228,11 @@ public class Fixture_dxJointSlider_Compare_Body_At_Zero_Axis_Along_X extends Tes
   }
 
 
-  // This test compare the result of a slider with 2 bodies where body body 1 is
+  // This test compares the result of a slider with 2 bodies where body 1 is
   // fixed to the world to a slider with only one body at position 2.
   //
-  // Test the limits [0, 0] when only one body at is attached to the joint
-  // using dJointAttache(jId, 0, bId);
+  // Test the limits [0, 0] when only one body is attached to the joint
+  // using dJointAttach(jId, 0, bId);
   //
   // The body should not move since their is no room between the two limits
   //

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointUniversal_B1_and_B2_At_Random_Axis_Along_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointUniversal_B1_and_B2_At_Random_Axis_Along_X.java
@@ -51,8 +51,8 @@ import org.ode4j.ode.DUniversalJoint;
 import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.joints.DxJointUniversal;
 
-// The 2 bodies are positionned at (-1, -2, -3),  and (11, 22, 33)
-// The bodis have rotation of 27deg around some axis.
+// The 2 bodies are positioned at (-1, -2, -3), and (11, 22, 33)
+// The bodies have rotation of 27deg around some axis.
 // The joint is a Universal Joint
 // Axis is along the X axis
 // Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointUniversal_B1_and_B2_At_Zero_Axis1_Along_X_Axis2_Along_Y.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointUniversal_B1_and_B2_At_Zero_Axis1_Along_X_Axis2_Along_Y.java
@@ -56,8 +56,8 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.cpp4j.java.RefDouble;
 import org.ode4j.ode.internal.joints.DxJointUniversal;
 
-// The 2 bodies are positionned at (0, 0, 0)
-// The bodis have no rotation.
+// The 2 bodies are positioned at (0, 0, 0)
+// The bodies have no rotation.
 // The joint is a Universal Joint
 // Axis1 is along the X axis
 // Axis2 is along the Y axis
@@ -654,7 +654,7 @@ public class Fixture_dxJointUniversal_B1_and_B2_At_Zero_Axis1_Along_X_Axis2_Alon
 
 	// Rotate 1st body 0.23rad around X axis and 2nd body 0.37rad around Y (Axis2)
 	// then back to their original position.
-	// The Axis offset are set one at a time
+	// The Axis offsets are set one at a time
 	//
 	//    ^  ^    ^         ^          Z ^   ^ Y (N.B. Y is going in the screen)
 	//    |  |  => \      /             |  /

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointUniversal_B1_and_B2_At_Zero_Axis1_Inverse_of_X.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointUniversal_B1_and_B2_At_Zero_Axis1_Inverse_of_X.java
@@ -55,7 +55,7 @@ import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.cpp4j.java.RefDouble;
 import org.ode4j.ode.internal.joints.DxJointUniversal;
 
-//  The 2 bodies are positionned at (0, 0, 0), with no rotation
+//  The 2 bodies are positioned at (0, 0, 0) with no rotation
 //  The joint is an Universal Joint.
 //  Axis in the inverse direction of the X axis
 //  Anchor at (0, 0, 0)

--- a/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointUniversal_B1_and_B2_Axis_Random.java
+++ b/core-cpp/src/test/java/org/ode4j/tests/joints/Fixture_dxJointUniversal_B1_and_B2_Axis_Random.java
@@ -53,8 +53,8 @@ import org.ode4j.ode.DUniversalJoint;
 import org.ode4j.ode.DWorld;
 import org.ode4j.ode.internal.cpp4j.java.RefDouble;
 
-// The 2 bodies are positionned at (0,0,0),  and (0,0,0)
-// The bodis have no rotation.
+// The 2 bodies are positioned at (0,0,0) and (0,0,0)
+// The bodies have no rotation.
 // The joint is a Universal Joint
 // The axis of the joint are at random (Still at 90deg w.r.t each other)
 // Anchor at (0, 0, 0)

--- a/core/LIB_CCD_README
+++ b/core/LIB_CCD_README
@@ -27,7 +27,7 @@ Compile And Install
 Simply type 'make' and 'make install' in src/ directory.
 
 Library libccd is by default compiled in double precision of floating point
-numbers - you can controll this by options USE_SINGLE/USE_DOUBLE, i.e.:
+numbers - you can control this by options USE_SINGLE/USE_DOUBLE, i.e.:
     $ make USE_SINGLE=yes
 will compile library in single precision.
 

--- a/core/src/main/java/org/ode4j/ode/DBody.java
+++ b/core/src/main/java/org/ode4j/ode/DBody.java
@@ -608,7 +608,7 @@ public interface DBody {
 	 * Sets the finite rotation axis for a body.
 	 * 
 	 * <p>REMARK:
-	 * This is axis only has meaning when the finite rotation mode is set
+	 * This axis only has meaning when the finite rotation mode is set
 	 * If this axis is zero (0,0,0), full finite rotations are performed on
 	 * the body.
 	 * If this axis is nonzero, the body is rotated by performing a partial finite
@@ -629,7 +629,7 @@ public interface DBody {
 	 * Sets the finite rotation axis for a body.
 	 * 
 	 * <p>REMARK:
-	 * This is axis only has meaning when the finite rotation mode is set
+	 * This axis only has meaning when the finite rotation mode is set
 	 * If this axis is zero (0,0,0), full finite rotations are performed on
 	 * the body.
 	 * If this axis is nonzero, the body is rotated by performing a partial finite
@@ -647,7 +647,7 @@ public interface DBody {
 
 	/**
 	 * Get the way a body's orientation is updated each timestep.
-	 * @return the mode 0 (infitesimal) or 1 (finite).
+	 * @return the mode 0 (infinitesimal) or 1 (finite).
 	 */
 	boolean getFiniteRotationMode();
 	/**
@@ -663,7 +663,7 @@ public interface DBody {
 	int getNumJoints();
 	/**
 	 * Return a joint attached to this body, given by index.
-	 * @param index valid range is  0 to n-1 where n is the value returned by
+	 * @param index valid range is 0 to n-1 where n is the value returned by
 	 * dBodyGetNumJoints().
 	 * @return Joint object
 	 */

--- a/core/src/main/java/org/ode4j/ode/DContact.java
+++ b/core/src/main/java/org/ode4j/ode/DContact.java
@@ -60,6 +60,8 @@ public class DContact {
 		public double motion1,motion2,motionN;
 		public double slip1;
 		public double slip2;
+		/** Inward force limit (zero or a negative number up to -dInfinity) */
+		public double inward_force_limit;
 
 		public DSurfaceParameters() {}
 

--- a/core/src/main/java/org/ode4j/ode/DGeom.java
+++ b/core/src/main/java/org/ode4j/ode/DGeom.java
@@ -423,7 +423,7 @@ public interface DGeom {
 	    /**
 	     * @param data The user data object, as passed to dSpaceCollide.
 	     * @param o1   The first geom being tested.
-	     * @param o2   The second geom being test.
+	     * @param o2   The second geom being tested.
 	     */
 		public void call (Object data, DGeom o1, DGeom o2);
 	}
@@ -471,7 +471,7 @@ public interface DGeom {
 //	 * dGeomCommonAnyControlCode applies to any control class and returns success if 
 //	 * at least one control code is available for the given class with given geom.
 //	 * <br>
-//	 * Currently there are the folliwing control classes supported:<br>
+//	 * Currently there are the following control classes supported:<br>
 //	 * <li> dGeomColliderControlClass</li>
 //	 * <p>
 //	 * For dGeomColliderControlClass there are the following codes available:<br>

--- a/core/src/main/java/org/ode4j/ode/DMass.java
+++ b/core/src/main/java/org/ode4j/ode/DMass.java
@@ -144,7 +144,7 @@ public interface DMass extends DMassC {
 	
 	//	/**
 //	 * Check if a mass structure has valid value.
-//	 * The function check if the mass and innertia matrix are positive definits
+//	 * The function check if the mass and inertia matrix are positive definits
 //	 *
 //	 * @param m A mass structure to check
 //	 *

--- a/core/src/main/java/org/ode4j/ode/DPUJoint.java
+++ b/core/src/main/java/org/ode4j/ode/DPUJoint.java
@@ -212,18 +212,6 @@ public interface DPUJoint extends DJoint {
 	 */
 	double getPositionRate();
 
-	//	/**
-	//	 * Applies torque about the rotoide axes of the PU joint.
-	//	 *
-	//	 * <p> </p>That is, it applies torque1 about the universal axis 1 and torque2 about the
-	//	 * universal axis 2 to body 1, and with the same magnitude but in opposite
-	//	 * direction to body 2.
-	//	 * <p>REMARKS: This function is just a wrapper for dBodyAddTorque().
-	//	 */
-	//  TODO there is no implementation. Use dBodyAddTorque???? Or leave unimplemented?
-	//	void addTorque (dReal torque1, dReal torque2);
-
-
 	/**
 	 * Set the PU anchor as if the 2 bodies were already at [dx, dy, dz] apart.
 	 * <p>
@@ -273,5 +261,16 @@ public interface DPUJoint extends DJoint {
 	 */
 	@Override
 	double getParam (PARAM_N parameter);
+
+	/**
+	 * Applies torques about the rotoide axes of PU joint
+	 * <p>
+	 * That is, it applies torque1 about the universal axis 1 and torque2 about the
+	 * universal axis 2 to body 1, and with the same magnitude but in opposite
+	 * direction to body 2.
+	 * <p>
+	 * <b>REMARKS:</b> This function is just a wrapper for {@link DBody#addTorque(DVector3C)}.
+	 */
+	void addTorques (double torque1, double torque2);
 
 }

--- a/core/src/main/java/org/ode4j/ode/DPUJoint.java
+++ b/core/src/main/java/org/ode4j/ode/DPUJoint.java
@@ -212,21 +212,22 @@ public interface DPUJoint extends DJoint {
 	 */
 	double getPositionRate();
 
-//	/**
-//	 * Applies the torque about the rotoide axis of the PU joint.
-//	 *
-//	 * That is, it applies a torque with specified magnitude in the direction
-//	 * of the rotoide axis, to body 1, and with the same magnitude but in opposite
-//	 * direction to body 2. This function is just a wrapper for dBodyAddTorque()}
-//	 */
-//  TODO there is no implementation. Use dBodyAddTorque???? Or leave unimplemented?
-//	void addTorque (double torque);
+	//	/**
+	//	 * Applies torque about the rotoide axes of the PU joint.
+	//	 *
+	//	 * <p> </p>That is, it applies torque1 about the universal axis 1 and torque2 about the
+	//	 * universal axis 2 to body 1, and with the same magnitude but in opposite
+	//	 * direction to body 2.
+	//	 * <p>REMARKS: This function is just a wrapper for dBodyAddTorque().
+	//	 */
+	//  TODO there is no implementation. Use dBodyAddTorque???? Or leave unimplemented?
+	//	void addTorque (dReal torque1, dReal torque2);
 
 
 	/**
 	 * Set the PU anchor as if the 2 bodies were already at [dx, dy, dz] apart.
 	 * <p>
-	 * This function initialize the anchor and the relative position of each body
+	 * This function initializes the anchor and the relative position of each body
 	 * as if the position between body1 and body2 was already the projection of [dx, dy, dz]
 	 * along the Piston axis. (i.e as if the body1 was at its current position - [dx,dy,dy] when the
 	 * axis is set).

--- a/core/src/main/java/org/ode4j/ode/DPistonJoint.java
+++ b/core/src/main/java/org/ode4j/ode/DPistonJoint.java
@@ -120,7 +120,7 @@ public interface DPistonJoint extends DJoint {
 	/**
 	 * Set the Piston anchor as if the 2 bodies were already at [dx,dy, dz] apart.
 	 * <p>
-	 * This function initialize the anchor and the relative position of each body
+	 * This function initializes the anchor and the relative position of each body
 	 * as if the position between body1 and body2 was already the projection of [dx, dy, dz]
 	 * along the Piston axis. (i.e as if the body1 was at its current position - [dx,dy,dy] when the
 	 * axis is set).
@@ -201,7 +201,7 @@ public interface DPistonJoint extends DJoint {
 
 	
 	/**
-	 * Get the Piston angular position (i.e. the  twist between the 2 bodies).
+	 * Get the Piston angular position (i.e. the twist between the 2 bodies).
 	 * <p>
 	 * When the axis is set, the current position of the attached bodies is
 	 * examined and that position will be the zero position.

--- a/core/src/main/java/org/ode4j/ode/DUniversalJoint.java
+++ b/core/src/main/java/org/ode4j/ode/DUniversalJoint.java
@@ -169,7 +169,7 @@ public interface DUniversalJoint extends DJoint {
 	 * Set the Universal axis1 as if the 2 bodies were already at 
 	 *        offset1 and offset2 appart with respect to axis1 and axis2.
 	 * <p>
-	 * This function initialize the axis1 and the relative orientation of 
+	 * This function initializes the axis1 and the relative orientation of
 	 * each body as if body1 was rotated around the new axis1 by the offset1 
 	 * value and as if body2 was rotated around the axis2 by offset2. <p>
 	 * Ex: <br>

--- a/core/src/main/java/org/ode4j/ode/DWorld.java
+++ b/core/src/main/java/org/ode4j/ode/DWorld.java
@@ -28,6 +28,8 @@ import org.ode4j.math.DVector3;
 import org.ode4j.math.DVector3C;
 import org.ode4j.ode.threading.task.TaskExecutor;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  * The world object is a container for rigid bodies and joints. Objects in
  * different worlds can not interact, for example rigid bodies from two
@@ -437,67 +439,67 @@ public interface DWorld {
 	//	#define dWORLDQUICKSTEP_EXTRA_ITERATION_REQUIREMENT_DELTA_DEFAULT   1e-2f
 	double dWORLDQUICKSTEP_EXTRA_ITERATION_REQUIREMENT_DELTA_DEFAULT = 1e-2f;
 
-	/**
-	 * Configure QuickStep method dynamic iteration count adjustment.
-	 *
-	 * <p> REMARK: The function controls dynamic iteration count adjustment basing on maximal contact force change
-	 * per iteration in matrix.
-	 *
-	 * <p>If Premature Exit Delta is configured with {@code ptr_iteration_premature_exit_delta}
-	 * and the maximal contact force adjustment does not exceed the value the iterations are abandoned
-	 * prematurely and computations complete in fewer steps than it would take normally.
-	 * Passing zero in {@code ptr_iteration_premature_exit_delta} will disable the premature exit and enforce
-	 * unconditional execution of iteration count set by {@link #setQuickStepNumIterations(int)}.
-	 *
-	 * <p>If extra iterations are enabled by passing  a positive fraction in {@code ptr_max_num_extra_factor}
-	 * and, after the normal number of iterations is executed, the maximal contact force adjustment is still
-	 * larger than the limit set with the {@code ptr_extra_iteration_requirement_delta}, up to that fraction of
-	 * normal iteration count is executed extra until the maximal contact force change falls below the margin.
-	 *
-	 * <p>At least one parameter must be not NULL for the call.
-	 * If NULL is passed for any of the parameters the corresponding parameter will retain its previous value.
-	 * If the standard number of iterations is changed with {@link #setQuickStepNumIterations(int)} call and
-	 * an extra iteration count was configured with {@code ptr_max_num_extra_factor} the extra absolute value will be
-	 * adjusted accordingly.
-	 *
-	 * @param ptr_iteration_premature_exit_delta A margin value such that, if contact force adjustment value maximum in an iteration
-	 * becomes less, the method is allowed to terminate prematurely.
-	 * @param ptr_max_num_extra_factor A non-negative coefficient that defines fraction of the standard iteration count to be executed extra
-	 * if contact force still significantly changes after the standard iterations complete.
-	 * @param ptr_extra_iteration_requirement_delta A margin that defines when the extra iterations are not needed or can be abandoned after
-	 * the start.
-	 * @see #getQuickStepDynamicIterationParameters(double[], double[], double[])
-	 */
-	//		ODE_API void dWorldSetQuickStepDynamicIterationParameters(dWorldID w, const dReal *ptr_iteration_premature_exit_delta/*=NULL*/,
-	//		const dReal *ptr_max_num_extra_factor/*=NULL*/, const dReal *ptr_extra_iteration_requirement_delta/*=NULL*/);
-	void setQuickStepDynamicIterationParameters(final double[] ptr_iteration_premature_exit_delta/*=NULL*/,
-		final double[] ptr_max_num_extra_factor/*=NULL*/, final double[] ptr_extra_iteration_requirement_delta/*=NULL*/);
+	//	/**
+	//	 * Configure QuickStep method dynamic iteration count adjustment.
+	//	 *
+	//	 * <p> REMARK: The function controls dynamic iteration count adjustment basing on maximal contact force change
+	//	 * per iteration in matrix.
+	//	 *
+	//	 * <p>If Premature Exit Delta is configured with {@code ptr_iteration_premature_exit_delta}
+	//	 * and the maximal contact force adjustment does not exceed the value the iterations are abandoned
+	//	 * prematurely and computations complete in fewer steps than it would take normally.
+	//	 * Passing zero in {@code ptr_iteration_premature_exit_delta} will disable the premature exit and enforce
+	//	 * unconditional execution of iteration count set by {@link #setQuickStepNumIterations(int)}.
+	//	 *
+	//	 * <p>If extra iterations are enabled by passing  a positive fraction in {@code ptr_max_num_extra_factor}
+	//	 * and, after the normal number of iterations is executed, the maximal contact force adjustment is still
+	//	 * larger than the limit set with the {@code ptr_extra_iteration_requirement_delta}, up to that fraction of
+	//	 * normal iteration count is executed extra until the maximal contact force change falls below the margin.
+	//	 *
+	//	 * <p>At least one parameter must be not NULL for the call.
+	//	 * If NULL is passed for any of the parameters the corresponding parameter will retain its previous value.
+	//	 * If the standard number of iterations is changed with {@link #setQuickStepNumIterations(int)} call and
+	//	 * an extra iteration count was configured with {@code ptr_max_num_extra_factor} the extra absolute value will be
+	//	 * adjusted accordingly.
+	//	 *
+	//	 * @param ptr_iteration_premature_exit_delta A margin value such that, if contact force adjustment value maximum in an iteration
+	//	 * becomes less, the method is allowed to terminate prematurely.
+	//	 * @param ptr_max_num_extra_factor A non-negative coefficient that defines fraction of the standard iteration count to be executed extra
+	//	 * if contact force still significantly changes after the standard iterations complete.
+	//	 * @param ptr_extra_iteration_requirement_delta A margin that defines when the extra iterations are not needed or can be abandoned after
+	//	 * the start.
+	//	 * @see #getQuickStepDynamicIterationParameters(double[], double[], double[])
+	//	 */
+	//	//		ODE_API void dWorldSetQuickStepDynamicIterationParameters(dWorldID w, const dReal *ptr_iteration_premature_exit_delta/*=NULL*/,
+	//	//		const dReal *ptr_max_num_extra_factor/*=NULL*/, const dReal *ptr_extra_iteration_requirement_delta/*=NULL*/);
+	//	void setQuickStepDynamicIterationParameters(final double[] ptr_iteration_premature_exit_delta/*=NULL*/,
+	//		final double[] ptr_max_num_extra_factor/*=NULL*/, final double[] ptr_extra_iteration_requirement_delta/*=NULL*/);
 
 
-	/**
-	 * Retrieve QuickStep method dynamic iteration count adjustment parameters.
-	 *
-	 * <p>REMARK: The function retrieves dynamic iteration count adjustment parameters.
-	 *
-	 * <p>See {@link #setQuickStepDynamicIterationParameters(double[], double[], double[])} for the parameters description.
-	 *
-	 * <p>At least one parameter must be not NULL for the call.
-	 *
-	 * @param out_iteration_premature_exit_delta Premature Exit Delta value (can be NULL if the value is not needed).
-	 * @param out_max_num_extra_factor Maximum Extra Iteration Number Factor value (can be NULL if the value is not needed).
-	 * @param out_extra_iteration_requirement_delta Extra Iteration Requirement Delta value (can be NULL if the value is not needed).
-	 * @see #setQuickStepDynamicIterationParameters(double[], double[], double[])
-	 */
-	//		ODE_API void dWorldGetQuickStepDynamicIterationParameters(dWorldID w, dReal *out_iteration_premature_exit_delta/*=NULL*/,
-	//																  dReal *out_max_num_extra_factor/*=NULL*/, dReal *out_extra_iteration_requirement_delta/*=NULL*/);
-	void getQuickStepDynamicIterationParameters(double[] out_iteration_premature_exit_delta/*=NULL*/,
-											    double[] out_max_num_extra_factor/*=NULL*/, double[] out_extra_iteration_requirement_delta/*=NULL*/);
+	//	/**
+	//	 * Retrieve QuickStep method dynamic iteration count adjustment parameters.
+	//	 *
+	//	 * <p>REMARK: The function retrieves dynamic iteration count adjustment parameters.
+	//	 *
+	//	 * <p>See {@link #setQuickStepDynamicIterationParameters(double[], double[], double[])} for the parameters description.
+	//	 *
+	//	 * <p>At least one parameter must be not NULL for the call.
+	//	 *
+	//	 * @param out_iteration_premature_exit_delta Premature Exit Delta value (can be NULL if the value is not needed).
+	//	 * @param out_max_num_extra_factor Maximum Extra Iteration Number Factor value (can be NULL if the value is not needed).
+	//	 * @param out_extra_iteration_requirement_delta Extra Iteration Requirement Delta value (can be NULL if the value is not needed).
+	//	 * @see #setQuickStepDynamicIterationParameters(double[], double[], double[])
+	//	 */
+	//	//		ODE_API void dWorldGetQuickStepDynamicIterationParameters(dWorldID w, dReal *out_iteration_premature_exit_delta/*=NULL*/,
+	//	//																  dReal *out_max_num_extra_factor/*=NULL*/, dReal *out_extra_iteration_requirement_delta/*=NULL*/);
+	//	void getQuickStepDynamicIterationParameters(double[] out_iteration_premature_exit_delta/*=NULL*/,
+	//											    double[] out_max_num_extra_factor/*=NULL*/, double[] out_extra_iteration_requirement_delta/*=NULL*/);
 
 
 	/**
 	 * Statistics structure to accumulate QuickStep iteration couunt dynamic adjustment data.
 	 *
-	 * @see #attachQuickStepDynamicIterationStatisticsSink
+//	 * @see #attachQuickStepDynamicIterationStatisticsSink
 	 */
 	class dWorldQuickStepIterationCount_DynamicAdjustmentStatistics
 	{
@@ -511,18 +513,18 @@ public interface DWorld {
 		@Deprecated
 		int struct_size;         /*< to be initialized with the structure size */
 
-		int iteration_count;      /*< number of iterations executed */
+		public final AtomicInteger iteration_count = new AtomicInteger();      /*< number of iterations executed */
 
-		int premature_exits;      /*< number of times solution took fewer than the regular iteration count */
-		int prolonged_execs;      /*< number of times solution took more  than the regular iteration count */
-		int full_extra_execs;     /*< number of times the assigned exit criteria were not achieved even after all extra iterations allowed */
+		public final AtomicInteger premature_exits = new AtomicInteger();      /*< number of times solution took fewer than the regular iteration count */
+		public final AtomicInteger prolonged_execs = new AtomicInteger();      /*< number of times solution took more  than the regular iteration count */
+		public final AtomicInteger full_extra_execs = new AtomicInteger();     /*< number of times the assigned exit criteria were not achieved even after all extra iterations allowed */
 
 		public void set(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics other) {
 			struct_size = other.struct_size;
-			iteration_count = other.iteration_count;
-			premature_exits = other.premature_exits;
-			prolonged_execs = other.prolonged_execs;
-			full_extra_execs = other.full_extra_execs;
+			iteration_count.set(other.iteration_count.get());
+			premature_exits.set(other.premature_exits.get());
+			prolonged_execs.set(other.prolonged_execs.get());
+			full_extra_execs.set(other.full_extra_execs.get());
 		}
 	} // dWorldQuickStepIterationCount_DynamicAdjustmentStatistics;
 
@@ -535,33 +537,33 @@ public interface DWorld {
 	static void initializeQuickStepIterationCount_DynamicAdjustmentStatistics(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics ptr_stat)
 	{
 		// memset(ptr_stat, 0, sizeof(*ptr_stat));
-		ptr_stat.iteration_count = 0;
-		ptr_stat.premature_exits = 0;
-		ptr_stat.prolonged_execs = 0;
-		ptr_stat.full_extra_execs = 0;
+		ptr_stat.iteration_count.set(0);
+		ptr_stat.premature_exits.set(0);
+		ptr_stat.prolonged_execs.set(0);
+		ptr_stat.full_extra_execs.set(0);
 		ptr_stat.struct_size = 5*4 + 12;
 	}
 
 
-	/**
-	 * Attach or remove a structure to collect QuickStep iteration count dynamic adjustment statistics.
-	 *
-	 * <p>REMARKS: The function can be used to attach or remove a structure instance that will be updated with iteration count dynamic adjustment statistics
-	 * of QuickStep. To break the attachment, the function must be called with NULL for the {@code var_stats}.
-	 *
-	 * <p>See {@link #setQuickStepDynamicIterationParameters(double[], double[], double[])} for information on the iteration count dynamic adjustment options.
-	 *
-	 * <p>The caller is responsible for initializing the structure before assignment. The structure must persist in memory until unattached or
-	 * the host world object is destroyed. The same structure instance may be shared among multiple worlds if that makes sense.
-	 *
-	 * <p>The assignment may fail if the feature is not configured within the library, or if the structure was not initialized properly.
-	 *
-	 * @param var_stats A pointer to structure instance to assigned or NULL to break the previous attachment for the world.
-	 * @return Boolean status indicating whether the function succeeded
-	 * @see dWorldQuickStepIterationCount_DynamicAdjustmentStatistics
-	 */
-	// ODE_API int dWorldAttachQuickStepDynamicIterationStatisticsSink(dWorldID w, dWorldQuickStepIterationCount_DynamicAdjustmentStatistics *var_stats/*=NULL*/);
-	int attachQuickStepDynamicIterationStatisticsSink(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics var_stats/*=NULL*/);
+	//	/**
+	//	 * Attach or remove a structure to collect QuickStep iteration count dynamic adjustment statistics.
+	//	 *
+	//	 * <p>REMARKS: The function can be used to attach or remove a structure instance that will be updated with iteration count dynamic adjustment statistics
+	//	 * of QuickStep. To break the attachment, the function must be called with NULL for the {@code var_stats}.
+	//	 *
+	//	 * <p>See {@link #setQuickStepDynamicIterationParameters(double[], double[], double[])} for information on the iteration count dynamic adjustment options.
+	//	 *
+	//	 * <p>The caller is responsible for initializing the structure before assignment. The structure must persist in memory until unattached or
+	//	 * the host world object is destroyed. The same structure instance may be shared among multiple worlds if that makes sense.
+	//	 *
+	//	 * <p>The assignment may fail if the feature is not configured within the library, or if the structure was not initialized properly.
+	//	 *
+	//	 * @param var_stats A pointer to structure instance to assigned or NULL to break the previous attachment for the world.
+	//	 * @return Boolean status indicating whether the function succeeded
+	//	 * @see dWorldQuickStepIterationCount_DynamicAdjustmentStatistics
+	//	 */
+	//	// ODE_API int dWorldAttachQuickStepDynamicIterationStatisticsSink(dWorldID w, dWorldQuickStepIterationCount_DynamicAdjustmentStatistics *var_stats/*=NULL*/);
+	//	int attachQuickStepDynamicIterationStatisticsSink(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics var_stats/*=NULL*/);
 
 
 

--- a/core/src/main/java/org/ode4j/ode/DWorld.java
+++ b/core/src/main/java/org/ode4j/ode/DWorld.java
@@ -207,13 +207,13 @@ public interface DWorld {
 	{
 		/* must always be defined */
 		// unsigned
-		int param_set; /**< Combination of dWSTP_... flags */
+		public int param_set; /**< Combination of dWSTP_... flags */
 		// unsigned
-		int world_islands_iteration_max_threads;
+		public int world_islands_iteration_max_threads;
 		// unsigned
-		int island_stepping_max_threads;
+		public int island_stepping_max_threads;
 		// unsigned
-		int lcp_solving_max_threads;
+		public int lcp_solving_max_threads;
 
 	} // dWorldSteppingThreadingParameters;
 
@@ -517,6 +517,13 @@ public interface DWorld {
 		int prolonged_execs;      /*< number of times solution took more  than the regular iteration count */
 		int full_extra_execs;     /*< number of times the assigned exit criteria were not achieved even after all extra iterations allowed */
 
+		public void set(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics other) {
+			struct_size = other.struct_size;
+			iteration_count = other.iteration_count;
+			premature_exits = other.premature_exits;
+			prolonged_execs = other.prolonged_execs;
+			full_extra_execs = other.full_extra_execs;
+		}
 	} // dWorldQuickStepIterationCount_DynamicAdjustmentStatistics;
 
 	// ODE_PURE_INLINE

--- a/core/src/main/java/org/ode4j/ode/OdeConstants.java
+++ b/core/src/main/java/org/ode4j/ode/OdeConstants.java
@@ -51,6 +51,8 @@ public class OdeConstants {
 	public static final int 	  dContactSlip2		= 0x200;
 	/** Rolling/Angular friction */
 	public static final int 	  dContactRolling   = 0x400;
+	/** Allow inward contact force for inelastic collision */
+	public static final int 	  dContactInelastic = 0x800;
 
 	public static final int 	  dContactApprox0	= 0x0000;
 	public static final int 	  dContactApprox1_1	= 0x1000;

--- a/core/src/main/java/org/ode4j/ode/OdeHelper.java
+++ b/core/src/main/java/org/ode4j/ode/OdeHelper.java
@@ -841,9 +841,9 @@ public abstract class OdeHelper {
 	}
 	
 	/**
-	 * Close ODE after it is not needed any more.
+	 * Close ODE after it is not needed anymore.
 	 * <p>
-	 * The function is required to be called when program does not need ODE features any more.
+	 * The function is required to be called when program does not need ODE features anymore.
 	 * The call to <tt>dCloseODE</tt> releases all the resources allocated for library
 	 * including all the thread local data that might be allocated for all the threads
 	 * that were using ODE.
@@ -988,10 +988,25 @@ public abstract class OdeHelper {
 	 * ODE_EXT_trimesh
 	 * ODE_EXT_opcode
 	 * ODE_EXT_gimpact
-	 * ODE_EXT_malloc_not_alloca
-	 * ODE_EXT_gyroscopic
+	 * ODE_EXT_malloc_not_alloca  ---
+	 * ODE_EXT_gyroscopic -----
 	 * ODE_OPC_16bit_indices
 	 * ODE_OPC_new_collider
+	 * ODE_EXT_libccd
+	 * ODE_CCD_IMPL_internal
+	 * ODE_CCD_COLL_box_cyl
+	 * ODE_CCD_COLL_cyl_cyl
+	 * ODE_CCD_COLL_cap_cyl
+	 * ODE_CCD_COLL_box_conv
+	 * ODE_CCD_COLL_cap_conv
+	 * ODE_CCD_COLL_conv_cyl
+	 * ODE_CCD_COLL_conv_sph
+	 * ODE_CCD_COLL_conv_conv
+	 * ODE_EXT_mt_collisions
+	 * ODE_EXT_threading
+	 * ODE_THR_builtin_impl
+	 * ODE_EXT_inelastic_collisions
+	 *
 	 * @return String
 	 */
 	public static String getConfiguration () {
@@ -999,7 +1014,7 @@ public abstract class OdeHelper {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return The version String.
 	 */
 	public static String getVersion() {

--- a/core/src/main/java/org/ode4j/ode/OdeMath.java
+++ b/core/src/main/java/org/ode4j/ode/OdeMath.java
@@ -869,7 +869,7 @@ public class OdeMath extends DRotation {
 
 
 	/*
-	 * special case matrix multipication, with operator selection
+	 * special case matrix multiplication, with operator selection
 	 */
 
 	private static void dMultiplyHelper0_331(DVector3 res, DMatrix3C a, DVector3C b) {

--- a/core/src/main/java/org/ode4j/ode/internal/CollideBoxPlane.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideBoxPlane.java
@@ -42,7 +42,7 @@ import static org.ode4j.ode.internal.DxGeom.NUMC_MASK;
 class CollideBoxPlane implements DColliderFn {
 	//int dCollideBoxPlane (dxGeom *o1, dxGeom *o2,
 	//    int flags, dContactGeom *contact, int skip)
-	int dCollideBoxPlaneOld (DxBox o1, DxPlane o2,
+	int dCollideBoxPlane (DxBox o1, DxPlane o2,
 			int flags, DContactGeomBuffer contacts, int skip)
 	{
 		//dIASSERT (skip >= (int)sizeof(dContactGeom));
@@ -336,7 +336,7 @@ class CollideBoxPlane implements DColliderFn {
 
 	//	int dCollideBoxPlane(dxGeom *o1, dxGeom *o2,
 	//						 int flags, dContactGeom *contact, int skip)
-	private int dCollideBoxPlane (DxBox o1, DxPlane o2,
+	private int dCollideBoxPlaneNew (DxBox o1, DxPlane o2,
 							 int flags, DContactGeomBuffer contacts, int skip)
 	{
 		// dIASSERT(skip >= (int)sizeof(dContactGeom));

--- a/core/src/main/java/org/ode4j/ode/internal/CollideBoxPlane.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideBoxPlane.java
@@ -37,18 +37,19 @@ import org.ode4j.ode.internal.cpp4j.java.RefInt;
 import static org.ode4j.ode.OdeMath.*;
 import static org.ode4j.ode.internal.Common.dFabs;
 import static org.ode4j.ode.internal.Common.dIASSERT;
+import static org.ode4j.ode.internal.DxGeom.NUMC_MASK;
 
 class CollideBoxPlane implements DColliderFn {
 	//int dCollideBoxPlane (dxGeom *o1, dxGeom *o2,
 	//    int flags, dContactGeom *contact, int skip)
-	int dCollideBoxPlane (DxBox o1, DxPlane o2,
+	int dCollideBoxPlaneOld (DxBox o1, DxPlane o2,
 			int flags, DContactGeomBuffer contacts, int skip)
 	{
 		//dIASSERT (skip >= (int)sizeof(dContactGeom));
 		dIASSERT (skip == 1);
 //		dIASSERT (o1.type == dBoxClass);
 //		dIASSERT (o2.type == dPlaneClass);
-		dIASSERT ((flags & DxGeom.NUMC_MASK) >= 1);
+		dIASSERT ((flags & NUMC_MASK) >= 1);
 
 		DxBox box = o1;
 		DxPlane plane = o2;
@@ -88,7 +89,7 @@ class CollideBoxPlane implements DColliderFn {
 		if (depth.get() < 0) return 0;
 
 		// find number of contacts requested
-		int maxc = flags & DxGeom.NUMC_MASK;
+		int maxc = flags & NUMC_MASK;
 		// if (maxc < 1) maxc = 1; // an assertion is made on entry
 		if (maxc > 4) maxc = 4;	// not more than 4 contacts per box allowed
 
@@ -328,7 +329,302 @@ class CollideBoxPlane implements DColliderFn {
 			contact.normal.set(n);
 		}
 	}
-	
+
+	// Fill in the the non-varying contact info for the first contactCount contacts.
+	// static inline void finishBoxPlaneContacts(unsigned contactCount, dContactGeom *&contact, int skip, dxGeom *o1, dxGeom *o2, const dReal *normal);
+	// TZ: -> See below
+
+	//	int dCollideBoxPlane(dxGeom *o1, dxGeom *o2,
+	//						 int flags, dContactGeom *contact, int skip)
+	private int dCollideBoxPlane (DxBox o1, DxPlane o2,
+							 int flags, DContactGeomBuffer contacts, int skip)
+	{
+		// dIASSERT(skip >= (int)sizeof(dContactGeom));
+		dIASSERT(skip == 1);
+		//		dIASSERT(o1->type == dBoxClass);
+		//		dIASSERT(o2->type == dPlaneClass);
+		dIASSERT((flags & NUMC_MASK) >= 1);
+
+		DxBox box = o1;
+		DxPlane plane = o2;
+
+		//@@@ problem: using 4-vector (plane->p) as 3-vector (normal).
+    	DVector3C normal = plane.getNormal();          // normal vector
+
+		// The number of contacts found.
+		int nContactsFound = 0;
+
+		do
+		{
+         DMatrix3C R = box.final_posr().R(); // rotation of box
+
+			// project sides lengths along normal vector, get absolute values
+			// A[i] will be the reduction in depth resulting from moving in direction i by an amount of side[i].
+        	final double Q0 = dCalcVectorDot3_14(normal, R, 0);
+			final double Q1 = dCalcVectorDot3_14(normal, R, 1);
+			final double Q2 = dCalcVectorDot3_14(normal, R, 2);
+        	final DVector3C side = box.side;
+        	DVector3C A = new DVector3(side.get0() * Q0, side.get1() * Q1, side.get2() * Q2);
+
+			// Find centerDepth
+        	final double centerDepth = plane.getDepth() - dCalcVectorDot3(normal, box.final_posr().pos());
+
+			// The depths (positive = deeper) of the 8 vertices will be:
+			//
+			// centerDepth - 0.5*(+/- A[0] +/- A[1] +/- A[2])
+			//
+			// for the 8 combinations of +/-.
+
+			// What we'd *really* like is to get the vertices in depth order (deepest first), so that we can
+			// easily return the maxc deepest vertices and also return early once we get to a vertex with a
+			// negative depth. To achieve that efficiently, it will turn out to be useful to use |A[s]|
+			// instead of A[s] when computing the depths. We store that in B.
+			double[] B = {dFabs(A.get0()), dFabs(A.get1()), dFabs(A.get2())};
+
+			// Note that A[s]=sgn(A[s])*B[s]. That means that the depths are
+			// given by:
+			//
+			// centerDepth - 0.5*(+/- sgn(A[0])*B[0] +/- sgn(A[1])*B[1] +/- sgn(A[2])*B[2])
+			//
+			// The depth of the deepest vertex is achieved when the choice of + or - is opposite the
+			// corresponding sgn() function. That will lead to the depth of the deepest vertex being:
+			double firstContactDepth = centerDepth + 0.5 * (B[0] + B[1] + B[2]);
+
+			// If that isn't below the plane, there is no collision and we can return immediately.
+			if (firstContactDepth < 0)
+			{
+				break;
+			}
+
+			// The number of contacts requested. We can't return more than this many.
+        	final int maxc = flags & NUMC_MASK;
+			dIASSERT(maxc != 0);
+
+			// Otherwise, we need to figure out the position of the vertex, and potentially other vertices.
+
+			// Let p be the center point of the box.
+        	DVector3C p = new DVector3(box.final_posr().pos());//.get0->pos[0], box->final_posr->pos[1], box->final_posr->pos[2]);
+
+			// To compute the positions of each of the 8 vertices, note that side[s]*R[4*c+s] is the change
+			// in coordinate c associated with moving along the full length of side s. As a result, the cth
+			// coord of the vertices are given by:
+			//
+			// p[c] +/- 0.5*side[0]*R[4*c+0] +/- 0.5*side[1]*R[4*c+1] +/- 0.5*side[2]*R[4*c+2]
+			//
+			// for c in 0, 1, 2, and all 8 combinations of +/- where the choices for +/- for a vertex match
+			// the choices when computing the depth of the vertex:
+			//
+			// centerDepth - 0.5*(+/- sgn(A[0])*B[0] +/- sgn(A[1])*B[1] +/- sgn(A[2])*B[2])
+			//
+			// Since the sgn() function will just flip or not flip the +/- to a -/+, and we just need to
+			// keep the choices consistent between the computations of the vertices' depths and the
+			// positions, we can move the sgn() to the computation of the coords to get:
+			//
+			// centerDepth - 0.5*(+/- B[0] +/- B[1] +/- B[2])
+			//
+			// and:
+			//
+			// p[c] +/- 0.5*sgn(A[0])*side[0]*R[4*c+0] +/- 0.5*sgn(A[1])*side[1]*R[4*c+1] +/-
+			// 0.5*sgn(A[2])*side[2]*R[4*c+2]
+			//
+			// We can precompute signedHalfSides[s]=0.5*sgn(A[s])*side[s] and
+			// signedHalfSideVectors[s][c]=signedHalfSides[s]*R[4*s+c]
+			DVector3C signedHalfSides = new DVector3(
+					dCopySign(0.5, A.get0()) * side.get0(),
+					dCopySign(0.5, A.get1()) * side.get1(),
+					dCopySign(0.5, A.get2()) * side.get2()
+					);
+
+			DVector3C[] signedHalfSideVectors = new DVector3C[3] = {
+				{signedHalfSides[0] * R[0 + 0], signedHalfSides[0] * R[4 + 0], signedHalfSides[0] * R[8 + 0]},
+				{signedHalfSides[1] * R[0 + 1], signedHalfSides[1] * R[4 + 1], signedHalfSides[1] * R[8 + 1]},
+				{signedHalfSides[2] * R[0 + 2], signedHalfSides[2] * R[4 + 2], signedHalfSides[2] * R[8 + 2]},
+			};
+
+			// Now the vertices are given by:
+			//
+			// p[c] +/- signedHalfSides[0]*R[4*c+0] +/- signedHalfSides[1]*R[4*c+1] +/-
+			// signedHalfSides[2]*R[4*c+2]
+			//
+			// The deepest vertex corresponds to always choosing "-". So we can fill it in right away.
+			{
+				DContactGeom currContact = contact;
+				dIASSERT(contact == CONTACT(contact, nContactsFound * skip));
+				currContact.pos.set0( p.get0() - signedHalfSideVectors[2].get0() - signedHalfSideVectors[1].get0() - signedHalfSideVectors[0].get0() );
+				currContact.pos.set1( p.get1() - signedHalfSideVectors[2].get1() - signedHalfSideVectors[1].get1() - signedHalfSideVectors[0].get1() );
+				currContact.pos.set2( p.get2() - signedHalfSideVectors[2].get2() - signedHalfSideVectors[1].get2() - signedHalfSideVectors[0].get2() );
+				currContact.depth = firstContactDepth;
+				if (++nContactsFound == maxc)
+				{
+					break;
+				}
+			}
+
+			// The second deepest will correspond to choosing the - option for all but the smallest B[s].
+			// That corresponds to moving along the edge that causes the least change in depth. The third
+			// deepest will correspond to choosing the - option for all but the second smallest B[s]. The
+			// least, second least, and third *least* deep can be found similarly. So the ranks of 6 of the
+			// 8 vertices can be determined in this way. The only remaining ambiguity is which of the 2
+			// other vertices is deeper, which we will handle later.
+			//
+			// To compute the vertices and depths efficiently in the desired order, we will presort the
+			// sides and their corresponding Bs in ascending order of the Bs and we will precompute each of
+			// the signedHalfSide[s]*R[4*c+s] terms as follows:
+			//
+			// Let minSide, midSide, maxSide be the indices of the sides such that
+			// B[minSide]<=B[midSide]<=B[maxSide]
+			//
+			// Let orderedB[0]=B[minSide], orderedB[1]=B[midSide], and orderedB[2]=B[maxSide]
+			//
+			// and:
+			//
+			// orderedSignedHalfSideVectors[0][c] = signedHalfSideVectors[minSide]
+			// orderedSignedHalfSideVectors[1][c] = signedHalfSideVectors[midSide]
+			// orderedSignedHalfSideVectors[2][c] = signedHalfSideVectors[maxSide]
+			//
+			// The positions of the vertices will then be:
+			//
+			// p[c] +/- orderedHalfSideVector[0][c] +/- orderedHalfSideVector[1][c] +/-
+			// orderedHalfSideVector[2][c]
+			//
+			// and the corresponding depths:
+			//
+			// centerDepth - 0.5*(+/- orderedB[0] +/- orderedB[1] +/- orderedB[2])
+			//
+			// We will call the following macro with the various +/- combos to compute the depth of a
+			// vertex, add it to the contacts if it is inside and stop early if it isn't or we've found
+			// the requested number of contacts.
+//			#define ADD_VERTEX_IF_INSIDE(op1, op2, op3)                                                                                                              \
+//			{                                                                                                                                                        \
+//				double contactDepth = (centerDepth - 0.5 * (op3 orderedB[2] op2 orderedB[1] op1 orderedB[0]));                                                  \
+//				if (contactDepth < 0.0)                                                                                                                              \
+//				{                                                                                                                                                    \
+//					break;                                                                                                                                           \
+//				}                                                                                                                                                    \
+//				dContactGeom *currContact = CONTACT(contact, nContactsFound * skip);                                                                                 \
+//				currContact->pos[0] = p[0] op3 orderedSignedHalfSideVectors[2][0] op2 orderedSignedHalfSideVectors[1][0] op1 orderedSignedHalfSideVectors[0][0];     \
+//				currContact->pos[1] = p[1] op3 orderedSignedHalfSideVectors[2][1] op2 orderedSignedHalfSideVectors[1][1] op1 orderedSignedHalfSideVectors[0][1];     \
+//				currContact->pos[2] = p[2] op3 orderedSignedHalfSideVectors[2][2] op2 orderedSignedHalfSideVectors[1][2] op1 orderedSignedHalfSideVectors[0][2];     \
+//				currContact->depth = contactDepth;                                                                                                                   \
+//				if (++nContactsFound == maxc)                                                                                                                        \
+//				{                                                                                                                                                    \
+//					break;                                                                                                                                           \
+//				}                                                                                                                                                    \
+//			} // END OF MACRO DEFINITION
+
+
+			// But first we need to sort the sides and Bs. We'll start with them in their original order...
+        	DVector3C[] orderedSignedHalfSideVectors = new DVector3C[]{
+				&(signedHalfSideVectors[0][0]),
+            &(signedHalfSideVectors[1][0]),
+            &(signedHalfSideVectors[2][0]),
+        	};
+        	DVector3C orderedB = B; // TODO copy???
+
+			TriFunction ADD_VERTEX_IF_INSIDE = (op1, op2, op3) ->
+			{
+				double contactDepth = (centerDepth - 0.5 * (op3 * orderedB.get2() + op2 * orderedB.get1() + op1 * orderedB.get0()));
+				if (contactDepth < 0.0)
+				{
+					//break;
+					return true;
+				}
+				DContactGeom currContact = contacts.get(nContactsFound * skip); //CONTACT(contact, nContactsFound * skip);
+				currContact.pos.set0( p.get0() + op3 * orderedSignedHalfSideVectors[2].get0() + op2 * orderedSignedHalfSideVectors[1].get0() + op1 * orderedSignedHalfSideVectors[0].get0() );
+				currContact.pos.set1( p.get1() + op3 * orderedSignedHalfSideVectors[2].get1() + op2 * orderedSignedHalfSideVectors[1].get1() + op1 * orderedSignedHalfSideVectors[0].get1() );
+				currContact.pos.set2( p.get2() + op3 * orderedSignedHalfSideVectors[2].get2() + op2 * orderedSignedHalfSideVectors[1].get2() + op1 * orderedSignedHalfSideVectors[0].get2() );
+				currContact.depth = contactDepth;
+				if (++nContactsFound == maxc)
+				{
+					//break;
+					return true;
+				}
+				return false;
+			};
+
+			// Swap the one that corresponds to the lowest B into the 0th position.
+			if (B[1] < B[0])
+			{
+				dxSwap(B, 1, B, 0);
+				dxSwap(orderedSignedHalfSideVectors, 1, orderedSignedHalfSideVectors, 0);
+			}
+
+			if (B[2] < B[0])
+			{
+				dxSwap(B, 2, B, 0);
+				dxSwap(orderedSignedHalfSideVectors, 2, orderedSignedHalfSideVectors, 0);
+			}
+
+			// For the second deepest vertex, we don't actually care about the order of other 2 sides, so we
+			// can go ahead and process that one. Maybe we'll get lucky and exit early.
+			if (ADD_VERTEX_IF_INSIDE.isBreak(+1, -1, -1)) break;
+
+			// If we didn't get lucky, we need to sort the remaining 2 sides.
+			if (B[2] < B[1])
+			{
+				dxSwap(B, 2, B, 1);
+				dxSwap(orderedSignedHalfSideVectors, 2, orderedSignedHalfSideVectors, 1);
+			}
+
+			// Now we can process the third deepest vertex.
+			if (ADD_VERTEX_IF_INSIDE.isBreak(-1, +1, -1)) break;
+
+			// Determine which of the 2 middle vertices is deeper and process them in the correct order.
+			if (B[0] + B[1] < B[2])
+			{
+				if (ADD_VERTEX_IF_INSIDE.isBreak(+1, +1, -1)) break;
+				if (ADD_VERTEX_IF_INSIDE.isBreak(-1, -1, +1)) break;
+			}
+			else
+			{
+				if (ADD_VERTEX_IF_INSIDE.isBreak(-1, -1, +1)) break;
+				if (ADD_VERTEX_IF_INSIDE.isBreak(+1, +1, -1)) break;
+			}
+
+			// Process the 3 remaining vertices in order.
+			if (ADD_VERTEX_IF_INSIDE.isBreak(+1, -1, +1)) break;
+			if (ADD_VERTEX_IF_INSIDE.isBreak(-1, +1, +1)) break;
+			if (ADD_VERTEX_IF_INSIDE.isBreak(+1, +1, +1)) break;
+		}
+		while (false);
+
+		if (nContactsFound != 0)
+		{
+			finishBoxPlaneContacts(nContactsFound, contacts, skip, box, plane, normal);
+		}
+
+		int retVal = nContactsFound;
+		return retVal;
+	}
+
+	private interface TriFunction {
+		boolean isBreak(int op1, int op2, int op3);
+	}
+
+
+	// Fill in the the non-varying contact info for the first n contacts.
+	static
+	// void finishBoxPlaneContacts(unsigned contactCount, dContactGeom *&contact, int skip, dxGeom *o1, dxGeom *o2, const dReal *normal)
+	void finishBoxPlaneContacts(int contactCount, DContactGeomBuffer contacts, int skip, DxGeom o1, DxGeom o2, DVector3C normal)
+	{
+		for (int contactIndex = 0; contactIndex != contactCount; ++contactIndex)
+		{
+			DContactGeom currContact = contacts.get(contactIndex * skip); //CONTACT(contact, contactIndex * skip);
+			currContact.g1 = o1;
+			currContact.g2 = o2;
+			currContact.side1 = -1;
+			currContact.side2 = -1;
+
+			//			currContact.normal[0] = normal[0];
+			//			currContact.normal[1] = normal[1];
+			//			currContact.normal[2] = normal[2];
+			currContact.normal.set(normal);
+		}
+
+	}
+
+
+
 	@Override
 	public int dColliderFn (DGeom o1, DGeom o2, int flags, 
 			DContactGeomBuffer contacts) {

--- a/core/src/main/java/org/ode4j/ode/internal/CollideCylinderBox.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideCylinderBox.java
@@ -299,7 +299,7 @@ class CollideCylinderBox extends DxCollisionUtil implements DColliderFn {
 				return false; 
 			} 
 
-			// Finalyze the depth calculation
+			// Finalize the depth calculation
 			fDepth -= dFabs(fd);
 
 			// get maximum depth

--- a/core/src/main/java/org/ode4j/ode/internal/CollideCylinderSphere.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideCylinderSphere.java
@@ -201,7 +201,7 @@ class CollideCylinderSphere extends DxCollisionUtil implements DColliderFn {
 		}
 		else if( (radius - t) <= s && (radius - t) <= (length - s) )
 		{
-			// 1. collsision
+			// 1. collision
 			if(t > (radius2 + toleranz))
 			{
 				// cylinder-axis is outside the sphere
@@ -266,7 +266,7 @@ class CollideCylinderSphere extends DxCollisionUtil implements DColliderFn {
 			// 2. collision
 			if(s <= (length * (0.5)) )
 			{
-				// collsision with the first disc
+				// collision with the first disc
 				contact.depth = s + radius2;
 				if(contact.depth < 0)
 				{
@@ -290,7 +290,7 @@ class CollideCylinderSphere extends DxCollisionUtil implements DColliderFn {
 			}
 			else
 			{
-				// collsision with the second disc
+				// collision with the second disc
 				contact.depth = (radius2 + length - s);
 				if(contact.depth < 0)
 				{

--- a/core/src/main/java/org/ode4j/ode/internal/CollideCylinderTrimesh.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideCylinderTrimesh.java
@@ -177,7 +177,7 @@ class CollideCylinderTrimesh implements DColliderFn {
 	// Use to classify contacts to be "near" in normal direction
 	private static final double fSameContactNormalEpsilon = (0.0001); // 1e-4
 
-	// If this two contact can be classified as "near"
+	// If these two contact can be classified as "near"
 	//inline int _IsNearContacts(sLocalContactData& c1,sLocalContactData& c2)
 	private static boolean _IsNearContacts(sLocalContactData c1,sLocalContactData c2)
 	{
@@ -1238,24 +1238,35 @@ class CollideCylinderTrimesh implements DColliderFn {
 		DxCylinder Cylinder = o1;
 		DxGimpact Trimesh = o2;
 
-		// Main data holder
-		sCylinderTrimeshColliderData cData = new sCylinderTrimeshColliderData(flags, skip);
-		cData._InitCylinderTrimeshData(Cylinder, Trimesh);
+//		// Main data holder
+//		sCylinderTrimeshColliderData cData = new sCylinderTrimeshColliderData(flags, skip);
+//		cData._InitCylinderTrimeshData(Cylinder, Trimesh);
+//
+//		//*****at first , collide box aabb******//
+//
+//		aabb3f test_aabb = new aabb3f();
+//		DAABBC aabb = o1._aabb; // TODO TZ: remompute AABB with getAABB()?
+//		test_aabb.set(aabb.getMin0(), aabb.getMax0(), aabb.getMin1(), aabb.getMax1(), aabb.getMin2(), aabb.getMax2());
+//
+//
+		GimDynArrayInt collision_result = GimDynArrayInt.GIM_CREATE_BOXQUERY_LIST();
+
+		Cylinder.recomputeAABB();
+		Trimesh.recomputeAABB();
 
 		//*****at first , collide box aabb******//
 
 		aabb3f test_aabb = new aabb3f();
-		DAABBC aabb = o1._aabb; // TODO TZ: remompute AABB with getAABB()?
-		test_aabb.set(aabb.getMin0(), aabb.getMax0(), aabb.getMin1(), aabb.getMax1(), aabb.getMin2(), aabb.getMax2());
-
-
-		GimDynArrayInt collision_result = GimDynArrayInt.GIM_CREATE_BOXQUERY_LIST();
-
+		test_aabb.set(Cylinder._aabb.getMin0(), Cylinder._aabb.getMax0(), Cylinder._aabb.getMin1(), Cylinder._aabb.getMax1(), Cylinder._aabb.getMin2(), Cylinder._aabb.getMax2());
 		Trimesh.m_collision_trimesh().getAabbSet().gim_aabbset_box_collision(test_aabb, collision_result);
 
 		if (collision_result.size() != 0)
 		{
-		//*****Set globals for box collision******//
+			// Main data holder
+			sCylinderTrimeshColliderData cData = new sCylinderTrimeshColliderData(flags, skip);
+			cData._InitCylinderTrimeshData(Cylinder, Trimesh);
+
+			//*****Set globals for box collision******//
 
 			int ctContacts0 = 0;
 			// cData.m_gLocalContacts = (sLocalContactData*)dALLOCA16(sizeof(sLocalContactData)*(cData.m_iFlags & NUMC_MASK));

--- a/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshCCylinder.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshCCylinder.java
@@ -237,7 +237,7 @@ class CollideTrimeshCCylinder implements DColliderFn {
 //	// Use to classify contacts to be "near" in normal direction
 //	static const dReal fSameContactNormalEpsilon = REAL(0.0001); // 1e-4
 //
-//	// If this two contact can be classified as "near"
+//	// If these two contact can be classified as "near"
 //	inline int _IsNearContacts(sLocalContactData& c1,sLocalContactData& c2)
 //	{
 //		int bPosNear = 0;
@@ -1094,7 +1094,7 @@ class CollideTrimeshCCylinder implements DColliderFn {
 //		TrimeshCollidersCache *pccColliderCache = GetTrimeshCollidersCache(uiTLSKind);
 //		OBBCollider& Collider = pccColliderCache->_OBBCollider;
 //
-//		// Will it better to use LSS here? -> confirm Pierre.
+//		// Will it be better to use LSS here? -> confirm Pierre.
 //		dQueryCCTLPotentialCollisionTriangles(Collider, cData, 
 //			TriMesh, Capsule, pccColliderCache->defaultBoxCache);
 //

--- a/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshPlane.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollideTrimeshPlane.java
@@ -125,7 +125,7 @@ class CollideTrimeshPlane implements DColliderFn {
 	//				// Collision?
 	//				//
 	//
-	//				// If alpha < 0 then point is if front of plane. i.e. no contact
+	//				// If alpha < 0 then point is in front of plane. i.e. no contact
 	//				// If alpha = 0 then the point is on the plane
 	//				alpha = plane->p[ 3 ] - dDOT( plane->p, vertex );
 	//	      

--- a/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollisionLibccd.java
@@ -530,7 +530,6 @@ class CollisionLibccd {
                 if (ccdCollide(o1, o2, flags, tempContacts, c1, ccdSupportConvex, ccdCenter, c2, ccdSupportTriangle,
                         ccdCenter) == 1) {
                     DContactGeom tempContact = tempContacts.get();
-                    // TODO TZ: report this to ODE!
                     tempContact.side2 = triindices[i];
 
                     if (meshFaceAngleView == null ||

--- a/core/src/main/java/org/ode4j/ode/internal/CollisionTrimeshGimpact.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CollisionTrimeshGimpact.java
@@ -39,7 +39,7 @@ import static org.ode4j.ode.internal.gimpact.GimGeometry.*;
 // TriMesh code by Erwin de Vries.
 // Modified for FreeSOLID Compatibility by Rodrigo Hernandez
 // Trimesh caches separation by Oleh Derevenko
-// TriMesh storage classes refactoring and face angle computation code by Oleh Derevenko (C) 2016-2017
+// TriMesh storage classes refactoring and face angle computation code by Oleh Derevenko (C) 2016-2025
 
 //****************************************************************************
 // dxTriMesh class
@@ -243,7 +243,7 @@ class CollisionTrimeshGimpact {
      *                                                                       *
      *************************************************************************/
 
-    // TriMesh storage classes refactoring and face angle computation code by Oleh Derevenko (C) 2016-2017
+    // TriMesh storage classes refactoring and face angle computation code by Oleh Derevenko (C) 2016-2025
 
     //        #include<ode/collision.h>
     //            #include<ode/rotation.h>

--- a/core/src/main/java/org/ode4j/ode/internal/Common.java
+++ b/core/src/main/java/org/ode4j/ode/internal/Common.java
@@ -747,6 +747,11 @@ enum {
 		one[oneP] = another[anotherP];
 		another[anotherP] = tmp;
 	}
+	public static <T> void dxSwap(T[] one, int oneP, T[] another, int anotherP) {
+		T tmp = one[oneP];
+		one[oneP] = another[anotherP];
+		another[anotherP] = tmp;
+	}
 
 //	template<typename value_type, typename lo_type, typename hi_type>
 //	inline

--- a/core/src/main/java/org/ode4j/ode/internal/Common.java
+++ b/core/src/main/java/org/ode4j/ode/internal/Common.java
@@ -463,7 +463,11 @@ public class Common extends OdeConstants {
 	//#define dAtan2(y,x) (atan2f(y,x))		/* arc tangent with 2 args */
 	//#define dFMod(a,b) (fmodf(a,b))		/* modulo */
 	//#define dFloor(x) floorf(x)			/* floor */
-	//
+	//#define dCeil(x) ceilf(x)			    /* ceil */
+	//#define dCopySign(a,b) _ode_copysignf(a, b) /* copy value sign */
+	//#define dNextAfter(x, y) _ode_nextafterf(x, y) /* next value after */
+	//#define dMax(a, b) _ode_fmaxf(a, b)
+	//#define dMin(a, b) _ode_fminf(a, b)//
 	//#ifdef HAVE___ISNANF
 	//#define dIsNan(x) (__isnanf(x))
 	//#elif defined(HAVE__ISNANF)
@@ -526,16 +530,21 @@ public class Common extends OdeConstants {
 	//#define dCeil(x) ceilf(x)          /* ceil */
 	public static double dCeil(double x) { return Math.ceil(x); }
 
-	//#define dCopySign(a,b) ((dReal)copysignf(a,b)) /* copy value sign */
-    public static double dCopysign(double magnitude, double sign) {
-        return Math.copySign(magnitude, sign);
-    }
+	//#define dCopySign(a,b) (copysign((a),(b)))
+	public static double dCopySign(double a, double b) {
+		return Math.copySign(a, b);
+	}
 
     //#define dNextAfter(x, y) nextafterf(x, y) /* next value after */
     public static double dNextAfter(double start, double direction) {
         return Math.nextAfter(start, direction);
     }
 
+	//#define dMax(a, b) _ode_fmax(a, b)
+	public static double dMax(double x, double y) { return Math.max(x, y); }
+
+	//#define dMin(a, b) _ode_fmin(a, b)
+	public static double dMin(double x, double y) { return Math.min(x, y); }
 
 	//#ifdef HAVE___ISNAN
 	//#define dIsNan(x) (__isnan(x))
@@ -548,14 +557,6 @@ public class Common extends OdeConstants {
 	//#endif
 	public final boolean dIsNan(double x) { return Double.isNaN(x); }
 	public static final double dNaN = Double.NaN;
-
-	//#define dCopySign(a,b) (copysign((a),(b)))
-	public static double dCopySign(double a, double b) {
-		return Math.copySign(a, b);
-	}
-
-	public static double dMin(double x, double y) { return Math.min(x, y); }
-	public static double dMax(double x, double y) { return Math.max(x, y); }
 
 	/* error numbers */
 

--- a/core/src/main/java/org/ode4j/ode/internal/CommonEnums.java
+++ b/core/src/main/java/org/ode4j/ode/internal/CommonEnums.java
@@ -137,5 +137,12 @@ public class CommonEnums {
 		assert(dV3E_X == 0 && dV3E_Y == 1 && dV3E_Z == 2);
 	}
 
+	public static void dAssertDSA() {
+		// TZ: Using this elaborate construct of constants to access an array is inefficient with
+		//     ode4j's DVector3 implementation. Therefore, we do not use these constants but
+		//     assert() that they are as we expect them to be.
+		assert(dSA_X == 0 && dSA_Y == 1 && dSA_Z == 2);
+	}
+
 	private CommonEnums() {}
 }

--- a/core/src/main/java/org/ode4j/ode/internal/DBase.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DBase.java
@@ -33,11 +33,11 @@ package org.ode4j.ode.internal;
  */
 
 public abstract class DBase extends DDestructible {
-	//  void *operator new (size_t size) { return dAlloc (size); }
-	//  void *operator new (size_t size, void *p) { return p; }
-	//  void operator delete (void *ptr, size_t size) { dFree (ptr,size); }
-	//  void *operator new[] (size_t size) { return dAlloc (size); }
-	//  void operator delete[] (void *ptr, size_t size) { dFree (ptr,size); }
+    //    void *operator new (size_t size) { return dAlloc(size); }
+    //    void *operator new (size_t, void *p) { return p; }
+    //    void operator delete (void *ptr, size_t size) { dFree(ptr, size); }
+    //    void *operator new[](size_t size) { return dAlloc(size); }
+    //    void operator delete[](void *ptr, size_t size) { dFree(ptr, size); }
 
     protected DBase() {}
 }

--- a/core/src/main/java/org/ode4j/ode/internal/DObject.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DObject.java
@@ -40,14 +40,15 @@ public abstract class DObject extends DBase {
     public int tag;            // used by dynamics algorithms
     //void userdata;        // user settable data
     protected Object userdata;        // user settable data
+
     protected DObject(DxWorld w) { //From ODE.java
         world = w;
-        _next = new Ref<DObject>();
+        _next = new Ref<>();
         _tome = null;
         userdata = null;
         tag = 0;
     }
-   
+
     /**
      * Add an object `obj' to the list who's head pointer is pointed
      * to by `first'.

--- a/core/src/main/java/org/ode4j/ode/internal/DxBody.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxBody.java
@@ -77,6 +77,7 @@ public class DxBody extends DObject implements DBody {
 	//		  _i = i;
 	//	  }
 	//	};
+	// TODO (TZ) turn into enum as in C++?
 	private static final int dxBodyFlagFiniteRotation = 1;	// use finite rotations
 	private static final int dxBodyFlagFiniteRotationAxis= 2;	// use finite rotations only along axis
 	static final int dxBodyDisabled				=  4;		// body is disabled
@@ -102,7 +103,8 @@ public class DxBody extends DObject implements DBody {
 	public DQuaternion _q;		// orientation quaternion
 	public DVector3 lvel;		// linear and angular velocity of POR
 	public DVector3 avel;
-	DVector3 facc,tacc;		// force and torque accumulators
+	DVector3 facc; 				// force and torque accumulators
+	DVector3 tacc;
 	DVector3 finite_rot_axis;	// finite rotation axis, unit length or 0=none
 
 	// auto-disable information

--- a/core/src/main/java/org/ode4j/ode/internal/DxBody.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxBody.java
@@ -1044,7 +1044,7 @@ public class DxBody extends DObject implements DBody {
 		_posr.pos.eqSum(_posr.pos(), lvel, h);
 
 		if ((flags & dxBodyFlagFiniteRotation) != 0) {
-			DVector3 irv = new DVector3();	// infitesimal rotation vector
+			DVector3 irv = new DVector3();	// infinitesimal rotation vector
 			DQuaternion q = new DQuaternion();	// quaternion for finite rotation
 
 			if ((flags & dxBodyFlagFiniteRotationAxis) != 0) {
@@ -1092,7 +1092,7 @@ public class DxBody extends DObject implements DBody {
 			//for (j=0; j<4; j++) _q.v[j] = q2.v[j];
 			_q.set(q2);
 
-			// do the infitesimal rotation if required
+			// do the infinitesimal rotation if required
 			if ((flags & dxBodyFlagFiniteRotationAxis) != 0) {
 				DQuaternion dq = new DQuaternion();
 				dDQfromW (dq,irv,_q);
@@ -1101,7 +1101,7 @@ public class DxBody extends DObject implements DBody {
 			}
 		}
 		else {
-			// the normal way - do an infitesimal rotation
+			// the normal way - do an infinitesimal rotation
 			DQuaternion dq = new DQuaternion();
 			dDQfromW (dq,avel,_q);
 			//for (j=0; j<4; j++) _q.v[j] += h * dq[j];

--- a/core/src/main/java/org/ode4j/ode/internal/DxBox.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxBox.java
@@ -158,12 +158,6 @@ public class DxBox extends DxGeom implements DBox {
 		// if the point is inside all six sides
 
 		double[] dist = new double[6];
-		// TODO CHECK TZ
-		//  This is not the 0.16.3 solution but the solution from "master".
-		//  - This is weird because the code in 0.16.3 is from 2020-11-06, master is from 2020-11-08, 0.16.3 was tagged
-		//    much later on 2022-12-19 but it doesn´t include th master version.
-		//  - For some reason the 0.16.3 fails the DemoCollision test (it works in C++ though).
-		//  ---> We can just leave it as is.
 
 		boolean outside = false;
 		double lastOuterOffset = 0;

--- a/core/src/main/java/org/ode4j/ode/internal/DxConvex.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxConvex.java
@@ -492,7 +492,7 @@ public class DxConvex extends DxGeom implements DConvex {
 	//	 * @param Direction1 The direction of Ray 3
 	//	 * @param t the time "t" in Ray 1 that gives us the closest point
 	//	 * (closest_point=Origin1+(Direction1*t).
-	//	 * @return true if there is a closest point, false if the rays are paralell.
+	//	 * @return true if there is a closest point, false if the rays are parallel.
 	//	 */
 	//inline bool ClosestPointInRay(final dVector3 Origin1,
 	//	      final dVector3 Direction1,
@@ -531,6 +531,10 @@ public class DxConvex extends DxGeom implements DConvex {
 	 * @param q1 end of segment 1
 	 * @param p2 start of segment 2
 	 * @param q2 end of segment 2
+//	 * @param t the time "t" in Ray 1 that gives us the closest point
+//	 *   (closest_point=Origin1+(Direction1*t).
+//	 * @return true if there is a closest point, false if the rays are parallel.
+//	 *
 	 */
 //	private float ClosestPointBetweenSegments(dVector3& p1,
 //            dVector3& q1,
@@ -538,7 +542,7 @@ public class DxConvex extends DxGeom implements DConvex {
 //            dVector3& q2,
 //            dVector3& c1,
 //            dVector3& c2)
-	private static double ClosestPointBetweenSegments(DVector3 p1, DVector3 q1,
+	private static void ClosestPointBetweenSegments(DVector3 p1, DVector3 q1,
             DVector3 p2, DVector3 q2, DVector3 c1, DVector3 c2)
 	{
 	    // s & t were originaly part of the output args, but since
@@ -564,10 +568,7 @@ public class DxConvex extends DxGeom implements DConvex {
 	        s = t = 0.0f;
 	        c1.set( p1 );//dVector3Copy(p1,c1);
 	        c2.set( p2 );//dVector3Copy(p2,c2);
-//	        return (c1[0] - c2[0])*(c1[0] - c2[0])+
-//	               (c1[1] - c2[1])*(c1[1] - c2[1])+
-//	               (c1[2] - c2[2])*(c1[2] - c2[2]);
-	        return c1.reSub(c2).lengthSquared();
+	        return;
 	    }
 	    if (a <= dEpsilon)
 	    {
@@ -641,12 +642,6 @@ public class DxConvex extends DxGeom implements DConvex {
 //	    c2[1] = p2[1] + d2[1] * t;
 //	    c2[2] = p2[2] + d2[2] * t;
 	    c2.eqSum( p2, d2, t );
-//	    return (c1[0] - c2[0])*(c1[0] - c2[0])+
-//	           (c1[1] - c2[1])*(c1[1] - c2[1])+
-//	           (c1[2] - c2[2])*(c1[2] - c2[2]);
-	    return (c1.get0() - c2.get0())*(c1.get0() - c2.get0())+
-        (c1.get1() - c2.get1())*(c1.get1() - c2.get1())+
-        (c1.get2() - c2.get2())*(c1.get2() - c2.get2());
 	}
 
 //	#if 0
@@ -668,7 +663,7 @@ public class DxConvex extends DxGeom implements DConvex {
 //	 * @param p2 Plane 2
 //	 * @param p Contains the origin of the ray upon returning if planes intersect
 //	 * @param d Contains the direction of the ray upon returning if planes intersect
-//	 * @return true if the planes intersect, false if paralell.
+//	 * @return true if the planes intersect, false if parallel.
 //	 */
 //	private boolean IntersectPlanes(final DVector3 p1, double p13, final DVector3 p2, double p23,DVector3 p, DVector3 d)
 //	{
@@ -885,7 +880,7 @@ public class DxConvex extends DxGeom implements DConvex {
 				// Check if contacts are full and both signs have been already found
 				if (((contacts ^ maxc) | totalsign) == BOTH_SIGNS) // harder to comprehend but requires one register less
 				{
-					break; // Nothing can be changed any more
+					break; // Nothing can be changed anymore
 				}
 			}
 			if (totalsign == BOTH_SIGNS) return contacts;
@@ -1138,7 +1133,7 @@ public class DxConvex extends DxGeom implements DConvex {
 			}
 		}
 		// *: usually using the distance part of the plane (axis) is
-		// not necesary, however, here we need it here in order to know
+		// not necesary, however, here we need it in order to know
 		// which face to pick when there are 2 parallel sides.
 	}
 
@@ -1287,7 +1282,7 @@ Helper struct
         Take only into account the faces that penetrate cvx1 to determine
         minimum depth
         ((max2*min2)<=0) = different sign, or one is zero and thus
-        cvx2 barelly touches cvx1
+        cvx2 barely touches cvx1
 			 */
 			if (((max2.get()*min2.get())<=0) && (dFabs(depth)<dFabs(ccso.min_depth)))
 			{
@@ -1613,7 +1608,7 @@ Helper struct
 //								p.eqSum(i1, 1-t.get(), i2, t.get());
 //							} else { //#else // #if0
 								// Apply reference convex transformations to p
-								// The commented out piece of code is likelly to
+								// The commented out piece of code is likely to
 								// produce less operations than this one, but
 								// this way we know we are getting the right data
 								dMultiply0_331(tmp,cvx1.final_posr().R(),p);

--- a/core/src/main/java/org/ode4j/ode/internal/DxHeightfield.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxHeightfield.java
@@ -25,24 +25,13 @@
 package org.ode4j.ode.internal;
 
 import static org.ode4j.ode.OdeConstants.dInfinity;
-import static org.ode4j.ode.OdeMath.dMultiply0_331;
-import static org.ode4j.ode.OdeMath.dMultiply1_331;
-import static org.ode4j.ode.OdeMath.dMultiply1_333;
-import static org.ode4j.ode.internal.Common.dCeil;
-import static org.ode4j.ode.internal.Common.dEpsilon;
-import static org.ode4j.ode.internal.Common.dFabs;
-import static org.ode4j.ode.internal.Common.dFloor;
-import static org.ode4j.ode.internal.Common.dIASSERT;
+import static org.ode4j.ode.OdeMath.*;
+import static org.ode4j.ode.internal.Common.*;
 
 import org.ode4j.math.DMatrix3;
 import org.ode4j.math.DVector3;
 import org.ode4j.math.DVector3C;
-import org.ode4j.ode.DAABB;
-import org.ode4j.ode.DColliderFn;
-import org.ode4j.ode.DContactGeom;
-import org.ode4j.ode.DContactGeomBuffer;
-import org.ode4j.ode.DGeom;
-import org.ode4j.ode.DHeightfieldData;
+import org.ode4j.ode.*;
 import org.ode4j.ode.internal.trimesh.DxTriMesh;
 
 /**
@@ -110,7 +99,7 @@ public class DxHeightfield extends DxAbstractHeightfield {
 
 	//Uncomment this #define to use the (0,0) corner of the geom as the origin,
 	//rather than the center. This was the way the original heightfield worked,
-	//but as it does not match the way all other geometries work, so for constancy it
+	//but as it does not match the way all other geometries work, so for consistency it
 	//was changed to work like this.
 
 	//#define DHEIGHTFIELD_CORNER_ORIGIN
@@ -785,36 +774,36 @@ public class DxHeightfield extends DxAbstractHeightfield {
 		case dSphereClass:
 			geomRayNCollider		= new DxRay.CollideRaySphere();//dCollideRaySphere;
 			geomNPlaneCollider  	= new DxSphere.CollideSpherePlane();//.dCollideSpherePlane;
-			geomNDepthGetter		= //dGeomSpherePointDepth;
-				new dGetDepthFn() {
-				@Override
-				public double get(DGeom g, double x, double y, double z) {
-					return ((DxSphere)g).dGeomSpherePointDepth(x, y, z);
-				}};
+			geomNDepthGetter		= null; // //dGeomSpherePointDepth;
+			//				new dGetDepthFn() {
+			//				@Override
+			//				public double get(DGeom g, double x, double y, double z) {
+			//					return ((DxSphere)g).dGeomSpherePointDepth(x, y, z);
+			//				}};
 				//max_collisionContact    = 3;
 				break;
 
 		case dBoxClass:
 			geomRayNCollider		= new DxRay.CollideRayBox();//dCollideRayBox;
 			geomNPlaneCollider	    = new CollideBoxPlane();//dCollideBoxPlane;
-			geomNDepthGetter		= //dGeomBoxPointDepth;
-				new dGetDepthFn() {
-				@Override
-				public double get(DGeom g, double x, double y, double z) {
-					return ((DxBox)g).dGeomBoxPointDepth(x, y, z);
-				}};
+			geomNDepthGetter		= null; //dGeomBoxPointDepth;
+			//				new dGetDepthFn() {
+			//				@Override
+			//				public double get(DGeom g, double x, double y, double z) {
+			//					return ((DxBox)g).dGeomBoxPointDepth(x, y, z);
+			//				}};
 				//max_collisionContact    = 8;
 				break;
 
 		case dCapsuleClass:
 			geomRayNCollider		= new DxRay.CollideRayCapsule();//dCollideRayCapsule;
 			geomNPlaneCollider  	= new DxCapsule.CollideCapsulePlane();//dCollideCapsulePlane;
-			geomNDepthGetter		= //dGeomCapsulePointDepth;
-				new dGetDepthFn() {
-				@Override
-				public double get(DGeom g, double x, double y, double z) {
-					return ((DxCapsule)g).dGeomCapsulePointDepth(x, y, z);
-				}};
+			geomNDepthGetter		= null; //dGeomCapsulePointDepth;
+			//				new dGetDepthFn() {
+			//				@Override
+			//				public double get(DGeom g, double x, double y, double z) {
+			//					return ((DxCapsule)g).dGeomCapsulePointDepth(x, y, z);
+			//				}};
 				// max_collisionContact    = 3;
 				break;
 
@@ -854,7 +843,6 @@ public class DxHeightfield extends DxAbstractHeightfield {
 		//double[] triplane = new double[4];
 		DVector3 triplaneV = new DVector3();
 		double triplaneD = 0;
-		//int i;
 
 		// check some trivial case.
 		// Vector Up plane
@@ -949,7 +937,7 @@ public class DxHeightfield extends DxAbstractHeightfield {
 	            // find collision and compute contact points
 	            const int numTerrainContacts = geomNPlaneCollider (o2, sliding_plane, flags, contact, skip);
 				dIASSERT(numTerrainContacts <= numMaxContactsPossible);
-	            for (i = 0; i < numTerrainContacts; i++)
+	            for (int i = 0; i < numTerrainContacts; i++)
 	            {
 					pContact = CONTACT(contact, i*skip);
 	                dOPESIGN(pContact->normal, =, -, triplane);
@@ -961,7 +949,7 @@ public class DxHeightfield extends DxAbstractHeightfield {
 
 		int numTerrainContacts = 0;
 		//dContactGeom *PlaneContact = m_p_data.m_contacts;
-		DContactGeomBuffer PlaneContact = m_p_data.m_contacts;
+		DContactGeomBuffer planeContact = m_p_data.m_contacts;
 
 		//final unsigned 
 		final int numTriMax = (maxX - minX) * (maxZ - minZ) * 2;
@@ -988,20 +976,13 @@ public class DxHeightfield extends DxAbstractHeightfield {
 		// if small heightfield triangle related to O2 colliding
 		// or no Triangle colliding at all.
 		boolean needFurtherPasses = (o2.type == dTriMeshClass);
-		//compute Ratio between Triangle size and O2 aabb size
-		// no FurtherPasses are needed in ray class
-		if (o2.type != dRayClass  && needFurtherPasses == false)
+		// compute Ratio between Triangle size and O2 aabb size
+		// no further passes are needed in case of ray class
+		if (!needFurtherPasses && o2.type != dRayClass)
 		{
-			final double xratio = (o2._aabb.getMax0() - o2._aabb.getMin0()) * m_p_data.m_fInvSampleWidth;
-			if (xratio > (1.5))
-				needFurtherPasses = true;
-			else
-			{
-				final double zratio = (o2._aabb.getMax2() - o2._aabb.getMin2()) * m_p_data.m_fInvSampleDepth;
-				if (zratio > (1.5))
-					needFurtherPasses = true;
-			}
-
+			double zratio, xratio = (o2._aabb.getMax0() - o2._aabb.getMin0()) * m_p_data.m_fInvSampleWidth;
+			zratio = (o2._aabb.getMax2() - o2._aabb.getMin2()) * m_p_data.m_fInvSampleDepth;
+			needFurtherPasses = xratio > 1.5 || (zratio > 1.5);
 		}
 
 		//unsigned 
@@ -1121,12 +1102,14 @@ public class DxHeightfield extends DxAbstractHeightfield {
 			}
 		}
 
-		// at least on triangle should intersect geom
+		// at least one triangle should intersect the geom
 		dIASSERT (numTri != 0);
+
 		// pass1: VS triangle as Planes
 		// Group Triangle by same plane definition
 		// as Terrain often has many triangles using same plane definition
 		// then collide against that list of triangles.
+		boolean anyIntersectingButNotCollided = false;
 		{
 
 			DVector3 Edge1 = new DVector3(), Edge2 = new DVector3();
@@ -1165,7 +1148,7 @@ public class DxHeightfield extends DxAbstractHeightfield {
 				itTriangle.planeDefD = triplaneD;//[3];
 			}
 
-			// group by Triangles by Planes sharing shame plane definition
+			// group by Triangles by Planes sharing same plane definition
 			if (tempPlaneBufferSize  < numTri)
 			{
 				resetPlaneBuffer();
@@ -1177,8 +1160,9 @@ public class DxHeightfield extends DxAbstractHeightfield {
 			{
 				HeightFieldTriangle tri_base = tempTriangleBuffer[k];  // final ? TZ
 
-				if (tri_base.state == true)
+				if (tri_base.state) {
 					continue;// already tested or added to plane list.
+				}
 
 				//HeightFieldPlane * const currPlane = tempPlaneBuffer[numPlanes];
 				HeightFieldPlane currPlane = tempPlaneBuffer[numPlanes];// final ? TZ
@@ -1199,8 +1183,9 @@ public class DxHeightfield extends DxAbstractHeightfield {
 				{
 
 					HeightFieldTriangle tri_test = tempTriangleBuffer[m];  // final? TZ
-					if (tri_test.state == true)
+					if (tri_test.state) {
 						continue;// already tested or added to plane list.
+					}
 
 					// normals and distance are the same.
 					if (
@@ -1223,13 +1208,14 @@ public class DxHeightfield extends DxAbstractHeightfield {
 			}
 
 			// sort planes
-			if (isContactNumPointsLimited)
+			if (isContactNumPointsLimited) {
 				sortPlanes(numPlanes);
+			}
 
 			int numMaxContactsPerPlane;
 			int planeTestFlags;
-			if (!NO_CONTACT_CULLING_BY_ISONHEIGHTFIELD2) {//#if !defined(NO_CONTACT_CULLING_BY_ISONHEIGHTFIELD2)
-				/*
+
+			/*
 				Note by Oleh_Derevenko:
 				It seems to be incorrect to limit contact count by some particular value
 				since some of them (and even all of them) may be culled in following condition.
@@ -1238,16 +1224,9 @@ public class DxHeightfield extends DxAbstractHeightfield {
 				additionally repeated after some contacts have been generated (in "if (didCollide)").
 				The maximum of contacts in flags would then be set to minimum of contacts
 				remaining and HEIGHTFIELDMAXCONTACTPERCELL.
-				 */
-				planeTestFlags = (flags & ~NUMC_MASK) | HEIGHTFIELDMAXCONTACTPERCELL;
-				//dIASSERT((HEIGHTFIELDMAXCONTACTPERCELL & ~NUMC_MASK) == 0);
-			} else {//#else // if defined(NO_CONTACT_CULLING_BY_ISONHEIGHTFIELD2)
-				//				int numMaxContactsPerPlane = dMIN(numMaxContactsPossible - numTerrainContacts, HEIGHTFIELDMAXCONTACTPERCELL);
-				//				int planeTestFlags = (flags & ~NUMC_MASK) | numMaxContactsPerPlane;
-				numMaxContactsPerPlane = (int) dMIN(numMaxContactsPossible - numTerrainContacts, HEIGHTFIELDMAXCONTACTPERCELL);
-				planeTestFlags = (flags & ~NUMC_MASK) | numMaxContactsPerPlane;
-				//dIASSERT((HEIGHTFIELDMAXCONTACTPERCELL & ~NUMC_MASK) == 0);
-			}//#endif
+			 */
+			planeTestFlags = (flags & ~NUMC_MASK) | HEIGHTFIELDMAXCONTACTPERCELL;
+			dSASSERT((HEIGHTFIELDMAXCONTACTPERCELL & ~NUMC_MASK) == 0);
 
 			for (int k = 0; k < numPlanes; k++)
 			{
@@ -1255,82 +1234,89 @@ public class DxHeightfield extends DxAbstractHeightfield {
 				HeightFieldPlane itPlane = tempPlaneBuffer[k];
 
 				//set Geom
-				dGeomPlaneSetNoNormalize (sliding_plane,  itPlane.planeDefV, itPlane.planeDefD);
+				dGeomPlaneSetNoNormalize(sliding_plane, itPlane.planeDefV, itPlane.planeDefD);
 				//dGeomPlaneSetParams (sliding_plane, triangle_Plane[0], triangle_Plane[1], triangle_Plane[2], triangle_Plane[3]);
+
 				// find collision and compute contact points
 				boolean didCollide = false;
 				final int numPlaneContacts = 
-					geomNPlaneCollider.dColliderFn(o2, sliding_plane, planeTestFlags, PlaneContact);//, sizeof(dContactGeom));
+					geomNPlaneCollider.dColliderFn(o2, sliding_plane, planeTestFlags, planeContact);//, sizeof(dContactGeom));
 				final int planeTriListSize = itPlane.trianglelistCurrentSize;
+
 				for (int i = 0; i < numPlaneContacts; i++)
 				{
-					DContactGeom planeCurrContact = PlaneContact.get(i);
+					DContactGeom planeCurrContact = planeContact.get(i);
 					// Check if contact point found in plane is inside Triangle.
-					final DVector3C pCPos = planeCurrContact.pos;
-					for (int b = 0; planeTriListSize > b; b++)
+					final DVector3C contactPos = planeCurrContact.pos;
+
+					DVector3 triangleTestPos = new DVector3();
+					OdeMath.dAddVectorScaledVector3(triangleTestPos, contactPos, itPlane.planeDefV, planeCurrContact.depth);
+
+					for (int b = 0; b < planeTriListSize; b++)
 					{
-						if (m_p_data.IsOnHeightfield2 (itPlane.trianglelist[b].vertices[0],
-								pCPos,
+						HeightFieldTriangle testTriangle = itPlane.trianglelist[b];
+
+						if (m_p_data.IsOnHeightfield2 (testTriangle.vertices[0],
+								triangleTestPos,
 								itPlane.trianglelist[b].isUp))
 						{
 							pContact = contacts.get(numTerrainContacts*skip);//CONTACT(contact, numTerrainContacts*skip);
-							pContact.pos.set(pCPos);//dVector3Copy(pCPos, pContact.pos);
+							pContact.pos.set(triangleTestPos); //dCopyVector3(pContact->pos, triangleTestPos);
 							//dOPESIGN(pContact.normal, =, -, itPlane.planeDef);
 							pContact.normal.set(itPlane.planeDefV).scale(-1);
 							pContact.depth = planeCurrContact.depth;
 							pContact.side1 = planeCurrContact.side1;
 							pContact.side2 = planeCurrContact.side2;
 							numTerrainContacts++;
-							if ( numTerrainContacts == numMaxContactsPossible )
+							if ( numTerrainContacts == numMaxContactsPossible) {
 								return numTerrainContacts;
+							}
 
 							didCollide = true;
 							break;
 						}
 					}
 				}
-				if (didCollide)
-				{
-					if (NO_CONTACT_CULLING_BY_ISONHEIGHTFIELD2) {//#if defined(NO_CONTACT_CULLING_BY_ISONHEIGHTFIELD2)
-						/* Note by Oleh_Derevenko:
-						This code is not used - see another note above
-						 */
-						numMaxContactsPerPlane = (int) dMIN(numMaxContactsPossible - numTerrainContacts, HEIGHTFIELDMAXCONTACTPERCELL);
-						planeTestFlags = (flags & ~NUMC_MASK) | numMaxContactsPerPlane;
-						//dIASSERT((HEIGHTFIELDMAXCONTACTPERCELL & ~NUMC_MASK) == 0);
-					}//#endif
-					for (int b = 0; planeTriListSize > b; b++)
-					{
-						// flag Triangles Vertices as collided
-						// to prevent any collision test of those
-						for (int i = 0; i < 3; i++)
-							itPlane.trianglelist[b].vertices[i].state = true;
+
+				if (needFurtherPasses) {
+					if (didCollide) {
+						for (int b = 0; b < planeTriListSize; b++) {
+							HeightFieldTriangle currTriangle = itPlane.trianglelist[b];
+
+							// flag Triangles Vertices as collided
+							// to prevent any collision test of those
+							for (int i = 0; i < 3; i++) {
+								currTriangle.vertices[i].state = true;
+							}
+						}
 					}
-				}
-				else
-				{
-					// flag triangle as not collided so that Vertices or Edge
-					// of that triangles will be checked.
-					for (int b = 0; planeTriListSize > b; b++)
+					// Allow triangles for further checks only if their plane collided.
+					// If the plane did not, neither the vertices nor the edges can.
+					else if (numPlaneContacts > 0)
 					{
-						itPlane.trianglelist[b].state = false;
+						// flag triangle as not collided so that Vertices or Edge
+						// of that triangles will be checked.
+						for (int b = 0; b < planeTriListSize; b++) {
+							itPlane.trianglelist[b].state = false;
+						}
+
+						anyIntersectingButNotCollided = true;
 					}
 				}
 			}
 		}
 
-
-
 		// pass2: VS triangle vertices
-		if (needFurtherPasses)
+		if (/*needFurtherPasses && */anyIntersectingButNotCollided)
 		{
+			dIASSERT(needFurtherPasses);
+
 			DxRay tempRay = new DxRay(null, 1);
 			double depth = 0;
-			boolean vertexCollided;
 
 			// Only one contact is necessary for ray test
 			int rayTestFlags = (flags & ~NUMC_MASK) | 1;
-			//dIASSERT((1 & ~NUMC_MASK) == 0);
+			//dSASSERT((1 & ~NUMC_MASK) == 0);
 			//
 			// Find Contact Penetration Depth of each vertices
 			//
@@ -1338,24 +1324,28 @@ public class DxHeightfield extends DxAbstractHeightfield {
 			{
 				//final HeightFieldTriangle * final itTriangle = &tempTriangleBuffer[k];
 				HeightFieldTriangle itTriangle = tempTriangleBuffer[k];  // final ? TZ
-				if (itTriangle.state == true)
-					continue;// plane triangle did already collide.
+				if (itTriangle.state) {
+					continue;// the triangle plane already collided
+				}
 
 				for (int i = 0; i < 3; i++)
 				{
 					//HeightFieldVertex *vertex = itTriangle.vertices[i];
 					HeightFieldVertex vertex = itTriangle.vertices[i];
-					if (vertex.state == true)
-						continue;// vertice did already collide.
+					if (vertex.state) {
+						continue; // the vertex already collided
+					}
 
-					vertexCollided = false;
+					boolean vertexCollided = false;
 					DVector3C triVertex = vertex.vertex;
-					if ( geomNDepthGetter!=null )
+
+					boolean depthGetterAvailable = false; // geomNDepthGetter != NULL;
+					// dIASSERT(geomNDepthGetter == null);
+
+					if (depthGetterAvailable) // TODO (TZ) report -> always false
 					{
-						depth = geomNDepthGetter.get( o2,
-								triVertex.get0(), triVertex.get1(), triVertex.get2() );
-						if (depth > dEpsilon)
-							vertexCollided = true;
+						depth = geomNDepthGetter.get( o2, triVertex.get0(), triVertex.get1(), triVertex.get2() );
+
 					}
 					else
 					{
@@ -1368,29 +1358,30 @@ public class DxHeightfield extends DxAbstractHeightfield {
 						//    - itTriangle->Normal[0], - itTriangle->Normal[1], - itTriangle->Normal[2] );
 						dGeomRaySetNoNormalize(tempRay, triVertex, itTriangle.planeDefV);
 
-						if ( geomRayNCollider.dColliderFn( tempRay, o2, rayTestFlags, PlaneContact) != 0)//, sizeof( dContactGeom ) ) )
+						if ( geomRayNCollider.dColliderFn(tempRay, o2, rayTestFlags, planeContact) != 0)//, sizeof( dContactGeom ) ) )
 						{
-							depth = PlaneContact.get(0).depth;
-							vertexCollided = true;
+							depth = planeContact.get(0).depth;
+							vertexCollided = depth >= dEpsilon;
 						}
 					}
+
 					if (vertexCollided)
 					{
 						pContact = contacts.get(numTerrainContacts*skip);//CONTACT(contact, numTerrainContacts*skip);
 						//create contact using vertices
-						//dVector3Copy (triVertex, pContact.pos);
+						// dCopyVector3(pContact->pos, triVertex);
 						pContact.pos.set(triVertex);
 						//create contact using Plane Normal
 						//dOPESIGN(pContact.normal, =, -, itTriangle.planeDef);
 						pContact.normal.set(itTriangle.planeDefV).scale(-1);
-
 						pContact.depth = depth;
 						pContact.side1 = -1;
 						pContact.side2 = -1;
 
 						numTerrainContacts++;
-						if ( numTerrainContacts == numMaxContactsPossible )
+						if (numTerrainContacts == numMaxContactsPossible) {
 							return numTerrainContacts;
+						}
 
 						vertex.state = true;
 					}
@@ -1399,40 +1390,48 @@ public class DxHeightfield extends DxAbstractHeightfield {
 		}
 
 		//	#ifdef _HEIGHTFIELDEDGECOLLIDING
-		//	    // pass3: VS triangle Edges
-		//	    if (needFurtherPasses)
-		//	    {
-		//	        dVector3 Edge;
-		//	        dxRay edgeRay(0, 1);
+		// pass3: VS triangle Edges
+		//	if (needFurtherPasses)
+		//	{
+		//		dVector3 edgeVector;
+		//		dxRay edgeRay(0, 1);
 		//
-		//			int numMaxContactsPerTri = dMIN(numMaxContactsPossible - numTerrainContacts, HEIGHTFIELDMAXCONTACTPERCELL);
-		//			int triTestFlags = (flags & ~NUMC_MASK) | numMaxContactsPerTri;
-		//			dIASSERT((HEIGHTFIELDMAXCONTACTPERCELL & ~NUMC_MASK) == 0);
+		//		int numMaxContactsPerTri = dMIN(numMaxContactsPossible - numTerrainContacts, HEIGHTFIELDMAXCONTACTPERCELL);
+		//		int triTestFlags = (flags & ~NUMC_MASK) | numMaxContactsPerTri;
+		//		dSASSERT((HEIGHTFIELDMAXCONTACTPERCELL & ~NUMC_MASK) == 0);
 		//
-		//	        for (unsigned int k = 0; k < numTri; k++)
-		//	        {
-		//	            final HeightFieldTriangle * final itTriangle = &tempTriangleBuffer[k];
+		//		for (unsigned int k = 0; k < numTri; k++)
+		//		{
+		//		const HeightFieldTriangle * const itTriangle = &tempTriangleBuffer[k];
 		//
-		//	            if (itTriangle.state == true)
-		//	                continue;// plane did already collide.
+		//			if (itTriangle->state)
+		//			{
+		//				continue; // the triangle plane already collided
+		//			}
 		//
-		//	            for (size_t m = 0; m < 3; m++)
-		//	            {
-		//	                final size_t next = (m + 1) % 3;
-		//	                HeightFieldVertex *vertex0 = itTriangle.vertices[m];
-		//	                HeightFieldVertex *vertex1 = itTriangle.vertices[next];
+		//			for (unsigned int m = 0; m < 3; m++)
+		//			{
+		//			const unsigned int next = (m + 1) % 3;
+		//				HeightFieldVertex *vertex0 = itTriangle->vertices[m];
+		//				HeightFieldVertex *vertex1 = itTriangle->vertices[next];
 		//
-		//	                // not concave or under the AABB
-		//	                // nor triangle already collided against vertices
-		//	                if (vertex0.state == true && vertex1.state == true)
-		//	                    continue;// plane did already collide.
+		//				// not concave or under the AABB
+		//				// nor triangle already collided against vertices
+		//				if (vertex0->state && vertex1->state)
+		//				{
+		//					continue; // the edge is not to be considered
+		//				}
 		//
-		//	                dVector3Subtract(vertex1.vertex, vertex0.vertex, Edge);
-		//	                edgeRay.length = dVector3Length (Edge);
-		//	                dGeomRaySetNoNormalize(edgeRay, vertex1.vertex, Edge);
+		//				dVector3Subtract(vertex1->vertex, vertex0->vertex, edgeVector);
+		//				edgeRay.length = dVector3Length(edgeVector);
+		//
+		//				if (edgeRay.length >= dEpsilon)
+		//				{
+		//					dScaleVector3(edgeVector, 1.0f / edgeRay.length);
+		//					dGeomRaySetNoNormalize(edgeRay, vertex1->vertex, edgeVector);
 		//					int prevTerrainContacts = numTerrainContacts;
 		//					pContact = CONTACT(contact, prevTerrainContacts*skip);
-		//	                final int numCollision = geomRayNCollider(&edgeRay,o2,triTestFlags,pContact,skip);
+		//				const int numCollision = geomRayNCollider(&edgeRay, o2, triTestFlags, pContact, skip);
 		//					dIASSERT(numCollision <= numMaxContactsPerTri);
 		//
 		//					if (numCollision)
@@ -1444,26 +1443,27 @@ public class DxHeightfield extends DxAbstractHeightfield {
 		//							pContact = CONTACT(contact, prevTerrainContacts*skip);
 		//
 		//							//create contact using Plane Normal
-		//							dOPESIGN(pContact.normal, =, -, itTriangle.planeDef);
+		//							dOPESIGN(pContact->normal, = , -, itTriangle->planeDef);
 		//
-		//							pContact.depth = DistancePointToLine(pContact.pos, vertex1.vertex, Edge, edgeRay.length);
+		//							pContact->depth = DistancePointToLine(pContact->pos, vertex1->vertex, edgeVector, edgeRay.length);
 		//						}
 		//						while (++prevTerrainContacts != numTerrainContacts);
 		//
-		//						if ( numTerrainContacts == numMaxContactsPossible )
+		//						if (numTerrainContacts == numMaxContactsPossible)
 		//							return numTerrainContacts;
 		//
 		//						numMaxContactsPerTri = dMIN(numMaxContactsPossible - numTerrainContacts, HEIGHTFIELDMAXCONTACTPERCELL);
 		//						triTestFlags = (flags & ~NUMC_MASK) | numMaxContactsPerTri;
-		//						dIASSERT((HEIGHTFIELDMAXCONTACTPERCELL & ~NUMC_MASK) == 0);
+		//						dSASSERT((HEIGHTFIELDMAXCONTACTPERCELL & ~NUMC_MASK) == 0);
 		//					}
-		//	            }
+		//				}
+		//			}
 		//
-		//	            itTriangle.vertices[0].state = true;
-		//	            itTriangle.vertices[1].state = true;
-		//	            itTriangle.vertices[2].state = true;
-		//	        }
-		//	    }
+		//			itTriangle->vertices[0]->state = true;
+		//			itTriangle->vertices[1]->state = true;
+		//			itTriangle->vertices[2]->state = true;
+		//		}
+		//	}
 		//	#endif // _HEIGHTFIELDEDGECOLLIDING
 		return numTerrainContacts;
 	}
@@ -1478,7 +1478,7 @@ public class DxHeightfield extends DxAbstractHeightfield {
 			int i;
 
 			// if ((flags & NUMC_MASK) == 0) -- An assertion check is made on entry
-			//	{ flags = (flags & ~NUMC_MASK) | 1; dIASSERT((1 & ~NUMC_MASK) == 0); }
+			//	{ flags = (flags & ~NUMC_MASK) | 1; dSASSERT((1 & ~NUMC_MASK) == 0); }
 
 			int numMaxTerrainContacts = (flags & NUMC_MASK);
 

--- a/core/src/main/java/org/ode4j/ode/internal/DxQuickStep.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxQuickStep.java
@@ -1606,7 +1606,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         
         int stage4b_allowedThreads = 1;
         if (IsStage4bJointInfosIterationRequired(localContext)) {
-            int allowedThreads = callContext.m_stepperAllowedThreads();
+            int allowedThreads = Math.max(callContext.m_stepperAllowedThreads(), callContext.m_lcpAllowedThreads());
             stage4b_allowedThreads += CalculateOptimalThreadsCount(localContext.m_nj, allowedThreads - stage4b_allowedThreads, dxQUICKSTEPISLAND_STAGE4B_STEP);
         }
 

--- a/core/src/main/java/org/ode4j/ode/internal/DxQuickStep.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxQuickStep.java
@@ -34,7 +34,7 @@ import static org.ode4j.ode.OdeMath.dMultiply2_333;
 import static org.ode4j.ode.OdeMath.dMultiplyAdd0_331;
 import static org.ode4j.ode.OdeMath.dSetCrossMatrixMinus;
 import static org.ode4j.ode.internal.Common.*;
-import static org.ode4j.ode.internal.Matrix.dSetZero;
+import static org.ode4j.ode.internal.Matrix.*;
 import static org.ode4j.ode.internal.Misc.dRandInt;
 import static org.ode4j.ode.internal.CommonEnums.*;
 import static org.ode4j.ode.internal.QuickStepEnums.*;
@@ -465,8 +465,8 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
             m_LCP_fcStartReleasee = null;
             m_ji_4a.set(0);
             m_mi_iMJ.set(0);
-			m_bi_forceMaxAdj = 0;
-			m_bi_fc = 0;
+			m_bi_forceMaxAdj.set(0);
+			m_bi_fc.set(0);
             m_mi_Ad.set(0);
             m_LCP_iteration = 0;
 			m_LCP_extra_num_iterations = 0;
@@ -512,21 +512,25 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         dxQuickStepperLocalContext m_localContext;
         double[] m_lambda;
         double[] m_cforce;
+		double[] m_forceMaxAdjustments;
         double[] m_iMJ;
         IndexError[] m_order;
         double[] m_last_lambda;
         AtomicInteger[] m_bi_links_or_mi_levels;
         AtomicInteger[] m_mi_links;
+		double m_LCP_iteration_premature_exit_delta;
         TaskGroup m_LCP_IterationSyncReleasee;
         int m_LCP_IterationAllowedThreads;
         TaskGroup m_LCP_fcStartReleasee;
         final AtomicInteger m_ji_4a = new AtomicInteger();
         final AtomicInteger m_mi_iMJ = new AtomicInteger();
-        final AtomicInteger m_mi_fc = new AtomicInteger();
+		final AtomicInteger m_bi_forceMaxAdj = new AtomicInteger();
+		final AtomicInteger m_bi_fc = new AtomicInteger();
         final AtomicInteger m_LCP_fcPrepareThreadsRemaining = new AtomicInteger();
         int m_LCP_fcCompleteThreadsTotal;
         final AtomicInteger m_mi_Ad = new AtomicInteger();
         int m_LCP_iteration;
+		int m_LCP_extra_num_iterations;
         int m_LCP_iterationThreadsTotal;
         final AtomicInteger m_LCP_iterationThreadsRemaining = new AtomicInteger();
         TaskGroup m_LCP_iterationNextReleasee;
@@ -563,15 +567,17 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	 * (TZ) Performs a 331 multiplication on the 3-5 and 9-11 parts of
 	 * each row and writes the result into iMJ.  
 	 */
-	private static void compute_invM_JT (AtomicInteger mi_storage, final int m, final double[] J, final double[] iMJ, 
-	        final int[] jb,
-			final DxBody[]bodyP, final int bodyOfs, final double[] invI, int step_size)
+	private static void compute_invM_JT (AtomicInteger mi_storage, final int m, final double[] J, final double[] iMJ,
+										 final int[] jb,
+										 final DxBody[]bodyP, final int bodyOfs, final double[] invI,
+										 boolean dynamicIterationCountAdjustmentEnabled,
+										 int step_size)
 	{
 		int m_steps = (m + (step_size - 1)) / step_size;
 	    int mi_step;
 	    while ((mi_step = Atomics.ThrsafeIncrementIntUpToLimit(mi_storage, m_steps)) != m_steps) {
 	        int mi = mi_step * step_size;
-	        int miend = mi + Math.min(step_size, m - mi);
+	        int miend = mi + dRESTRICT_STEP(step_size, m - mi);
 	        int iMJ_ptr = mi * IMJ__MAX;
 	        int J_ptr = mi * JME__MAX;
 	        while (true) {
@@ -581,12 +587,14 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	            for (int j = 0; j != JVE__L_COUNT; j++) iMJ[iMJ_ptr + IMJ__1L_MIN + j] = k1 * J[J_ptr + JME__J1L_MIN + j];
 	            int invIrow1 = b1 * IIE__MAX + IIE__MATRIX_MIN;
 	            dMultiply0_331 (iMJ, iMJ_ptr + IMJ__1A_MIN, invI, invIrow1, J, J_ptr + JME__J1A_MIN);
+				iMJ[iMJ_ptr + IMJ_1JVE_MAXABS] = dynamicIterationCountAdjustmentEnabled ? dxCalculateModuloMaximum(iMJ, iMJ_ptr + IMJ__1JVE_MIN, JVE__MAX) : 0.0;
 
 				if (b2 != -1) {
 					double k2 = bodyP[b2+bodyOfs].invMass;
 		            for (int j = 0; j != JVE__L_COUNT; ++j) iMJ[iMJ_ptr + IMJ__2L_MIN + j] = k2 * J[J_ptr + JME__J2L_MIN + j];
 		            int invIrow2 = b2 * IIE__MAX + IIE__MATRIX_MIN;
 		            dMultiply0_331 (iMJ, iMJ_ptr + IMJ__2A_MIN, invI, invIrow2, J, J_ptr + JME__J2A_MIN);
+					iMJ[iMJ_ptr + IMJ_2JVE_MAXABS] = dynamicIterationCountAdjustmentEnabled ? dxCalculateModuloMaximum(iMJ, iMJ_ptr + IMJ__2JVE_MIN, JVE__MAX) : 0.0;
 				}
 
 	            if (++mi == miend) {
@@ -614,7 +622,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	    int mi_step;
 	    while ((mi_step = Atomics.ThrsafeIncrementIntUpToLimit(mi_storage, m_steps)) != m_steps) {
 	        int mi = mi_step * step_size;
-	        int miend = mi + Math.min(step_size, m - mi);
+	        int miend = mi + dRESTRICT_STEP(step_size, m - mi);
 	        int J_ptr = mi * JME__MAX;
 	        while (true) {
 				int b1 = first(jb, mi);
@@ -769,14 +777,14 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	private static
 	void dxQuickStepIsland_Stage0_Bodies(dxQuickStepperStage0BodiesCallContext callContext)
 	{
-	    DxBody[] bodyP = callContext.m_stepperCallContext.m_islandBodiesStartA();
+	    DxBody[] bodyA = callContext.m_stepperCallContext.m_islandBodiesStartA();
 	    int bodyOfs = callContext.m_stepperCallContext.m_islandBodiesStartOfs();
 	    int nb = callContext.m_stepperCallContext.m_islandBodiesCount();
 
 	    if (Atomics.ThrsafeExchange(callContext.m_tagsTaken, 1) == 0)
 	    {
 	        // number all bodies in the body list - set their tag values
-	        for (int i=0; i<nb; i++) bodyP[bodyOfs+i].tag = i;
+	        for (int i=0; i<nb; i++) bodyA[bodyOfs+i].tag = i;
 	    }
 
 	    if (Atomics.ThrsafeExchange(callContext.m_gravityTaken, 1) == 0)
@@ -787,29 +795,30 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 		    // since gravity does normally have only one component it's more efficient
 		    // to run three loops for each individual component
 		    double gravity_x = world.gravity.get0();
+			dAssertDSA();
 		    if (gravity_x != 0) {
 		        for (int i=0; i<nb; i++) {
-		            DxBody b = bodyP[i+bodyOfs];
+		            DxBody b = bodyA[i+bodyOfs];
 		            if ((b.flags & DxBody.dxBodyNoGravity)==0) {
-		                b.facc.add(0, b.mass._mass * gravity_x);
+		                b.facc.add(dSA_X, b.mass._mass * gravity_x);
 		            }
 		        }
 		    }
 		    double gravity_y = world.gravity.get1();
 		    if (gravity_y != 0) {
 		        for (int i=0; i<nb; i++) {
-		            DxBody b = bodyP[i+bodyOfs];
+		            DxBody b = bodyA[i+bodyOfs];
 		            if ((b.flags & DxBody.dxBodyNoGravity)==0) {
-		                b.facc.add(1, b.mass._mass * gravity_y);
+		                b.facc.add(dSA_Y, b.mass._mass * gravity_y);
 		            }
 		        }
 		    }
 		    double gravity_z = world.gravity.get2();
 		    if (gravity_z != 0) {
 		        for (int i=0; i<nb; i++) {
-		            DxBody b = bodyP[i+bodyOfs];
+		            DxBody b = bodyA[i+bodyOfs];
 		            if ((b.flags & DxBody.dxBodyNoGravity)==0) {
-		                b.facc.add(2, b.mass._mass * gravity_z);
+		                b.facc.add(dSA_Z, b.mass._mass * gravity_z);
 		            }
 		        }
 		    }
@@ -819,88 +828,102 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	    // frame, and compute the rotational force and add it to the torque
 	    // accumulator. I and invI are a vertical stack of 3x4 matrices, one per body.
         double[] invIA = callContext.m_invI;
-        int bodyIndex ;
-        while ((bodyIndex = Atomics.ThrsafeIncrementIntUpToLimit(callContext.m_inertiaBodyIndex, nb)) != nb) {
-            int invIrowP = bodyIndex * IIE__MAX;
-            DMatrix3 tmp = new DMatrix3();
-            DxBody b = bodyP[bodyIndex + bodyOfs];
 
-            // compute inverse inertia tensor in global frame
-            dMultiply2_333 (tmp,b.invI,b.posr().R());
-			dMultiply0_333(invIA, invIrowP + IIE__MATRIX_MIN, b.posr().R(), tmp);
+        final int step_size = dxQUICKSTEPISLAND_STAGE0_BODIES_STEP;
+		int nb_steps = (nb + (step_size - 1)) / step_size;
 
-            // Don't apply gyroscopic torques to bodies
-            // if not flagged or the body is kinematic
-            if (b.isFlagsGyroscopic() && (b.invMass>0)) {
-                DMatrix3 I = new DMatrix3();
-                // compute inertia tensor in global frame
-                dMultiply2_333 (tmp,b.mass._I,b.posr().R());
-                dMultiply0_333 (I,b.posr().R(),tmp);
-                // compute rotational force
-//	#if 0
-//	                    // Explicit computation
-//	                    dMultiply0_331 (tmp,I,b.avel);
-//	                    dSubtractVectorCross3(b.tacc,b.avel,tmp);
-//	#else
-                // Do the implicit computation based on 
-                //"Stabilizing Gyroscopic Forces in Rigid Multibody Simulations"
-                // (LacoursiÃ¨re 2006)
-                double h = callContext.m_stepperCallContext.m_stepSize(); // Step size
-                DVector3 L = new DVector3(); // Compute angular momentum
-                dMultiply0_331(L,I,b.avel);
-                
-                // Compute a new effective 'inertia tensor'
-                // for the implicit step: the cross-product 
-                // matrix of the angular momentum plus the
-                // old tensor scaled by the timestep.  
-                // Itild may not be symmetric pos-definite, 
-                // but we can still use it to compute implicit
-                // gyroscopic torques.
-                DMatrix3 Itild= new DMatrix3();//{0};  
-                dSetCrossMatrixMinus(Itild,L);//,4);
-//	                    for (int ii=0;ii<12;++ii) {
-//	                      Itild[ii]=Itild[ii]*h+I[ii];
-//	                    }
-                Itild.scale(h);
-                Itild.add(I);
+		int bi_step;
+        while ((bi_step = Atomics.ThrsafeIncrementIntUpToLimit(callContext.m_inertiaBodyIndex, nb_steps)) != nb_steps) {
+			int bi = bi_step * step_size;
+            final int biend = bi + dRESTRICT_STEP(step_size, nb - bi);
 
-                // Scale momentum by inverse time to get 
-                // a sort of "torque"
-                L.scale(dRecip(h));//dScaleVector3(L,dRecip(h)); 
-                // Invert the pseudo-tensor
-                DMatrix3 itInv = new DMatrix3();
-                // This is a closed-form inversion.
-                // It's probably not numerically stable
-                // when dealing with small masses with
-                // a large asymmetry.
-                // An LU decomposition might be better.
-                if (dInvertMatrix3(itInv,Itild)!=0) {
-                    // "Divide" the original tensor
-                    // by the pseudo-tensor (on the right)
-                    dMultiply0_333(Itild,I,itInv);
-                    // Subtract an identity matrix
-                    //Itild[0]-=1; Itild[5]-=1; Itild[10]-=1;
-                    Itild.sub(0, 0, 1);
-                    Itild.sub(1, 1, 1);
-                    Itild.sub(2, 2, 1);
+			// for (dReal *invIrow = invI + (sizeint)bi * IIE__MAX; ; invIrow += IIE__MAX) {
+			for (int invIrowP = bi * IIE__MAX; ; invIrowP += IIE__MAX) {
+				DxBody b = bodyA[bi + bodyOfs];
 
-                    // This new inertia matrix rotates the 
-                    // momentum to get a new set of torques
-                    // that will work correctly when applied
-                    // to the old inertia matrix as explicit
-                    // torques with a semi-implicit update
-                    // step.
-                    DVector3 tau0 = new DVector3();
-                    dMultiply0_331(tau0,Itild,L);
-                    
-                    // Add the gyro torques to the torque 
-                    // accumulator
-                    //for (int ii=0;ii<3;++ii) {
-                    //  b.tacc[ii]+=tau0[ii];
-                    //}
-                    b.tacc.add(tau0);
-                }
-//	#endif
+	            DMatrix3 tmp = new DMatrix3();
+				// compute inverse inertia tensor in global frame
+				dMultiply2_333 (tmp,b.invI,b.posr().R());
+				dMultiply0_333(invIA, invIrowP + IIE__MATRIX_MIN, b.posr().R(), tmp);
+
+				// Don't apply gyroscopic torques to bodies
+				// if not flagged or the body is kinematic
+				if (b.isFlagsGyroscopic() && (b.invMass>0)) {
+					DMatrix3 I = new DMatrix3();
+					// compute inertia tensor in global frame
+					dMultiply2_333(tmp, b.mass._I, b.posr().R());
+					dMultiply0_333(I, b.posr().R(), tmp);
+					// compute rotational force
+
+					//	#if 0
+					//	                    // Explicit computation
+					//	                    dMultiply0_331 (tmp,I,b.avel);
+					//	                    dSubtractVectorCross3(b.tacc,b.avel,tmp);
+					//	#else
+
+					// Do the implicit computation based on
+					//"Stabilizing Gyroscopic Forces in Rigid Multibody Simulations"
+					// (LacoursiÃ¨re 2006)
+					double h = callContext.m_stepperCallContext.m_stepSize(); // Step size
+					DVector3 L = new DVector3(); // Compute angular momentum
+					dMultiply0_331(L, I, b.avel);
+
+					// Compute a new effective 'inertia tensor'
+					// for the implicit step: the cross-product
+					// matrix of the angular momentum plus the
+					// old tensor scaled by the timestep.
+					// Itild may not be symmetric pos-definite,
+					// but we can still use it to compute implicit
+					// gyroscopic torques.
+					DMatrix3 Itild = new DMatrix3();//{0};
+					dSetCrossMatrixMinus(Itild, L);//,4);
+					//	                    for (int ii=0;ii<12;++ii) {
+					//	                      Itild[ii]=Itild[ii]*h+I[ii];
+					//	                    }
+					Itild.scale(h);
+					Itild.add(I);
+
+					// Scale momentum by inverse time to get
+					// a sort of "torque"
+					L.scale(dRecip(h));//dScaleVector3(L,dRecip(h));
+					// Invert the pseudo-tensor
+					DMatrix3 itInv = new DMatrix3();
+					// This is a closed-form inversion.
+					// It's probably not numerically stable
+					// when dealing with small masses with
+					// a large asymmetry.
+					// An LU decomposition might be better.
+					if (dInvertMatrix3(itInv, Itild) != 0) {
+						// "Divide" the original tensor
+						// by the pseudo-tensor (on the right)
+						dMultiply0_333(Itild, I, itInv);
+						// Subtract an identity matrix
+						//Itild[0]-=1; Itild[5]-=1; Itild[10]-=1;
+						Itild.sub(0, 0, 1);
+						Itild.sub(1, 1, 1);
+						Itild.sub(2, 2, 1);
+
+						// This new inertia matrix rotates the
+						// momentum to get a new set of torques
+						// that will work correctly when applied
+						// to the old inertia matrix as explicit
+						// torques with a semi-implicit update
+						// step.
+						DVector3 tau0 = new DVector3();
+						dMultiply0_331(tau0, Itild, L);
+
+						// Add the gyro torques to the torque
+						// accumulator
+						//for (int ii=0;ii<3;++ii) {
+						//  b.tacc[ii]+=tau0[ii];
+						//}
+						b.tacc.add(tau0);
+					}
+					//	#endif
+				}
+				if (++bi == biend) {
+					break;
+				}
             }
 	    }
 	}
@@ -1056,7 +1079,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
                         dxQuickStepIsland_Stage2aSync(stage2CallContext, stage2bSync);
                     }
                 });
-                int stage2a_allowedThreads = CalculateOptimalThreadsCount(nj, allowedThreads, 1);
+                int stage2a_allowedThreads = CalculateOptimalThreadsCount(nj, allowedThreads, dxQUICKSTEPISLAND_STAGE2A_STEP);
                 for (int i = 1; i < stage2a_allowedThreads; i ++) {
                     Task bodies = stage2aSync.subtask("QuickStepIsland Stage2a", new Runnable() {
                         @Override
@@ -1156,89 +1179,106 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 
 	        int validFIndices = 0;
 
-	        int ji;
-	        while ((ji = Atomics.ThrsafeIncrementIntUpToLimit(stage2CallContext.m_ji_J, nj)) != nj) {
-				final int ofsi = getMIndex(mindex, ji);
-				final int infom = getMIndex(mindex, ji + 1) - ofsi;
-	            int jRow = ofsi * JME__MAX;
-				{
-					int jEnd = jRow + infom * JME__MAX;
-					for (int jCurr = jRow; jCurr != jEnd; jCurr += JME__MAX) {
-						dSetZero(J, jCurr + JME__J1_MIN, JME__J1_COUNT);
-						J[jCurr + JME_RHS] = 0.0;
-						J[jCurr + JME_CFM] = worldCFM;
-						dSetZero(J, jCurr + JME__J2_MIN, JME__J2_COUNT);
-						J[jCurr + JME_LO] = -dInfinity;
-						J[jCurr + JME_HI] = dInfinity;
+			final int step_size = dxQUICKSTEPISLAND_STAGE2A_STEP;
+			int nj_steps = (nj + (step_size - 1)) / step_size;
+
+			int ji_step;
+	        while ((ji_step = Atomics.ThrsafeIncrementIntUpToLimit(stage2CallContext.m_ji_J, nj_steps)) != nj_steps) {
+				int ji = ji_step * step_size;
+	            final int jiend = ji + dRESTRICT_STEP(step_size, nj - ji);
+
+				for (int infom, ofsi = getMIndex(mindex, ji); ; ofsi += infom) {
+					infom = getMIndex(mindex, ji + 1) - ofsi;
+
+					int jRow = ofsi * JME__MAX;
+					{
+						int jEnd = jRow + infom * JME__MAX;
+						for (int jCurr = jRow; jCurr != jEnd; jCurr += JME__MAX) {
+							dSetZero(J, jCurr + JME__J1_MIN, JME__J1_COUNT);
+							J[jCurr + JME_RHS] = 0.0;
+							J[jCurr + JME_CFM] = worldCFM;
+							dSetZero(J, jCurr + JME__J2_MIN, JME__J2_COUNT);
+							J[jCurr + JME_LO] = -dInfinity;
+							J[jCurr + JME_HI] = dInfinity;
+						}
+						dSASSERT(JME__J1_COUNT + 2 + JME__J2_COUNT + 2 == JME__MAX);
 					}
-					dSASSERT(JME__J1_COUNT + 2 + JME__J2_COUNT + 2 == JME__MAX);
-				}
-	            int findexRow = ofsi;
-	            dSetValue(findex, findexRow, infom, -1);
+					int findexRow = ofsi;
+					dSetValue(findex, findexRow, infom, -1);
 
-	            DxJoint joint = jointinfos[ji].joint;
-				joint.getInfo2(stepsizeRecip, worldERP, JME__MAX, J, jRow + JME__J1_MIN, J, jRow + JME__J2_MIN,
-						JME__MAX, J, jRow + JME__RHS_CFM_MIN, J, jRow + JME__LO_HI_MIN, findex, findexRow);
+					DxJoint joint = jointinfos[ji].joint;
+					joint.getInfo2(stepsizeRecip, worldERP, JME__MAX, J, jRow + JME__J1_MIN, J, jRow + JME__J2_MIN,
+							JME__MAX, J, jRow + JME__RHS_CFM_MIN, J, jRow + JME__LO_HI_MIN, findex, findexRow);
 
-	            // findex iteration is compact and is not going to pollute caches - do it first
-				{
-					// adjust returned findex values for global index numbering
-					int findicesEndOfs = findexRow + infom;
-					for (int findexCurrOfs = findexRow; findexCurrOfs != findicesEndOfs; ++findexCurrOfs) {
-						int fival = findex[findexCurrOfs]; // *findexCurr;
-						if (fival != -1) {
-							findex[findexCurrOfs] = fival + ofsi; // *findexCurr = fival + ofsi;
-							++validFIndices;
+					// findex iteration is compact and is not going to pollute caches - do it first
+					{
+						// adjust returned findex values for global index numbering
+						int findicesEndOfs = findexRow + infom;
+						for (int findexCurrOfs = findexRow; findexCurrOfs != findicesEndOfs; ++findexCurrOfs) {
+							int fival = findex[findexCurrOfs]; // *findexCurr;
+							if (fival != -1) {
+								findex[findexCurrOfs] = fival + ofsi; // *findexCurr = fival + ofsi;
+								++validFIndices;
+							}
+						}
+						// TZ: This looks alright, but is different from the original where we use findexRow
+						//					for (int j = infom; j != 0; ) {
+						//						--j;
+						//						int fival = findex[j + ofsi];
+						//						if (fival != -1) {
+						//							findex[j + ofsi] = fival + ofsi;
+						//							++validFIndices;
+						//						}
+						//					}
+					}
+					{
+						// dReal *const JEnd = JRow + infom * JME__MAX;
+						int jEnd = jRow + infom * JME__MAX;
+						for (int jCurr = jRow; jCurr != jEnd; jCurr += JME__MAX) {
+							J[jCurr + JME_RHS] *= stepsizeRecip;
+							J[jCurr + JME_CFM] *= stepsizeRecip;
 						}
 					}
-					// TZ: This looks alright, but is different from the original where we use findexRow
-//					for (int j = infom; j != 0; ) {
-//						--j;
-//						int fival = findex[j + ofsi];
-//						if (fival != -1) {
-//							findex[j + ofsi] = fival + ofsi;
-//							++validFIndices;
-//						}
-//					}
-				}
-				{
-					// dReal *const JEnd = JRow + infom * JME__MAX;
-					int jEnd = jRow + infom * JME__MAX;
-					for (int jCurr = jRow; jCurr != jEnd; jCurr += JME__MAX) {
-						J[jCurr + JME_RHS] *= stepsizeRecip;
-						J[jCurr + JME_CFM] *= stepsizeRecip;
-					}
-				}
-	            // we need a copy of Jacobian for joint feedbacks
-	            // because it gets destroyed by SOR solver
-	            // instead of saving all Jacobian, we can save just rows
-	            // for joints, that requested feedback (which is normally much less)
-				int mfbIndex = getFbIndex(mindex, ji); //mindex[ji].fbIndex;
-				if (mfbIndex != getMIndex(mindex, ji + 1)) { //mindex[ji + 1].fbIndex) {
-				// dReal *const JEnd = JRow + infom * JME__MAX;
-				// dReal *JCopyRow = JCopy + mfbIndex * JCE__MAX; // Random access by mfbIndex here! Do not optimize!
-					final int jEnd = jRow + infom * JME__MAX;
-					int JCopyRow = jCopy_ofs + mfbIndex * JCE__MAX; // Random access by mfbIndex here! Do not optimize!
-					//for (const dReal *JCurr = JRow; ; ) {
-					for (int jCurr = jRow; jCurr < jEnd ;) {
-						//for (unsigned i = 0; i != JME__J1_COUNT; ++i) { JCopyRow[i + JCE__J1_MIN] = JCurr[i + JME__J1_MIN]; }
-						//for (unsigned j = 0; j != JME__J2_COUNT; ++j) { JCopyRow[j + JCE__J2_MIN] = JCurr[j + JME__J2_MIN]; }
-						System.arraycopy(J, jCurr + JME__J1_MIN, Jcopy, JCopyRow + JCE__J1_MIN, JME__J1_COUNT);
-						System.arraycopy(J, jCurr + JME__J2_MIN, Jcopy, JCopyRow + JCE__J2_MIN, JME__J2_COUNT);
-						JCopyRow += JCE__MAX;
+					{
+						// we need a copy of Jacobian for joint feedbacks
+						// because it gets destroyed by SOR solver
+						// instead of saving all Jacobian, we can save just rows
+						// for joints, that requested feedback (which is normally much less)
+						int mfbIndex = getFbIndex(mindex, ji); //mindex[ji].fbIndex;
+						if (mfbIndex != getMIndex(mindex, ji + 1)) { //mindex[ji + 1].fbIndex) {
+							// dReal *const JEnd = JRow + infom * JME__MAX;
+							// dReal *JCopyRow = JCopy + mfbIndex * JCE__MAX; // Random access by mfbIndex here! Do not optimize!
+							final int jEnd = jRow + infom * JME__MAX;
+							int JCopyRow = jCopy_ofs + mfbIndex * JCE__MAX; // Random access by mfbIndex here! Do not optimize!
+							//for (const dReal *JCurr = JRow; ; ) {
+							for (int jCurr = jRow; jCurr < jEnd; ) {
+								//for (unsigned i = 0; i != JME__J1_COUNT; ++i) { JCopyRow[i + JCE__J1_MIN] = JCurr[i + JME__J1_MIN]; }
+								//for (unsigned j = 0; j != JME__J2_COUNT; ++j) { JCopyRow[j + JCE__J2_MIN] = JCurr[j + JME__J2_MIN]; }
+								System.arraycopy(J, jCurr + JME__J1_MIN, Jcopy, JCopyRow + JCE__J1_MIN, JME__J1_COUNT);
+								System.arraycopy(J, jCurr + JME__J2_MIN, Jcopy, JCopyRow + JCE__J2_MIN, JME__J2_COUNT);
+								JCopyRow += JCE__MAX;
 
-						// TZ move this outside of loop
-						// dSASSERT((unsigned)JCE__J1_COUNT == JME__J1_COUNT);
-						// dSASSERT((unsigned)JCE__J2_COUNT == JME__J2_COUNT);
-						// dSASSERT(JCE__J1_COUNT + JCE__J2_COUNT == JCE__MAX);
+								// TZ move this outside of loop
+								// dSASSERT((unsigned)JCE__J1_COUNT == JME__J1_COUNT);
+								// dSASSERT((unsigned)JCE__J2_COUNT == JME__J2_COUNT);
+								// dSASSERT(JCE__J1_COUNT + JCE__J2_COUNT == JCE__MAX);
 
-						if ((jCurr += JME__MAX) == jEnd) {
-							break;
+								if ((jCurr += JME__MAX) == jEnd) {
+									break;
+								}
+							}
 						}
 					}
-                }
+
+					if (++ji == jiend) {
+						break;
+					}
+				}
 	        }
-    	    Atomics.ThrsafeAdd(localContext.m_valid_findices, validFIndices);
+
+			if (validFIndices != 0) {
+				Atomics.ThrsafeAdd(localContext.m_valid_findices, validFIndices);
+			}
 	    }
 
 		// TZ moved this here from inside loop above.
@@ -1250,20 +1290,35 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	        int[] jb = localContext.m_jb;
 
 	        // create an array of body numbers for each joint row
-	        int ji;
-	        while ((ji = Atomics.ThrsafeIncrementIntUpToLimit(stage2CallContext.m_ji_jb, nj)) != nj) {
-	        	DxJoint joint = jointinfos[ji].joint;
-		                
-	        	int b1 = (joint.node[0].body!=null) ? (joint.node[0].body.tag) : -1;
-	        	int b2 = (joint.node[1].body!=null) ? (joint.node[1].body.tag) : -1;
+			final int step_size = dxQUICKSTEPISLAND_STAGE2A_STEP;
+			int nj_steps = (nj + (step_size - 1)) / step_size;
 
-	        	int jb_end = 2 * getMIndex(mindex, ji + 1);
-	        	int jb_ptr = 2 * getMIndex(mindex, ji);
-	        	for (; jb_ptr != jb_end; jb_ptr += 2) {
-	        		jb[jb_ptr] = b1;
-	        		jb[jb_ptr+1] = b2;
-	        	}
-	        }
+			int ji_step;
+			while ((ji_step = Atomics.ThrsafeIncrementIntUpToLimit(stage2CallContext.m_ji_jb, nj_steps)) != nj_steps) {
+				int ji = ji_step * step_size;
+				final int jiend = ji + dRESTRICT_STEP(step_size, nj - ji);
+
+				for (int infom, ofsi = getMIndex(mindex, ji); ; ofsi += infom) {
+					infom = getMIndex(mindex, ji + 1) - ofsi;
+
+					DxJoint joint = jointinfos[ji].joint;
+					int b1 = (joint.node[0].body != null) ? (joint.node[0].body.tag) : -1;
+					int b2 = (joint.node[1].body != null) ? (joint.node[1].body.tag) : -1;
+
+					//	dxJBodiesItem *jb_ptr = jb + ofsi;
+					//	dxJBodiesItem *const jb_end = jb_ptr + infom;
+					int jb_ptr = 0 + ofsi;
+					final int jb_end = jb_ptr + infom;
+					for (; jb_ptr != jb_end; ++jb_ptr) {
+						jb[jb_ptr * 2] = b1;
+						jb[jb_ptr * 2 + 1] = b2;
+					}
+
+					if (++ji == jiend) {
+						break;
+					}
+				}
+			}
 	    }
 	}
 
@@ -1296,7 +1351,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	        int bi_step;
 	        while ((bi_step = Atomics.ThrsafeIncrementIntUpToLimit(stage2CallContext.m_bi, nb_steps)) != nb_steps) {
 	            int bi = bi_step * step_size;
-	            int biend = bi + Math.min(step_size, nb - bi);
+	            int biend = bi + dRESTRICT_STEP(step_size, nb - bi);
 	            int rhscurr = bi * RHS__MAX;
 	            int invIrow = bi * IIE__MAX;
 	            while (true) {
@@ -1363,6 +1418,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
             int nb = callContext.m_islandBodiesCount();
 
             double[] cforce = memarena.AllocateArrayDReal(nb * CFE__MAX);
+			double[] forceMaxAdjustments = memarena.AllocateArrayDReal(nb * FAE__MAX);
             double[] iMJ = memarena.AllocateArrayDReal(m * IMJ__MAX);//, INVMJ_ALIGNMENT);
 	        // order to solve constraint rows in
 	        IndexError[] order = new IndexError[m];
@@ -1376,7 +1432,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	        	last_lambda = memarena.AllocateArrayDReal(m);
 	        }
 
-	        int allowedThreads = callContext.m_stepperAllowedThreads();
+	        int allowedThreads = callContext.m_lcpAllowedThreads();
 	        boolean singleThreadedExecution = allowedThreads == 1;
 
 	        AtomicInteger[] bi_links_or_mi_levels = null;
@@ -1389,7 +1445,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	        }
 
 	        final dxQuickStepperStage4CallContext stage4CallContext = new dxQuickStepperStage4CallContext();
-	        stage4CallContext.Initialize(callContext, localContext, lambda, cforce, iMJ, order, last_lambda, bi_links_or_mi_levels, mi_links);
+	        stage4CallContext.Initialize(callContext, localContext, lambda, cforce, forceMaxAdjustments, iMJ, order, last_lambda, bi_links_or_mi_levels, mi_links);
         
 	        if (singleThreadedExecution) {
 	            dxQuickStepIsland_Stage4a(stage4CallContext);
@@ -1401,18 +1457,52 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	            dxQuickStepIsland_Stage4LCP_ReorderPrep(stage4CallContext);
 	            
 	            DxWorld world = callContext.m_world();
-	            int num_iterations = world.qs.num_iterations;
-				for (int iteration = 0; iteration < num_iterations; iteration++) {
+//	            int num_iterations = world.qs.num_iterations;
+//				for (int iteration = 0; iteration < num_iterations; iteration++) {
+				final boolean dynamicIterationCountAdjustmentEnabled = world.qs.GetIsDynamicIterationCountAdjustmentEnabled();
+				double prematureExitDelta = world.qs.GetPrematureExitDelta();
+				final int num_iterations = world.qs.m_iterationCount;
+
+				for (int iteration = 0, extra_num_iterations = 0; ; ) {
 					if (IsSORConstraintsReorderRequiredForIteration(iteration)) {
 						stage4CallContext.ResetSOR_ConstraintsReorderVariables(0);
 						dxQuickStepIsland_Stage4LCP_ConstraintsShuffling(stage4CallContext, iteration);
 					}
+
 					dxQuickStepIsland_Stage4LCP_STIteration(stage4CallContext);
-	            }
+					++iteration;
+
+					if (iteration - extra_num_iterations == num_iterations) {
+						if (extra_num_iterations != 0 || world.qs.m_maxExtraIterationCount == 0) {
+							if (extra_num_iterations != 0) {
+								AtomicInteger fullExtraExecutionsStorage = world.qs.GetStatisticsFullExtraExecutionsStorage();
+								Atomics.ThrsafeIncrementNoResult(fullExtraExecutionsStorage);
+							}
+							break;
+						}
+
+						extra_num_iterations = world.qs.m_maxExtraIterationCount;
+						prematureExitDelta = world.qs.GetExtraIterationsRequirementDelta();
+					}
+
+					if (dynamicIterationCountAdjustmentEnabled && CheckForMaximumToBeLessThanLimitAndResetMaxAdjustments(stage4CallContext.m_forceMaxAdjustments, nb, prematureExitDelta)) {
+						if (iteration < num_iterations) {
+							AtomicInteger prematureExitsStorage = world.qs.GetStatisticsPrematureExitsStorage();
+							Atomics.ThrsafeIncrementNoResult(prematureExitsStorage);
+						}
+						else if (iteration > num_iterations) {
+							AtomicInteger prolongedExecutionsStorage = world.qs.GetStatisticsProlongedExecutionsStorage();
+							Atomics.ThrsafeIncrementNoResult(prolongedExecutionsStorage);
+						}
+						break;
+					}	            }
 	            dxQuickStepIsland_Stage4b(stage4CallContext);
 	            dxQuickStepIsland_Stage5(stage5CallContext);
 	        } else {
-	            final TaskGroup stage5 = callContext.m_taskGroup().subgroup("QuickStepIsland Stage5", new Runnable() {
+				DxWorld world = callContext.m_world();
+				stage4CallContext.m_LCP_iteration_premature_exit_delta = world.qs.GetPrematureExitDelta();
+
+				final TaskGroup stage5 = callContext.m_taskGroup().subgroup("QuickStepIsland Stage5", new Runnable() {
                     @Override
                     public void run() {
                         dxQuickStepIsland_Stage5(stage5CallContext);
@@ -1504,7 +1594,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         while ((ji_step = Atomics.ThrsafeIncrementIntUpToLimit(stage4CallContext.m_ji_4a, nj_steps)) != nj_steps) {
             int ji = ji_step * step_size;
             int lambdacurr = getMIndex(mindex, ji);
-            int lambdsnext = getMIndex(mindex, ji + Math.min(step_size, nj - ji));
+            int lambdsnext = getMIndex(mindex, ji + dRESTRICT_STEP(step_size, nj - ji));
             dSetZero(lambda, lambdacurr, lambdsnext - lambdacurr);
         }
     }
@@ -1547,9 +1637,10 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	    DxBody[] body = callContext.m_islandBodiesStartA();
 	    int bodyOfs = callContext.m_islandBodiesStartOfs();
 	    double[]invI = localContext.m_invI;
-	
+		boolean dynamicIterationCountAdjustmentEnabled = callContext.m_world().qs.GetIsDynamicIterationCountAdjustmentEnabled();
+
 	    // precompute iMJ = inv(M)*J'
-	    compute_invM_JT(stage4CallContext.m_mi_iMJ, m, J, iMJ, jb, body, bodyOfs, invI, dxQUICKSTEPISLAND_STAGE4LCP_IMJ_STEP);
+	    compute_invM_JT(stage4CallContext.m_mi_iMJ, m, J, iMJ, jb, body, bodyOfs, invI, dynamicIterationCountAdjustmentEnabled, dxQUICKSTEPISLAND_STAGE4LCP_IMJ_STEP);
 	}
 
     private static
@@ -1559,7 +1650,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         dxQuickStepperLocalContext localContext = stage4CallContext.m_localContext;
         
         int m = localContext.m_m;
-        int allowedThreads = callContext.m_stepperAllowedThreads();
+        int allowedThreads = Math.max(callContext.m_stepperAllowedThreads(), callContext.m_lcpAllowedThreads());
 
         int stage4LCP_Ad_allowedThreads = CalculateOptimalThreadsCount(m, allowedThreads, dxQUICKSTEPISLAND_STAGE4LCP_AD_STEP);
 
@@ -1584,7 +1675,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         int fcPrepareComplexity = localContext.m_m;
         int fcCompleteComplexity = 0;
 
-        int allowedThreads = callContext.m_stepperAllowedThreads();
+        int allowedThreads = callContext.m_lcpAllowedThreads();
         int stage4LCP_fcPrepare_allowedThreads = CalculateOptimalThreadsCount(fcPrepareComplexity, allowedThreads, dxQUICKSTEPISLAND_STAGE4LCP_FC_STEP);
         int stage4LCP_fcComplete_allowedThreads = CalculateOptimalThreadsCount(fcCompleteComplexity, allowedThreads, dxQUICKSTEPISLAND_STAGE4LCP_FC_STEP);
         stage4CallContext.AssignLCP_fcAllowedThreads(stage4LCP_fcPrepare_allowedThreads, stage4LCP_fcComplete_allowedThreads);
@@ -1605,6 +1696,10 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
     void dxQuickStepIsland_Stage4LCP_MTfcComputation(dxQuickStepperStage4CallContext stage4CallContext)
     {
         dxQuickStepIsland_Stage4LCP_MTfcComputation_cold(stage4CallContext);
+
+		// Start the forceMaxAdjustments zeroing after the cforce computation so that, in "warm" case,
+		// first threads had a work in parallel while the last one will be finishing the cforce.
+		dxQuickStepIsland_Stage4LCP_MTForceMaxAdjustmentZeroing(stage4CallContext);
     }
 
     private static 
@@ -1612,27 +1707,52 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
     {
         DxStepperProcessingCallContext callContext = stage4CallContext.m_stepperCallContext;
     
-        double[] fc = stage4CallContext.m_cforce;
         int nb = callContext.m_islandBodiesCount();
+
         int step_size = dxQUICKSTEPISLAND_STAGE4LCP_FC_STEP;
         int nb_steps = (nb + (step_size - 1)) / step_size;
-    
+		double[] fc = stage4CallContext.m_cforce;
+
         int bi_step;
-        while ((bi_step = Atomics.ThrsafeIncrementIntUpToLimit(stage4CallContext.m_mi_fc, nb_steps)) != nb_steps) {
+        while ((bi_step = Atomics.ThrsafeIncrementIntUpToLimit(stage4CallContext.m_bi_fc, nb_steps)) != nb_steps) {
             int bi = bi_step * step_size;
-            int bicnt = Math.min(step_size, nb - bi);
+            int bicnt = dRESTRICT_STEP(step_size, nb - bi);
             dSetZero(fc, bi * CFE__MAX, bicnt * CFE__MAX);
         }
     }
 
-    // TODO: not needed if we stick to allocating m_cforce on each call
+	private static
+	void dxQuickStepIsland_Stage4LCP_MTForceMaxAdjustmentZeroing(dxQuickStepperStage4CallContext stage4CallContext)
+	{
+    	final DxStepperProcessingCallContext callContext = stage4CallContext.m_stepperCallContext;
+
+		int nb = callContext.m_islandBodiesCount();
+
+    	final int step_size = dxQUICKSTEPISLAND_STAGE4LCP_FORCEMAXADJ_STEP;
+		int nb_steps = (nb + (step_size - 1)) / step_size;
+		double[] forceMaxAdjustments = stage4CallContext.m_forceMaxAdjustments;
+
+		int bi_step;
+		while ((bi_step = Atomics.ThrsafeIncrementIntUpToLimit(stage4CallContext.m_bi_forceMaxAdj, nb_steps)) != nb_steps) {
+			int bi = bi_step * step_size;
+			int bicnt = dRESTRICT_STEP(step_size, nb - bi);
+			dSetZero(forceMaxAdjustments,bi * FAE__MAX, bicnt * FAE__MAX);
+		}
+	}
+
+	// TODO: not needed if we stick to allocating m_cforce on each call
     private static
     void dxQuickStepIsland_Stage4LCP_STfcComputation(dxQuickStepperStage4CallContext stage4CallContext)
     {
-    	double[] fc = stage4CallContext.m_cforce;
-        DxStepperProcessingCallContext callContext = stage4CallContext.m_stepperCallContext;
-        int nb = callContext.m_islandBodiesCount();
-        dSetZero(fc, nb * CFE__MAX);
+	    final DxStepperProcessingCallContext callContext = stage4CallContext.m_stepperCallContext;
+		int nb = callContext.m_islandBodiesCount();
+
+		double[] forceMaxAdjustments = stage4CallContext.m_forceMaxAdjustments;
+		dxSetZero(forceMaxAdjustments, nb * FAE__MAX);
+
+
+		double[] fc = stage4CallContext.m_cforce;
+        Matrix.dSetZero(fc, nb * CFE__MAX);
     }
     
     private static
@@ -1649,7 +1769,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         dxQuickStepParameters qs = world.qs;
         double sor_w = qs.w;		// SOR over-relaxation parameter
 
-        double[]iMJ = stage4CallContext.m_iMJ;
+        final double[] iMJ = stage4CallContext.m_iMJ;
 
         int step_size = dxQUICKSTEPISLAND_STAGE4LCP_AD_STEP;
         int m_steps = (m + (step_size - 1)) / step_size;
@@ -1657,16 +1777,16 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         int mi_step;
         while ((mi_step = Atomics.ThrsafeIncrementIntUpToLimit(stage4CallContext.m_mi_Ad, m_steps)) != m_steps) {
             int mi = mi_step * step_size;
-            int miend = mi + Math.min(step_size, m - mi);
+            int miend = mi + dRESTRICT_STEP(step_size, m - mi);
 
             int iMJ_ptr = mi * IMJ__MAX;
             int j_ptr = mi * JME__MAX;
             while (true) {
                 double sum = 0;
-                for (int j=JVE__MIN; j != JVE__MAX; j++) sum += iMJ[iMJ_ptr + j + IMJ__1_MIN] * J[j_ptr + j + JME__J1_MIN];
+                for (int j=JVE__MIN; j != JVE__MAX; j++) sum += iMJ[iMJ_ptr + j + IMJ__1JVE_MIN] * J[j_ptr + j + JME__J1_MIN];
                 int b2 = jb[mi*2+1];
                 if (b2 != -1) {
-                    for (int j=JVE__MIN; j != JVE__MAX; j++) sum += iMJ[iMJ_ptr + j + IMJ__2_MIN] * J[j_ptr + j + JME__J2_MIN];
+                    for (int j=JVE__MIN; j != JVE__MAX; j++) sum += iMJ[iMJ_ptr + j + IMJ__2JVE_MIN] * J[j_ptr + j + JME__J2_MIN];
                 }
                 double cfm_i = J[j_ptr + JME_CFM];
                 double Ad_i = sor_w / (sum + cfm_i);
@@ -1723,7 +1843,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
     {
         DxStepperProcessingCallContext callContext = stage4CallContext.m_stepperCallContext;
         DxWorld world = callContext.m_world();
-        int num_iterations = world.qs.num_iterations;
+        int num_iterations = world.qs.m_iterationCount;
 		for (int iteration = 0; iteration < num_iterations; iteration++) {
 			if (IsSORConstraintsReorderRequiredForIteration(iteration)) {
 				stage4CallContext.ResetSOR_ConstraintsReorderVariables(0);
@@ -1742,11 +1862,26 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         DxWorld world = callContext.m_world();
         dxQuickStepParameters qs = world.qs;
 
-        int num_iterations = qs.num_iterations;
+        int num_iterations = qs.m_iterationCount;
         int iteration = stage4CallContext.m_LCP_iteration;
-        
-        if (iteration < num_iterations)
-        {
+		dIASSERT(iteration< num_iterations + stage4CallContext.m_LCP_extra_num_iterations);
+
+		boolean abortIterating = false;
+		if (iteration != 0
+				&& world.qs.GetIsDynamicIterationCountAdjustmentEnabled()
+				&& CheckForMaximumToBeLessThanLimitAndResetMaxAdjustments(stage4CallContext.m_forceMaxAdjustments, callContext.m_islandBodiesCount(), stage4CallContext.m_LCP_iteration_premature_exit_delta)) {
+			if (iteration < num_iterations) {
+				AtomicInteger prematureExitsStorage = world.qs.GetStatisticsPrematureExitsStorage();
+				Atomics.ThrsafeIncrementNoResult(prematureExitsStorage);
+			}
+			else if (iteration > num_iterations) {
+				AtomicInteger prolongedExecutionsStorage = world.qs.GetStatisticsProlongedExecutionsStorage();
+				Atomics.ThrsafeIncrementNoResult(prolongedExecutionsStorage);
+			}
+			abortIterating = true;
+		}
+
+		if (!abortIterating) {
             int stage4LCP_Iteration_allowedThreads = stage4CallContext.m_LCP_IterationAllowedThreads;
 
             boolean reorderRequired = false;
@@ -1767,8 +1902,23 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 
             TaskGroup iterationSync = stage4CallContext.m_LCP_IterationSyncReleasee;
             TaskGroup stage4LCP_IterationStart = null;
-            if (iteration + 1 != num_iterations) {
-            	stage4LCP_IterationStart = iterationSync.subgroup("QuickStepIsland Stage4LCP_Iteration Start", new Runnable() {
+			boolean lastIteration = false;
+			if (iteration + 1 - stage4CallContext.m_LCP_extra_num_iterations == num_iterations) {
+				if (stage4CallContext.m_LCP_extra_num_iterations != 0 || world.qs.m_maxExtraIterationCount == 0) {
+					if (stage4CallContext.m_LCP_extra_num_iterations != 0) {
+						AtomicInteger fullExtraExecutionsStorage = world.qs.GetStatisticsFullExtraExecutionsStorage();
+						Atomics.ThrsafeIncrementNoResult(fullExtraExecutionsStorage);
+					}
+					lastIteration = true;
+				}
+				else {
+					stage4CallContext.m_LCP_extra_num_iterations = world.qs.m_maxExtraIterationCount;
+					stage4CallContext.m_LCP_iteration_premature_exit_delta = world.qs.GetExtraIterationsRequirementDelta();
+				}
+			}
+
+			if (!lastIteration) {
+				stage4LCP_IterationStart = iterationSync.subgroup("QuickStepIsland Stage4LCP_Iteration Start", new Runnable() {
                     @Override
                     public void run() {
                         dxQuickStepIsland_Stage4LCP_IterationStart(stage4CallContext);
@@ -1833,14 +1983,14 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         int iteration = stage4CallContext.m_LCP_iteration - 1; // Iteration is pre-incremented before scheduled tasks are released for execution
         if (dxQuickStepIsland_Stage4LCP_ConstraintsShuffling(stage4CallContext, iteration)) {
             dxQuickStepIsland_Stage4LCP_LinksArraysZeroing(stage4CallContext);
-            if (Atomics.ThrsafeExchangeAdd(stage4CallContext.m_SOR_reorderThreadsRemaining, -1) == 1) { // If last thread has exited the reordering routine...
+            if (Atomics.ThrsafeDecrement(stage4CallContext.m_SOR_reorderThreadsRemaining) == 0) { // If last thread has exited the reordering routine...
                 // Rebuild the object dependency map
                 dxQuickStepIsland_Stage4LCP_DependencyMapForNewOrderRebuilding(stage4CallContext);
             }
         }
 		else {
 			// NOTE: So far, this branch is only called in CONSTRAINTS_REORDERING_METHOD == REORDERING_METHOD__BY_ERROR case
-			if (Atomics.ThrsafeExchangeAdd(stage4CallContext.m_SOR_reorderThreadsRemaining, -1) == 1) { // If last thread has exited the reordering routine...
+			if (Atomics.ThrsafeDecrement(stage4CallContext.m_SOR_reorderThreadsRemaining) == 0) { // If last thread has exited the reordering routine...
 				dIASSERT(iteration != 0);
 				dxQuickStepIsland_Stage4LCP_DependencyMapFromSavedLevelsReconstruction(stage4CallContext);
 			}
@@ -2263,7 +2413,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         }
 
         // Decrement running threads count on exit
-        Atomics.ThrsafeAdd(stage4CallContext.m_LCP_iterationThreadsRemaining, -1);
+        Atomics.ThrsafeDecrementNoResult(stage4CallContext.m_LCP_iterationThreadsRemaining);
     }
 
 	private static
@@ -2279,7 +2429,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	//***************************************************************************
 	// SOR-LCP method
 
-		// nb is the number of bodies in the body array.
+	// nb is the number of bodies in the body array.
 	// J is an m*16 matrix of constraint rows with rhs, cfm, lo and hi in padding
 	// jb is an array of first and second body numbers for each constraint row
 	// invI is the global frame inverse inertia for each body (stacked 3x3 matrices)
@@ -2296,6 +2446,9 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
         IndexError[ ]order = stage4CallContext.m_order;
         int index = order[i].index;
 
+		final int NULL = -1;				;
+		int fc_ptr1P;
+		int fc_ptr2P = NULL;
         double delta = 0;
         
         double[] lambda = stage4CallContext.m_lambda;
@@ -2304,23 +2457,27 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 		double[] J = localContext.m_J;
         int J_ptr = index * JME__MAX;
 
+		int b1AsSizeint; // 64bit in ODE --  sizeint
+		int b1ToB2Offset = 0; // 64bit in ODE --  diffint
+
         delta = J[J_ptr + JME_RHS] - old_lambda * J[J_ptr + JME_CFM];
 
         double[] fc = stage4CallContext.m_cforce;
 
         int[] jb = localContext.m_jb;
-        int b1 = jb[index * 2];
+        b1AsSizeint = jb[index * 2];
         int b2 = jb[index * 2 + 1];
         
 	    // @@@ potential optimization: SIMD-ize this and the b2 >= 0 case
-        int fc_ptr1 = b1 * CFE__MAX;
-        delta -= fc[fc_ptr1 + CFE_LX] * J[J_ptr + JME_J1LX] + fc[fc_ptr1 + CFE_LY] * J[J_ptr + JME_J1LY] +
-        		fc[fc_ptr1 + CFE_LZ] * J[J_ptr + JME_J1LZ] + fc[fc_ptr1 + CFE_AX] * J[J_ptr + JME_J1AX] +
-        		fc[fc_ptr1 + CFE_AY] * J[J_ptr + JME_J1AY] + fc[fc_ptr1 + CFE_AZ] * J[J_ptr + JME_J1AZ];
+        fc_ptr1P = b1AsSizeint * CFE__MAX;
+        delta -= fc[fc_ptr1P + CFE_LX] * J[J_ptr + JME_J1LX] + fc[fc_ptr1P + CFE_LY] * J[J_ptr + JME_J1LY] +
+        		fc[fc_ptr1P + CFE_LZ] * J[J_ptr + JME_J1LZ] + fc[fc_ptr1P + CFE_AX] * J[J_ptr + JME_J1AX] +
+        		fc[fc_ptr1P + CFE_AY] * J[J_ptr + JME_J1AY] + fc[fc_ptr1P + CFE_AZ] * J[J_ptr + JME_J1AZ];
         // @@@ potential optimization: handle 1-body constraints in a separate
 	    // @@@ potential optimization: handle 1-body constraints in a separate
 	    //     loop to avoid the cost of test & jump?
 	    if (b2 != -1) {
+			b1ToB2Offset = b2 - b1AsSizeint;
 	        int fc_ptr2 = b2 * CFE__MAX;
 	        delta -= fc[fc_ptr2 + CFE_LX] * J[J_ptr + JME_J2LX] + fc[fc_ptr2 + CFE_LY] * J[J_ptr + JME_J2LY] +
 	        		fc[fc_ptr2 + CFE_LZ] * J[J_ptr + JME_J2LZ] + fc[fc_ptr2 + CFE_AX] * J[J_ptr + JME_J2AX] +
@@ -2363,26 +2520,41 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 		//@@@ a trick that may or may not help
 		//dReal ramp = (1-((dReal)(iteration+1)/(dReal)num_iterations));
 		//delta *= ramp;
-	    double[] iMJ = stage4CallContext.m_iMJ;
-	    final int iMJ_ptr = index * IMJ__MAX;
-		// update fc.
-		// @@@ potential optimization: SIMD for this and the b2 >= 0 case
-	    fc[fc_ptr1 + CFE_LX] += delta * iMJ[iMJ_ptr + 0];
-		fc[fc_ptr1 + CFE_LY] += delta * iMJ[iMJ_ptr + 1];
-		fc[fc_ptr1 + CFE_LZ] += delta * iMJ[iMJ_ptr + 2];
-		fc[fc_ptr1 + CFE_AX] += delta * iMJ[iMJ_ptr + 3];
-		fc[fc_ptr1 + CFE_AY] += delta * iMJ[iMJ_ptr + 4];
-		fc[fc_ptr1 + CFE_AZ] += delta * iMJ[iMJ_ptr + 5];
-		// @@@ potential optimization: handle 1-body constraints in a separate
-		//     loop to avoid the cost of test & jump?
-	    if (b2 != -1) {
-	        int fc_ptr2 = b2 * CFE__MAX;
-			fc[fc_ptr2 + CFE_LX] += delta * iMJ[iMJ_ptr + 6];
-			fc[fc_ptr2 + CFE_LY] += delta * iMJ[iMJ_ptr + 7];
-			fc[fc_ptr2 + CFE_LZ] += delta * iMJ[iMJ_ptr + 8];
-			fc[fc_ptr2 + CFE_AX] += delta * iMJ[iMJ_ptr + 9];
-			fc[fc_ptr2 + CFE_AY] += delta * iMJ[iMJ_ptr + 10];
-			fc[fc_ptr2 + CFE_AZ] += delta * iMJ[iMJ_ptr + 11];
+
+		if (delta != 0) {
+			double[] forceMaxAdjustments = stage4CallContext.m_forceMaxAdjustments;
+			// Reuse already available comparison result of delta with zero
+			//dReal * faBase = forceMaxAdjustments + ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(delta > 0);
+			double [] faBaseA = forceMaxAdjustments;
+			int faBaseP = ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(delta > 0);
+
+			double[] iMJ = stage4CallContext.m_iMJ;
+			final int iMJ_ptr = index * IMJ__MAX;
+			// update fc.
+			// @@@ potential optimization: SIMD for this and the b2 >= 0 case
+			fc[fc_ptr1P + CFE_LX] += delta * iMJ[iMJ_ptr + 0];
+			fc[fc_ptr1P + CFE_LY] += delta * iMJ[iMJ_ptr + 1];
+			fc[fc_ptr1P + CFE_LZ] += delta * iMJ[iMJ_ptr + 2];
+			fc[fc_ptr1P + CFE_AX] += delta * iMJ[iMJ_ptr + 3];
+			fc[fc_ptr1P + CFE_AY] += delta * iMJ[iMJ_ptr + 4];
+			fc[fc_ptr1P + CFE_AZ] += delta * iMJ[iMJ_ptr + 5];
+
+			// dReal *fa1 = faBase + b1AsSizeint * FAE__MAX;
+			int fa1P = faBaseP + b1AsSizeint * FAE__MAX;
+	        faBaseA[fa1P] += delta * iMJ[iMJ_ptr + IMJ_1JVE_MAXABS];
+			// @@@ potential optimization: handle 1-body constraints in a separate
+			//     loop to avoid the cost of test & jump?
+			if (fc_ptr2P != NULL) {
+				// dReal *fa2 = fa1 + b1ToB2Offset * FAE__MAX;
+				int fa2P = fa1P + b1ToB2Offset * FAE__MAX;
+	            faBaseA[fa2P] += delta * iMJ[iMJ_ptr + IMJ_2JVE_MAXABS];
+				fc[fc_ptr2P + CFE_LX] += delta * iMJ[iMJ_ptr + 6];
+				fc[fc_ptr2P + CFE_LY] += delta * iMJ[iMJ_ptr + 7];
+				fc[fc_ptr2P + CFE_LZ] += delta * iMJ[iMJ_ptr + 8];
+				fc[fc_ptr2P + CFE_AX] += delta * iMJ[iMJ_ptr + 9];
+				fc[fc_ptr2P + CFE_AY] += delta * iMJ[iMJ_ptr + 10];
+				fc[fc_ptr2P + CFE_AZ] += delta * iMJ[iMJ_ptr + 11];
+			}
 		}
     }  
 
@@ -2432,7 +2604,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
             int ji_step;
             while ((ji_step = Atomics.ThrsafeIncrementIntUpToLimit(stage4CallContext.m_ji_4b, nj_steps)) != nj_steps) {
                 int ji = ji_step * step_size;
-				final int jiend = ji + Math.min(step_size, nj - ji);
+				final int jiend = ji + dRESTRICT_STEP(step_size, nj - ji);
 
 				//const dReal *Jcopycurr = Jcopy + (sizeint)mindex[ji].fbIndex * JCE__MAX;
 				int Jcopycurr = getFbIndex(mindex, ji) * JCE__MAX;
@@ -2511,7 +2683,21 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 		final DxStepperProcessingCallContext callContext = stage5CallContext.m_stepperCallContext;
 	    dxQuickStepperLocalContext localContext = stage5CallContext.m_localContext;
 
-	    DxWorldProcessMemArena memarena = callContext.m_stepperArena();
+		DxWorld world = callContext.m_world();
+		AtomicInteger iterationCountStorage = world.qs.GetStatisticsIterationCountStorage();
+		if (PRINT_DYNAMIC_ADJUSTMENT_STATS == 0) {
+			Atomics.ThrsafeIncrementNoResult(iterationCountStorage);
+		} else {
+			int iterationCount = Atomics.ThrsafeIncrement(iterationCountStorage);
+			if (iterationCount % 256 == 0) {
+				System.out.printf("Iteration %08u: PE=%u LE=%u, FE=%u\r", iterationCount,
+						world.qs.GetStatisticsPrematureExitsStorage().get(),
+						world.qs.GetStatisticsProlongedExecutionsStorage().get(),
+						world.qs.GetStatisticsFullExtraExecutionsStorage().get());
+			}
+		} // #endif
+
+		DxWorldProcessMemArena memarena = callContext.m_stepperArena();
 	    memarena.RestoreState(stage5CallContext.m_stage3MemArenaState);
 
 	    final dxQuickStepperStage6CallContext stage6CallContext = new dxQuickStepperStage6CallContext();
@@ -2549,7 +2735,49 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
             stage6aSync.submit();
 	    }
 	}
-	
+
+	private static
+	// bool CheckForMaximumToBeLessThanLimitAndResetMaxAdjustments(dReal *forceMaxAdjustments/*=[FAE__MAX]*/,
+	// unsigned int elementCount, dReal limitValue)
+	boolean CheckForMaximumToBeLessThanLimitAndResetMaxAdjustments(double[] forceMaxAdjustments/*=[FAE__MAX]*/,
+																   int elementCount, double limitValue)
+	{
+		dIASSERT(limitValue >= 0);
+
+		boolean hitTheLimit = false;
+
+		// dReal *const adjustmentsEnd = forceMaxAdjustments + (sizeint)elementCount * FAE__MAX;
+		int adjustmentsEndP = elementCount * FAE__MAX;
+
+		if (limitValue == 0) {
+			dxSetZero(forceMaxAdjustments, elementCount * FAE__MAX);
+			hitTheLimit = true; // Due to the "strict less" comparison (see further in the function implementation), no absolute adjustment can "pass below" this limit
+		}
+
+		// for (dReal *currentAdjustment = !hitTheLimit ? forceMaxAdjustments : adjustmentsEnd;
+		// currentAdjustment != adjustmentsEnd; currentAdjustment += FAE__MAX) {
+		for (int currentAdjustmentP = !hitTheLimit ? 0 : adjustmentsEndP; currentAdjustmentP != adjustmentsEndP; currentAdjustmentP += FAE__MAX) {
+			dIASSERT(forceMaxAdjustments[currentAdjustmentP + FAE_NEGATIVE] <= 0); // TODO (TZ) remove / comment out.
+			dIASSERT(forceMaxAdjustments[currentAdjustmentP + FAE_POSITIVE] >= 0);
+			dSASSERT(FAE__MAX == 2);
+
+			// Use "strict less" comparison to allow disabling premature algorithm exits by setting limit to zero
+			if (!(forceMaxAdjustments[currentAdjustmentP + FAE_POSITIVE] < limitValue) ||
+					!(-forceMaxAdjustments[currentAdjustmentP + FAE_NEGATIVE] < limitValue)) {
+				dxSetZero(forceMaxAdjustments, currentAdjustmentP + adjustmentsEndP - currentAdjustmentP);
+				hitTheLimit = true;
+				break;
+			}
+
+			forceMaxAdjustments[currentAdjustmentP + FAE_NEGATIVE] = 0;
+			forceMaxAdjustments[currentAdjustmentP + FAE_POSITIVE] = 0;
+			dSASSERT(FAE__MAX == 2);
+		}
+
+		boolean result = !hitTheLimit;
+		return result;
+	}
+
 	private static
 	void dxQuickStepIsland_Stage6a(dxQuickStepperStage6CallContext stage6CallContext)
 	{
@@ -2568,7 +2796,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	    int bi_step;
 	    while ((bi_step = Atomics.ThrsafeIncrementIntUpToLimit(stage6CallContext.m_bi_6a, nb_steps)) != nb_steps) {
 	        int bi = bi_step * step_size;
-	        int bicnt = Math.min(step_size, nb - bi);
+	        int bicnt = dRESTRICT_STEP(step_size, nb - bi);
 
 	        int invIrow = bi * IIE__MAX;
 	        int bodycurr = bi;
@@ -2668,7 +2896,7 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	    int bi_step;
 	    while ((bi_step = Atomics.ThrsafeIncrementIntUpToLimit(stage6CallContext.m_bi_6b, nb_steps)) != nb_steps) {
 	        int bi = bi_step * step_size;
-	        int bicnt = Math.min(step_size, nb - bi);
+	        int bicnt = dRESTRICT_STEP(step_size, nb - bi);
 
 	        int bodycurr = bi;
 	        int bodyend = bodycurr + bicnt;
@@ -2693,19 +2921,21 @@ dmemestimate_fn_t, dmaxcallcountestimate_fn_t {
 	}
 
 	/*extern */
-	private int dxEstimateQuickStepMaxCallCount(int activeThreadCount, int allowedThreadCount)
+	private int dxEstimateQuickStepMaxCallCount(int activeThreadCount, int steppingAllowedThreadCount, int lcpAllowedThreadCount)
 	{
 		//(void)activeThreadCount; // unused
+		int maxAllowedThreadCount = Math.max(steppingAllowedThreadCount, lcpAllowedThreadCount);
 	    int result = 1 // dxQuickStepIsland itself
-	        + (2 * allowedThreadCount + 2) // (dxQuickStepIsland_Stage2a + dxQuickStepIsland_Stage2b) * allowedThreadCount + 2 * dxStepIsland_Stage2?_Sync
-	        + 1; // dxStepIsland_Stage3
+	        + (2 * maxAllowedThreadCount + 2) // (dxQuickStepIsland_Stage2a + dxQuickStepIsland_Stage2b) * allowedThreadCount + 2 * dxStepIsland_Stage2?_Sync
+	        + 1 // dxStepIsland_Stage3
+			+ maxAllowedThreadCount;
 	    return result;
 	}
 
 
 	@Override
-	public int run(int activeThreadCount, int allowedThreadCount) {
-		return dxEstimateQuickStepMaxCallCount(activeThreadCount, allowedThreadCount);
+	public int run(int activeThreadCount, int steppingAllowedThreadCount, int lcpAllowedThreadCount) {
+		return dxEstimateQuickStepMaxCallCount(activeThreadCount, steppingAllowedThreadCount, lcpAllowedThreadCount);
 	}
 
 	@Override

--- a/core/src/main/java/org/ode4j/ode/internal/DxSpace.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxSpace.java
@@ -39,7 +39,7 @@ import static org.ode4j.ode.internal.Common.*;
  * the contained geoms are divided into two kinds: clean and dirty.
  * the clean geoms have not moved since they were put in the list,
  * and their AABBs are valid. the dirty geoms have changed position, and
- * their AABBs are may not be valid. the two types are distinguished by the
+ * their AABBs may not be valid. the two types are distinguished by the
  * GEOM_DIRTY flag. all dirty geoms come *before* all clean geoms in the list.
  */ 
 public abstract class DxSpace extends DxGeom implements DSpace {

--- a/core/src/main/java/org/ode4j/ode/internal/DxTrimeshHeightfield.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxTrimeshHeightfield.java
@@ -87,7 +87,7 @@ public class DxTrimeshHeightfield extends DxAbstractHeightfield {
 
     //Uncomment this #define to use the (0,0) corner of the geom as the origin,
     //rather than the center. This was the way the original heightfield worked,
-    //but as it does not match the way all other geometries work, so for constancy it
+    //but as it does not match the way all other geometries work, so for consistency it
     //was changed to work like this.
 
     //#define DHEIGHTFIELD_CORNER_ORIGIN

--- a/core/src/main/java/org/ode4j/ode/internal/DxWorld.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxWorld.java
@@ -26,11 +26,7 @@ package org.ode4j.ode.internal;
 
 import static org.ode4j.ode.OdeConstants.dInfinity;
 import static org.ode4j.ode.OdeMath.dCalcVectorDot3;
-import static org.ode4j.ode.internal.Common.dIASSERT;
-import static org.ode4j.ode.internal.Common.dNODEBUG;
-import static org.ode4j.ode.internal.Common.dRecip;
-import static org.ode4j.ode.internal.Common.dSqrt;
-import static org.ode4j.ode.internal.Common.dUASSERT;
+import static org.ode4j.ode.internal.Common.*;
 import static org.ode4j.ode.internal.ErrorHandler.dMessage;
 
 import org.ode4j.math.DVector3;
@@ -82,6 +78,8 @@ public class DxWorld extends DBase implements DWorld {
 	dxAutoDisable adis;		// auto-disable parameters
 	int body_flags;               // flags for new bodies
     private int islands_max_threads; // maximum threads to allocate for island processing
+	private int stepping_max_threads; // maximum threads to allocate for stepping each island
+	private int solving_max_threads; // maximum threads to allocate for solving equation systems
 	public DxStepWorkingMemory wmem; // Working memory object for dWorldStep/dWorldQuickStep
 
 	dxQuickStepParameters qs;
@@ -118,6 +116,8 @@ public class DxWorld extends DBase implements DWorld {
 		adis = null;
 		body_flags = 0;  // everything disabled
 		islands_max_threads = dWORLDSTEP_THREADCOUNT_UNLIMITED;
+		stepping_max_threads(dWORLDSTEP_THREADCOUNT_UNLIMITED),
+		solving_max_threads(1),
 		wmem = null;
 		qs = null;
 		contactp = null;
@@ -178,6 +178,36 @@ public class DxWorld extends DBase implements DWorld {
 		DESTRUCTOR();
 	}
 
+	//	void assignThreadingImpl(final dxThreadingFunctionsInfo functions_info, dThreadingImplementationID threading_impl);
+	//
+	//	unsigned calculateIslandIterationMaxThreadCount(unsigned *ptrOut_activeThreadCount = NULL) const
+	//	{
+	//		unsigned activeThreadCount, *ptrActiveThreadCountToUse = ptrOut_activeThreadCount != NULL ? &activeThreadCount : NULL;
+	//		unsigned limitedCount = calculateThreadingLimitedThreadCount(islands_max_threads, false, ptrActiveThreadCountToUse);
+	//		if (ptrOut_activeThreadCount != NULL) {
+	//            *ptrOut_activeThreadCount = dMACRO_MAX(activeThreadCount, 1U);
+	//		}
+	//		return dMACRO_MAX(limitedCount, 1U);
+	//	}
+	//
+	//	unsigned calculatePerIslandSteppingMaxThreadCount() const
+	//	{
+	//		unsigned limitedCount = calculateThreadingLimitedThreadCount(stepping_max_threads, false);
+	//		return dMACRO_MAX(limitedCount, 1U);
+	//	}
+	//
+	//	unsigned calculatePerIslandSolvingMaxThreadCount() const
+	//	{
+	//		unsigned limitedCount = calculateThreadingLimitedThreadCount(solving_max_threads, false);
+	//		return dMACRO_MAX(limitedCount, 1U);
+	//	}
+	//
+	//	dxWorldProcessContext *unsafeGetWorldProcessingContext() const;
+	//
+	//	private: // dxIThreadingDefaultImplProvider
+	//	virtual const dxThreadingFunctionsInfo *retrieveThreadingDefaultImpl(dThreadingImplementationID &out_defaultImpl);
+
+
 	public void dWorldSetData (Object data)
 	{
 		userdata = data;
@@ -236,6 +266,49 @@ public class DxWorld extends DBase implements DWorld {
 	private double dWorldGetCFM ()
 	{
 		return global_cfm;
+	}
+
+	void dWorldSetSteppingThreadingParameters(final dWorldSteppingThreadingParameters ptr_params)
+	{
+		// dAASSERT(w);
+		// dAASSERT(ptr_params);
+
+		int param_set = ptr_params.param_set;
+
+		if ((param_set & dWSTP.dWSTP_WorldIslandsIterationMaxThreads.v) != 0)
+		{
+			this.islands_max_threads = ptr_params.world_islands_iteration_max_threads;
+		}
+
+		if ((param_set & dWSTP.dWSTP_IslandSteppingMaxThreads.v) != 0)
+		{
+			this.stepping_max_threads = ptr_params.island_stepping_max_threads;
+		}
+
+		if ((param_set & dWSTP.dWSTP_LCPSolvingMaxThreads.v) != 0)
+		{
+			this.solving_max_threads = ptr_params.lcp_solving_max_threads;
+		}
+	}
+
+	void dWorldGetSteppingThreadingParameters(dWorldSteppingThreadingParameters ptr_params)
+	{
+		int param_set = ptr_params.param_set;
+
+		if ((param_set & dWSTP.dWSTP_WorldIslandsIterationMaxThreads.v) != 0)
+		{
+			ptr_params.world_islands_iteration_max_threads = this.islands_max_threads;
+		}
+
+		if ((param_set & dWSTP.dWSTP_IslandSteppingMaxThreads.v) != 0)
+		{
+			ptr_params.island_stepping_max_threads = this.stepping_max_threads;
+		}
+
+		if ((param_set & dWSTP.dWSTP_LCPSolvingMaxThreads.v) != 0)
+		{
+			ptr_params.lcp_solving_max_threads = this.solving_max_threads;
+		}
 	}
 
 	void dWorldSetStepIslandsProcessingMaxThreadCount(int count)
@@ -511,13 +584,94 @@ public class DxWorld extends DBase implements DWorld {
 	public void dWorldSetQuickStepNumIterations (int num)
 	{
 		//dAASSERT(w);
-		qs.num_iterations = num;
+		dAASSERT(num > 0);
+
+		this.qs.AssignNumIterations(Math.max(num, 1)); // QuickStep implementation relies of number of iteration not being zero
 	}
 
 
 	private int dWorldGetQuickStepNumIterations ()
 	{
-		return qs.num_iterations;
+
+		return this.qs.GetNumIterations();
+	}
+
+
+	/*extern */
+	//	void dWorldSetQuickStepDynamicIterationParameters(dWorldID w, const dReal *ptr_iteration_premature_exit_delta/*=NULL*/,
+	//    const dReal *ptr_max_num_extra_factor/*=NULL*/, const dReal *ptr_extra_iteration_requirement_delta/*=NULL*/)
+	void dWorldSetQuickStepDynamicIterationParameters(final double[] ptr_iteration_premature_exit_delta/*=NULL*/,
+    final double[] ptr_max_num_extra_factor/*=NULL*/, final double[] ptr_extra_iteration_requirement_delta/*=NULL*/)
+
+	{
+		// dAASSERT(w);
+		dAASSERT(ptr_iteration_premature_exit_delta != null || ptr_max_num_extra_factor != null || ptr_extra_iteration_requirement_delta != null);
+		dAASSERT(ptr_iteration_premature_exit_delta == null || *ptr_iteration_premature_exit_delta >= 0);
+		dAASSERT(ptr_max_num_extra_factor == null || *ptr_max_num_extra_factor >= 0);
+		dAASSERT(ptr_extra_iteration_requirement_delta == null || *ptr_extra_iteration_requirement_delta >= 0);
+
+		if (ptr_iteration_premature_exit_delta != null) {
+			this.qs.AssignPrematureExitDelta(Math.max(*ptr_iteration_premature_exit_delta, 0.0));
+		}
+
+		if (ptr_extra_iteration_requirement_delta != null) {
+			this.qs.AssignExtraIterationsRequirementDelta(Math.max(*ptr_extra_iteration_requirement_delta, 0.0));
+		}
+
+		if (ptr_max_num_extra_factor != null) {
+			this.qs.AssignMaxNumExtraFactor(Math.max(*ptr_max_num_extra_factor, 0.0));
+		}
+	}
+
+	/*extern */
+	//	void dWorldGetQuickStepDynamicIterationParameters(dWorldID w, dReal *out_iteration_premature_exit_delta/*=NULL*/,
+	//				  dReal *out_max_num_extra_factor/*=NULL*/, dReal *out_extra_iteration_requirement_delta/*=NULL*/)
+	void dWorldGetQuickStepDynamicIterationParameters(double[] out_iteration_premature_exit_delta/*=NULL*/,
+													  double[] out_max_num_extra_factor/*=NULL*/,
+													  double[] out_extra_iteration_requirement_delta/*=NULL*/)
+	{
+		// dAASSERT(w);
+		dAASSERT(out_iteration_premature_exit_delta != null || out_max_num_extra_factor != null || out_extra_iteration_requirement_delta != null);
+
+		if (out_iteration_premature_exit_delta != null) {
+        *out_iteration_premature_exit_delta = this.qs.GetPrematureExitDelta();
+		}
+
+		if (out_extra_iteration_requirement_delta != null) {
+        *out_extra_iteration_requirement_delta = this.qs.GetExtraIterationsRequirementDelta();
+		}
+
+		if (out_max_num_extra_factor != null) {
+        *out_max_num_extra_factor = this.qs.GetMaxNumExtraFactor();
+		}
+	}
+
+	/*extern */
+	//	int dWorldAttachQuickStepDynamicIterationStatisticsSink(dWorldID w,
+	//							dWorldQuickStepIterationCount_DynamicAdjustmentStatistics *var_stats/*=NULL*/)
+	boolean dWorldAttachQuickStepDynamicIterationStatisticsSink(
+							dWorldQuickStepIterationCount_DynamicAdjustmentStatistics var_stats/*=NULL*/)
+
+	{
+		// dAASSERT(w);
+		dAASSERT(var_stats == null || (var_stats.struct_size >= sizeof(*var_stats) && var_stats.struct_size % sizeof(duint32) == 0));
+		dSASSERT(sizeof(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics) % sizeof(duint32) == 0);
+
+		boolean result = false;
+
+		if (var_stats != null) {
+			if (var_stats.struct_size >= sizeof(*var_stats) && var_stats.struct_size % sizeof(duint32) == 0) {
+
+				this.qs.AssignStatisticsSink(var_stats);
+				result = true;
+			}
+		}
+		else {
+			this.qs.ClearStatisticsSink();
+			result = true;
+		}
+
+		return result;
 	}
 
 

--- a/core/src/main/java/org/ode4j/ode/internal/DxWorld.java
+++ b/core/src/main/java/org/ode4j/ode/internal/DxWorld.java
@@ -116,8 +116,8 @@ public class DxWorld extends DBase implements DWorld {
 		adis = null;
 		body_flags = 0;  // everything disabled
 		islands_max_threads = dWORLDSTEP_THREADCOUNT_UNLIMITED;
-		stepping_max_threads(dWORLDSTEP_THREADCOUNT_UNLIMITED),
-		solving_max_threads(1),
+		stepping_max_threads = dWORLDSTEP_THREADCOUNT_UNLIMITED;
+		solving_max_threads = 1;
 		wmem = null;
 		qs = null;
 		contactp = null;
@@ -268,7 +268,8 @@ public class DxWorld extends DBase implements DWorld {
 		return global_cfm;
 	}
 
-	void dWorldSetSteppingThreadingParameters(final dWorldSteppingThreadingParameters ptr_params)
+	//	void dWorldSetSteppingThreadingParameters(final dWorldSteppingThreadingParameters ptr_params)
+	public void setSteppingThreadingParameters(final dWorldSteppingThreadingParameters ptr_params)
 	{
 		// dAASSERT(w);
 		// dAASSERT(ptr_params);
@@ -291,7 +292,8 @@ public class DxWorld extends DBase implements DWorld {
 		}
 	}
 
-	void dWorldGetSteppingThreadingParameters(dWorldSteppingThreadingParameters ptr_params)
+	// void dWorldGetSteppingThreadingParameters(dWorldSteppingThreadingParameters ptr_params)
+	public void getSteppingThreadingParameters(dWorldSteppingThreadingParameters ptr_params)
 	{
 		int param_set = ptr_params.param_set;
 
@@ -580,7 +582,7 @@ public class DxWorld extends DBase implements DWorld {
 	}
 
 
-//	void dWorldSetQuickStepNumIterations (dxWorld w, int num)
+	//	void dWorldSetQuickStepNumIterations (dxWorld w, int num)
 	public void dWorldSetQuickStepNumIterations (int num)
 	{
 		//dAASSERT(w);
@@ -590,6 +592,7 @@ public class DxWorld extends DBase implements DWorld {
 	}
 
 
+	// private int dWorldGetQuickStepNumIterations ()
 	private int dWorldGetQuickStepNumIterations ()
 	{
 
@@ -600,79 +603,79 @@ public class DxWorld extends DBase implements DWorld {
 	/*extern */
 	//	void dWorldSetQuickStepDynamicIterationParameters(dWorldID w, const dReal *ptr_iteration_premature_exit_delta/*=NULL*/,
 	//    const dReal *ptr_max_num_extra_factor/*=NULL*/, const dReal *ptr_extra_iteration_requirement_delta/*=NULL*/)
-	void dWorldSetQuickStepDynamicIterationParameters(final double[] ptr_iteration_premature_exit_delta/*=NULL*/,
-    final double[] ptr_max_num_extra_factor/*=NULL*/, final double[] ptr_extra_iteration_requirement_delta/*=NULL*/)
-
-	{
-		// dAASSERT(w);
-		dAASSERT(ptr_iteration_premature_exit_delta != null || ptr_max_num_extra_factor != null || ptr_extra_iteration_requirement_delta != null);
-		dAASSERT(ptr_iteration_premature_exit_delta == null || *ptr_iteration_premature_exit_delta >= 0);
-		dAASSERT(ptr_max_num_extra_factor == null || *ptr_max_num_extra_factor >= 0);
-		dAASSERT(ptr_extra_iteration_requirement_delta == null || *ptr_extra_iteration_requirement_delta >= 0);
-
-		if (ptr_iteration_premature_exit_delta != null) {
-			this.qs.AssignPrematureExitDelta(Math.max(*ptr_iteration_premature_exit_delta, 0.0));
-		}
-
-		if (ptr_extra_iteration_requirement_delta != null) {
-			this.qs.AssignExtraIterationsRequirementDelta(Math.max(*ptr_extra_iteration_requirement_delta, 0.0));
-		}
-
-		if (ptr_max_num_extra_factor != null) {
-			this.qs.AssignMaxNumExtraFactor(Math.max(*ptr_max_num_extra_factor, 0.0));
-		}
-	}
+	//	void dWorldSetQuickStepDynamicIterationParameters(final double[] ptr_iteration_premature_exit_delta/*=NULL*/,
+	//    final double[] ptr_max_num_extra_factor/*=NULL*/, final double[] ptr_extra_iteration_requirement_delta/*=NULL*/)
+	//
+	//	{
+	//		// dAASSERT(w);
+	//		dAASSERT(ptr_iteration_premature_exit_delta != null || ptr_max_num_extra_factor != null || ptr_extra_iteration_requirement_delta != null);
+	//		dAASSERT(ptr_iteration_premature_exit_delta == null || *ptr_iteration_premature_exit_delta >= 0);
+	//		dAASSERT(ptr_max_num_extra_factor == null || *ptr_max_num_extra_factor >= 0);
+	//		dAASSERT(ptr_extra_iteration_requirement_delta == null || *ptr_extra_iteration_requirement_delta >= 0);
+	//
+	//		if (ptr_iteration_premature_exit_delta != null) {
+	//			this.qs.AssignPrematureExitDelta(Math.max(*ptr_iteration_premature_exit_delta, 0.0));
+	//		}
+	//
+	//		if (ptr_extra_iteration_requirement_delta != null) {
+	//			this.qs.AssignExtraIterationsRequirementDelta(Math.max(*ptr_extra_iteration_requirement_delta, 0.0));
+	//		}
+	//
+	//		if (ptr_max_num_extra_factor != null) {
+	//			this.qs.AssignMaxNumExtraFactor(Math.max(*ptr_max_num_extra_factor, 0.0));
+	//		}
+	//	}
 
 	/*extern */
 	//	void dWorldGetQuickStepDynamicIterationParameters(dWorldID w, dReal *out_iteration_premature_exit_delta/*=NULL*/,
 	//				  dReal *out_max_num_extra_factor/*=NULL*/, dReal *out_extra_iteration_requirement_delta/*=NULL*/)
-	void dWorldGetQuickStepDynamicIterationParameters(double[] out_iteration_premature_exit_delta/*=NULL*/,
-													  double[] out_max_num_extra_factor/*=NULL*/,
-													  double[] out_extra_iteration_requirement_delta/*=NULL*/)
-	{
-		// dAASSERT(w);
-		dAASSERT(out_iteration_premature_exit_delta != null || out_max_num_extra_factor != null || out_extra_iteration_requirement_delta != null);
-
-		if (out_iteration_premature_exit_delta != null) {
-        *out_iteration_premature_exit_delta = this.qs.GetPrematureExitDelta();
-		}
-
-		if (out_extra_iteration_requirement_delta != null) {
-        *out_extra_iteration_requirement_delta = this.qs.GetExtraIterationsRequirementDelta();
-		}
-
-		if (out_max_num_extra_factor != null) {
-        *out_max_num_extra_factor = this.qs.GetMaxNumExtraFactor();
-		}
-	}
+	//	void dWorldGetQuickStepDynamicIterationParameters(double[] out_iteration_premature_exit_delta/*=NULL*/,
+	//													  double[] out_max_num_extra_factor/*=NULL*/,
+	//													  double[] out_extra_iteration_requirement_delta/*=NULL*/)
+	//	{
+	//		// dAASSERT(w);
+	//		dAASSERT(out_iteration_premature_exit_delta != null || out_max_num_extra_factor != null || out_extra_iteration_requirement_delta != null);
+	//
+	//		if (out_iteration_premature_exit_delta != null) {
+	//        *out_iteration_premature_exit_delta = this.qs.GetPrematureExitDelta();
+	//		}
+	//
+	//		if (out_extra_iteration_requirement_delta != null) {
+	//        *out_extra_iteration_requirement_delta = this.qs.GetExtraIterationsRequirementDelta();
+	//		}
+	//
+	//		if (out_max_num_extra_factor != null) {
+	//        *out_max_num_extra_factor = this.qs.GetMaxNumExtraFactor();
+	//		}
+	//	}
 
 	/*extern */
 	//	int dWorldAttachQuickStepDynamicIterationStatisticsSink(dWorldID w,
 	//							dWorldQuickStepIterationCount_DynamicAdjustmentStatistics *var_stats/*=NULL*/)
-	boolean dWorldAttachQuickStepDynamicIterationStatisticsSink(
-							dWorldQuickStepIterationCount_DynamicAdjustmentStatistics var_stats/*=NULL*/)
-
-	{
-		// dAASSERT(w);
-		dAASSERT(var_stats == null || (var_stats.struct_size >= sizeof(*var_stats) && var_stats.struct_size % sizeof(duint32) == 0));
-		dSASSERT(sizeof(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics) % sizeof(duint32) == 0);
-
-		boolean result = false;
-
-		if (var_stats != null) {
-			if (var_stats.struct_size >= sizeof(*var_stats) && var_stats.struct_size % sizeof(duint32) == 0) {
-
-				this.qs.AssignStatisticsSink(var_stats);
-				result = true;
-			}
-		}
-		else {
-			this.qs.ClearStatisticsSink();
-			result = true;
-		}
-
-		return result;
-	}
+	//	boolean dWorldAttachQuickStepDynamicIterationStatisticsSink(
+	//							dWorldQuickStepIterationCount_DynamicAdjustmentStatistics var_stats/*=NULL*/)
+	//
+	//	{
+	//		// dAASSERT(w);
+	//		dAASSERT(var_stats == null || (var_stats.struct_size >= sizeof(*var_stats) && var_stats.struct_size % sizeof(duint32) == 0));
+	//		dSASSERT(sizeof(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics) % sizeof(duint32) == 0);
+	//
+	//		boolean result = false;
+	//
+	//		if (var_stats != null) {
+	//			if (var_stats.struct_size >= sizeof(*var_stats) && var_stats.struct_size % sizeof(duint32) == 0) {
+	//
+	//				this.qs.AssignStatisticsSink(var_stats);
+	//				result = true;
+	//			}
+	//		}
+	//		else {
+	//			this.qs.ClearStatisticsSink();
+	//			result = true;
+	//		}
+	//
+	//		return result;
+	//	}
 
 
 	private void dWorldSetQuickStepW (double param)
@@ -768,9 +771,9 @@ public class DxWorld extends DBase implements DWorld {
 	
 	static int EstimateIslandProcessingSimultaneousCallsMaximumCount(int activeThreadCount, 
 			int islandsAllowedThreadCount, 
-			int stepperAllowedThreadCount, dmaxcallcountestimate_fn_t maxCallCountEstimator)
+			int steppingAllowedThreadCount, int lcpAllowedThreadCount, dmaxcallcountestimate_fn_t maxCallCountEstimator)
 	{
-		int stepperCallsMaximum = maxCallCountEstimator.run(activeThreadCount, stepperAllowedThreadCount);
+		int stepperCallsMaximum = maxCallCountEstimator.run(activeThreadCount, steppingAllowedThreadCount,lcpAllowedThreadCount);
 		int islandsIntermediateCallsMaximum = (1 + 2); // ThreadedProcessIslandSearch_Callback + (ThreadedProcessIslandStepper_Callback && ThreadedProcessIslandSearch_Callback)
 
 		int result = 
@@ -819,9 +822,11 @@ public class DxWorld extends DBase implements DWorld {
 		dIASSERT(activeThreadCount.get() >= islandsAllowedThreadCount);
 
 		// For now, set stepper allowed threads equal to island stepping threads
-		int stepperAllowedThreadCount = islandsAllowedThreadCount; 
+		int stepperAllowedThreadCount = this.calculatePerIslandSteppingMaxThreadCount();
+		int lcpAllowedThreadCount = this.calculatePerIslandSolvingMaxThreadCount();
 
-		callContext.SetStepperAllowedThreads(Threading.ENABLE_STEPPER_MULTITHREADING ? stepperAllowedThreadCount : 1);
+		callContext.SetStepperAllowedThreads(Threading.ENABLE_STEPPER_MULTITHREADING ? stepperAllowedThreadCount : 1,
+				Threading.ENABLE_STEPPER_MULTITHREADING ? lcpAllowedThreadCount : 1);
 
 		final TaskGroup group = taskExecutor.group("World Islands Stepping Group", new Runnable() {
 			@Override
@@ -1033,6 +1038,47 @@ public class DxWorld extends DBase implements DWorld {
 	    return islands_max_threads == dWORLDSTEP_THREADCOUNT_UNLIMITED 
 	        ? active_thread_count 
 	        : (islands_max_threads < active_thread_count ? islands_max_threads : active_thread_count);
+	}
+
+	// TODO TZ moved here from dxThreadingBase / threading_base.h
+	private int calculateThreadingLimitedThreadCount(int limitValue, boolean countCallerAsExtraThread,
+													 RefInt ptrOut_activeThreadCount)
+	{
+		// TODO (TZ) should we just return GetThreadingIslandsMaxThreadsCount() ?
+		int activeThreadCount = taskExecutor.getThreadCount(); //RetrieveThreadingThreadCount();
+
+		if (ptrOut_activeThreadCount != null)
+		{
+			ptrOut_activeThreadCount.set(activeThreadCount);
+		}
+
+		int adjustedActiveThreads = countCallerAsExtraThread && activeThreadCount != Integer.MAX_VALUE ? activeThreadCount + 1 : activeThreadCount;
+		return limitValue == dTHREADING_THREAD_COUNT_UNLIMITED
+				? adjustedActiveThreads
+				: Math.min(limitValue, adjustedActiveThreads);
+	}
+
+	public int calculateIslandIterationMaxThreadCount(RefInt ptrOut_activeThreadCount)
+	{
+		// int activeThreadCount;
+		RefInt ptrActiveThreadCountToUse = ptrOut_activeThreadCount != null ? new RefInt() : null;
+		int limitedCount = calculateThreadingLimitedThreadCount(islands_max_threads, false, ptrActiveThreadCountToUse);
+		if (ptrOut_activeThreadCount != null) {
+            ptrOut_activeThreadCount.set(Math.max(ptrActiveThreadCountToUse.get(), 1));
+		}
+		return Math.max(limitedCount, 1);
+	}
+
+	int calculatePerIslandSteppingMaxThreadCount()
+	{
+		int limitedCount = calculateThreadingLimitedThreadCount(stepping_max_threads, false, null);
+		return Math.max(limitedCount, 1);
+	}
+
+	int calculatePerIslandSolvingMaxThreadCount()
+	{
+		int limitedCount = calculateThreadingLimitedThreadCount(solving_max_threads, false, null);
+		return Math.max(limitedCount, 1);
 	}
 
 	public DxWorldProcessContext UnsafeGetWorldProcessingContext()

--- a/core/src/main/java/org/ode4j/ode/internal/FastLDLTFactor.java
+++ b/core/src/main/java/org/ode4j/ode/internal/FastLDLTFactor.java
@@ -25,7 +25,10 @@ package org.ode4j.ode.internal;
 
 import static org.ode4j.ode.internal.Common.*;
 
-// Code style improvements and optimizations by Oleh Derevenko ????-2017
+/*
+ * Code style improvements and optimizations by Oleh Derevenko ????-2025
+ * LDLT cooperative factorization code of ThreadedEquationSolverLDLT copyright (c) 2017-2025 Oleh Derevenko, odar@eleks.com (change all "a" to "e")
+ */
 
 /**
  * Implementation of FastDLTImpl

--- a/core/src/main/java/org/ode4j/ode/internal/FastLSolve.java
+++ b/core/src/main/java/org/ode4j/ode/internal/FastLSolve.java
@@ -27,10 +27,13 @@ import static org.ode4j.ode.internal.Common.dIASSERT;
 
 class FastLSolve {
 
-// Code style improvements and optimizations by Oleh Derevenko ????-2017
+    /*
+     * Code style improvements and optimizations by Oleh Derevenko ????-2025
+     * L1Straight cooperative solving code of ThreadedEquationSolverLDLT copyright (c) 2017-2025 Oleh Derevenko, odar@eleks.com (change all "a" to "e")
+     */
 
-//#ifndef _ODE_FASTSOLVE_IMPL_H_
-//#define _ODE_FASTSOLVE_IMPL_H_
+    //#ifndef _ODE_FASTSOLVE_IMPL_H_
+    //#define _ODE_FASTSOLVE_IMPL_H_
 
 
     /* solve L*X=B, with B containing 1 right hand sides.
@@ -438,7 +441,7 @@ class FastLSolve {
                     Z11 += p1 * q1;
 
                     /* advance pointers */
-                    // ptrLElement += 1; -- not needed any more
+                    // ptrLElement += 1; -- not needed anymore
                     ptrBElement += 1 * b_stride;
                 }
 

--- a/core/src/main/java/org/ode4j/ode/internal/FastLTSolve.java
+++ b/core/src/main/java/org/ode4j/ode/internal/FastLTSolve.java
@@ -26,7 +26,10 @@ package org.ode4j.ode.internal;
 import static org.ode4j.ode.internal.Common.dIASSERT;
 
 class FastLTSolve {
-    // Code style improvements and optimizations by Oleh Derevenko ????-2017
+    /*
+     * Code style improvements and optimizations by Oleh Derevenko ????-2025
+     * L1Transposed cooperative solving code of ThreadedEquationSolverLDLT copyright (c) 2017-2025 Oleh Derevenko, odar@eleks.com (change all "a" to "e")
+     */
 
     //#ifndef _ODE_FASTLTSOLVE_IMPL_H_
     //#define _ODE_FASTLTSOLVE_IMPL_H_

--- a/core/src/main/java/org/ode4j/ode/internal/Matrix.java
+++ b/core/src/main/java/org/ode4j/ode/internal/Matrix.java
@@ -1014,16 +1014,17 @@ public class Matrix extends FastDot {
 
 	//ODE_PURE_INLINE
 	// dReal dxCalculateModuloMaximum(const dReal *valueStorage, sizeint valueCount)
-	double dxCalculateModuloMaximum(final double[] valueStorage)
+	public static double dxCalculateModuloMaximum(final double[] valueStorageA, int valueStorageP, int valueCount)
 	{
 		// dIASSERT(valueCount != 0);
 
-		double moduleMaximum = dFabs(valueStorage[0]);
+		double moduleMaximum = dFabs(valueStorageA[valueStorageP]);
 
     	//const dReal *const storageEnd = valueStorage + valueCount;
+		int storageEnd = valueStorageP + valueCount;
 		//for (const dReal *currentValue = valueStorage + 1; currentValue != storageEnd; ++currentValue) {
-		for (int i = 1; i < valueStorage.length; i++) {
-			moduleMaximum = dMax(moduleMaximum, dFabs(valueStorage[i]));
+		for (int i = valueStorageP + 1; i < storageEnd; i++) {
+			moduleMaximum = dMax(moduleMaximum, dFabs(valueStorageA[i]));
 		}
 
 		return moduleMaximum;

--- a/core/src/main/java/org/ode4j/ode/internal/Matrix.java
+++ b/core/src/main/java/org/ode4j/ode/internal/Matrix.java
@@ -1011,7 +1011,25 @@ public class Matrix extends FastDot {
 //		dxSetValue (a, n, value);
 //	}
 //
-//// dReal dDot (const dReal *a, const dReal *b, int n);
+
+	//ODE_PURE_INLINE
+	// dReal dxCalculateModuloMaximum(const dReal *valueStorage, sizeint valueCount)
+	double dxCalculateModuloMaximum(final double[] valueStorage)
+	{
+		// dIASSERT(valueCount != 0);
+
+		double moduleMaximum = dFabs(valueStorage[0]);
+
+    	//const dReal *const storageEnd = valueStorage + valueCount;
+		//for (const dReal *currentValue = valueStorage + 1; currentValue != storageEnd; ++currentValue) {
+		for (int i = 1; i < valueStorage.length; i++) {
+			moduleMaximum = dMax(moduleMaximum, dFabs(valueStorage[i]));
+		}
+
+		return moduleMaximum;
+	}
+
+	//// dReal dDot (const dReal *a, const dReal *b, int n);
 //
 //	/*extern */
 //	void dMultiply0 (dReal *A, const dReal *B, const dReal *C, int p,int q,int r)

--- a/core/src/main/java/org/ode4j/ode/internal/Objects_H.java
+++ b/core/src/main/java/org/ode4j/ode/internal/Objects_H.java
@@ -30,6 +30,8 @@ import org.ode4j.math.DVector3;
 import org.ode4j.math.DVector3C;
 import org.ode4j.ode.DWorld;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 /**
  *  object, body, and world structures.
  *  
@@ -184,10 +186,18 @@ public class Objects_H {
 		public void AssignStatisticsSink(DWorld.dWorldQuickStepIterationCount_DynamicAdjustmentStatistics statistics) { m_statistics = statistics; }
 		public void ClearStatisticsSink() { m_statistics.set(m_internal_statistics); }
 
-		//		public volatile atomicord32 *GetStatisticsIterationCountStorage() const { dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, iteration_count)); return _type_cast_union<atomicord32>(&m_statistics->iteration_count); }
-		//		public volatile atomicord32 *GetStatisticsPrematureExitsStorage() const { dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, premature_exits)); return _type_cast_union<atomicord32>(&m_statistics->premature_exits); }
-		//		public volatile atomicord32 *GetStatisticsProlongedExecutionsStorage() const { dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, prolonged_execs)); return _type_cast_union<atomicord32>(&m_statistics->prolonged_execs); }
-		//		public volatile atomicord32 *GetStatisticsFullExtraExecutionsStorage() const { dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, full_extra_execs)); return _type_cast_union<atomicord32>(&m_statistics->full_extra_execs); }
+		public AtomicInteger GetStatisticsIterationCountStorage() {
+			// dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, iteration_count));
+			return m_statistics.iteration_count; }
+		public AtomicInteger GetStatisticsPrematureExitsStorage() {
+			// dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, premature_exits));
+			return m_statistics.premature_exits; }
+		public AtomicInteger GetStatisticsProlongedExecutionsStorage() {
+			// dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, prolonged_execs));
+			return m_statistics.prolonged_execs; }
+		public AtomicInteger GetStatisticsFullExtraExecutionsStorage() {
+			// dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, full_extra_execs));
+			return m_statistics.full_extra_execs; }
 
 		// private:
 		private static int DeriveExtraIterationCount(int iterationCount, double extraIterationCountFactor)
@@ -214,7 +224,8 @@ public class Objects_H {
 		public double w;                               // the SOR over-relaxation parameter
 
 		// private:
-		private DWorld.dWorldQuickStepIterationCount_DynamicAdjustmentStatistics m_internal_statistics; // The internal statistics is used to not have to check m_statistics for NULL; the local instance is used instead of a global one to avoid cache line conflicts between different threads possibly serving separate worlds.
+		// The internal statistics is used to not have to check m_statistics for NULL; the local instance is used instead of a global one to avoid cache line conflicts between different threads possibly serving separate worlds.
+		private final DWorld.dWorldQuickStepIterationCount_DynamicAdjustmentStatistics m_internal_statistics = new DWorld.dWorldQuickStepIterationCount_DynamicAdjustmentStatistics();
 	}
 
 

--- a/core/src/main/java/org/ode4j/ode/internal/Objects_H.java
+++ b/core/src/main/java/org/ode4j/ode/internal/Objects_H.java
@@ -28,9 +28,10 @@ import org.ode4j.math.DMatrix3;
 import org.ode4j.math.DMatrix3C;
 import org.ode4j.math.DVector3;
 import org.ode4j.math.DVector3C;
+import org.ode4j.ode.DWorld;
 
 /**
- *  object, body, and world structs.
+ *  object, body, and world structures.
  *  
  *  @author Tilmann Zaeschke
  */
@@ -94,16 +95,126 @@ public class Objects_H {
 		}
 	}
 
+//	enum dxMarginalDeltaKind {
+//		MDK__MIN,
+//
+//		MDK_EXTRA_ITERATIONS_REQUIREMENT_DELTA = MDK__MIN,
+//		MDK_PREMATURE_EXIT_DELTA,
+//
+//		MDK__MAX;
+//	};
+	public static final int MDK__MIN = 0;
+	public static final int	MDK_EXTRA_ITERATIONS_REQUIREMENT_DELTA = MDK__MIN;
+	public static final int	MDK_PREMATURE_EXIT_DELTA = 1;
+	public static final int MDK__MAX = 2;
 
+	static final double[] g_QuickStepParameters_marginalDeltaValuesInitializer = //[/*MDK__MAX*/] =
+			{
+					DWorld.dWORLDQUICKSTEP_EXTRA_ITERATION_REQUIREMENT_DELTA_DEFAULT, // MDK_EXTRA_ITERATIONS_REQUIREMENT_DELTA,
+					DWorld.dWORLDQUICKSTEP_ITERATION_PREMATURE_EXIT_DELTA_DEFAULT, // MDK_PREMATURE_EXIT_DELTA,
+			};
+	static {
+		Common.dSASSERT(g_QuickStepParameters_marginalDeltaValuesInitializer.length == MDK__MAX);
+	}
 	/** quick-step parameters. */
 	public static class dxQuickStepParameters {
-		public int num_iterations;		// number of SOR iterations to perform
-		public double w;			// the SOR over-relaxation parameter
+//		public int num_iterations;		// number of SOR iterations to perform
+//		public double w;			// the SOR over-relaxation parameter
 
 	    dxQuickStepParameters() {
-	    	num_iterations = 20;
+			m_iterationCount = DWorld.dWORLDQUICKSTEP_ITERATION_COUNT_DEFAULT;
+			m_maxExtraIterationCount = DeriveExtraIterationCount(DWorld.dWORLDQUICKSTEP_ITERATION_COUNT_DEFAULT,
+					DWorld.dWORLDQUICKSTEP_MAXIMAL_EXTRA_ITERATION_COUNT_FACTOR_DEFAULT);
+			m_maxExtraIterationsFactor = DWorld.dWORLDQUICKSTEP_MAXIMAL_EXTRA_ITERATION_COUNT_FACTOR_DEFAULT;
+			m_statistics = m_internal_statistics; //(&m_internal_statistics),
+// TODO (TZ) remove	    	num_iterations = 20;
 	    	w = 1.3;
-	    }
+
+			// std::copy(g_QuickStepParameters_marginalDeltaValuesInitializer, g_QuickStepParameters_marginalDeltaValuesInitializer + dARRAY_SIZE(g_QuickStepParameters_marginalDeltaValuesInitializer), m_marginalDeltaValues);
+			m_marginalDeltaValues = g_QuickStepParameters_marginalDeltaValuesInitializer.clone();
+			Common.dSASSERT(g_QuickStepParameters_marginalDeltaValuesInitializer.length == m_marginalDeltaValues.length);
+
+			DWorld.initializeQuickStepIterationCount_DynamicAdjustmentStatistics(m_internal_statistics);
+
+			UpdateDynamicIterationCountAdjustmentEnabledState();
+		}
+
+
+		// private:
+		// private dxQuickStepParameters(const dxQuickStepParameters &anotherInstance) { dIASSERT(false); } // disabled
+		// private dxQuickStepParameters &operator =(const dxQuickStepParameters &anotherInstance) { dIASSERT(false); return *this; } // disabled
+
+		// public:
+		public void AssignNumIterations(int iterationCount)
+		{
+			Common.dIASSERT(iterationCount != 0); // QuickStep implementation relies of number of iteration not being zero
+
+			m_iterationCount = iterationCount;
+			m_maxExtraIterationCount = DeriveExtraIterationCount(iterationCount, m_maxExtraIterationsFactor);
+			UpdateDynamicIterationCountAdjustmentEnabledState();
+		}
+
+		public int GetNumIterations() { return m_iterationCount; }
+
+		public void AssignPrematureExitDelta(double deltaValue)
+		{
+			Common.dIASSERT(deltaValue >= 0);
+			m_marginalDeltaValues[MDK_PREMATURE_EXIT_DELTA] = deltaValue;
+			UpdateDynamicIterationCountAdjustmentEnabledState();
+		}
+
+		public double GetPrematureExitDelta() { return m_marginalDeltaValues[MDK_PREMATURE_EXIT_DELTA]; }
+
+		public void AssignExtraIterationsRequirementDelta(double deltaValue) { Common.dIASSERT(deltaValue >= 0); m_marginalDeltaValues[MDK_EXTRA_ITERATIONS_REQUIREMENT_DELTA] = deltaValue; }
+		public double GetExtraIterationsRequirementDelta() { return m_marginalDeltaValues[MDK_EXTRA_ITERATIONS_REQUIREMENT_DELTA]; }
+
+		public void AssignMaxNumExtraFactor(double maxNumExtraFactor)
+		{
+			Common.dIASSERT(maxNumExtraFactor >= 0);
+
+			m_maxExtraIterationsFactor = maxNumExtraFactor;
+			m_maxExtraIterationCount = DeriveExtraIterationCount(m_iterationCount, maxNumExtraFactor);
+			UpdateDynamicIterationCountAdjustmentEnabledState();
+		}
+
+		public double GetMaxNumExtraFactor() { return m_maxExtraIterationsFactor; }
+
+		public boolean GetIsDynamicIterationCountAdjustmentEnabled() { return m_dynamicIterationCountAdjustmentEnabled; }
+
+		public void AssignStatisticsSink(DWorld.dWorldQuickStepIterationCount_DynamicAdjustmentStatistics statistics) { m_statistics = statistics; }
+		public void ClearStatisticsSink() { m_statistics.set(m_internal_statistics); }
+
+		//		public volatile atomicord32 *GetStatisticsIterationCountStorage() const { dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, iteration_count)); return _type_cast_union<atomicord32>(&m_statistics->iteration_count); }
+		//		public volatile atomicord32 *GetStatisticsPrematureExitsStorage() const { dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, premature_exits)); return _type_cast_union<atomicord32>(&m_statistics->premature_exits); }
+		//		public volatile atomicord32 *GetStatisticsProlongedExecutionsStorage() const { dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, prolonged_execs)); return _type_cast_union<atomicord32>(&m_statistics->prolonged_execs); }
+		//		public volatile atomicord32 *GetStatisticsFullExtraExecutionsStorage() const { dSASSERT(sizeof(atomicord32) == membersize(dWorldQuickStepIterationCount_DynamicAdjustmentStatistics, full_extra_execs)); return _type_cast_union<atomicord32>(&m_statistics->full_extra_execs); }
+
+		// private:
+		private static int DeriveExtraIterationCount(int iterationCount, double extraIterationCountFactor)
+		{
+			Common.dIASSERT(iterationCount != 0);
+			Common.dIASSERT(extraIterationCountFactor >= 0);
+
+			double extraIterationCount = iterationCount * extraIterationCountFactor;
+			return extraIterationCount < Integer.MAX_VALUE ? (int)extraIterationCount : Integer.MAX_VALUE;
+		}
+
+		void UpdateDynamicIterationCountAdjustmentEnabledState()
+		{
+			m_dynamicIterationCountAdjustmentEnabled = m_maxExtraIterationCount != 0 || m_marginalDeltaValues[MDK_PREMATURE_EXIT_DELTA] != 0;
+		}
+
+		// public:
+		public int m_iterationCount;         // number of SOR iterations to perform
+		public int m_maxExtraIterationCount; // maximal number of extra iterations that can be performed until maximal delta falls below the upper margin
+		public double m_maxExtraIterationsFactor;      // factor of maximal extra iteration count with respect to standard iteration count
+		public double[] m_marginalDeltaValues;// = new double[MDK__MAX]; // marginal values for LCP iteration maximal delta
+		public boolean m_dynamicIterationCountAdjustmentEnabled;
+		public DWorld.dWorldQuickStepIterationCount_DynamicAdjustmentStatistics m_statistics; // Adjustment statistics (the internal one or an externally assigned)
+		public double w;                               // the SOR over-relaxation parameter
+
+		// private:
+		private DWorld.dWorldQuickStepIterationCount_DynamicAdjustmentStatistics m_internal_statistics; // The internal statistics is used to not have to check m_statistics for NULL; the local instance is used instead of a global one to avoid cache line conflicts between different threads possibly serving separate worlds.
 	}
 
 

--- a/core/src/main/java/org/ode4j/ode/internal/OdeFactoryImpl.java
+++ b/core/src/main/java/org/ode4j/ode/internal/OdeFactoryImpl.java
@@ -426,6 +426,50 @@ public class OdeFactoryImpl extends OdeJointsFactoryImpl {
 
 	} // dTRIMESH_ENABLED
 
+	// libccd use
+	//#if dLIBCCD_ENABLED
+		REGISTER_EXTENSION("ODE_EXT_libccd");
+	//
+	//#if dLIBCCD_INTERNAL
+	//	REGISTER_EXTENSION(ODE_CCD_IMPL_internal)
+	//#endif
+	//
+	//// NOTE: Colliding geometry contractions are ordered lexicographically
+	//#if dLIBCCD_BOX_CYL
+	//	REGISTER_EXTENSION(ODE_CCD_COLL_box_cyl)
+	//#endif
+	//
+	//#if dLIBCCD_CYL_CYL
+	//	REGISTER_EXTENSION(ODE_CCD_COLL_cyl_cyl)
+	//#endif
+	//
+	//#if dLIBCCD_CAP_CYL
+	//	REGISTER_EXTENSION(ODE_CCD_COLL_cap_cyl)
+	//#endif
+	//
+	//#if dLIBCCD_CONVEX_BOX
+	//	REGISTER_EXTENSION(ODE_CCD_COLL_box_conv)
+	//#endif
+	//
+	//#if dLIBCCD_CONVEX_CAP
+	//	REGISTER_EXTENSION(ODE_CCD_COLL_cap_conv)
+	//#endif
+	//
+	//#if dLIBCCD_CONVEX_CYL
+	//	REGISTER_EXTENSION(ODE_CCD_COLL_conv_cyl)
+	//#endif
+	//
+	//#if dLIBCCD_CONVEX_SPHERE
+	//	REGISTER_EXTENSION(ODE_CCD_COLL_conv_sph)
+	//#endif
+	//
+	//#if dLIBCCD_CONVEX_CONVEX
+	//	REGISTER_EXTENSION(ODE_CCD_COLL_conv_conv)
+	//#endif
+	//// NOTE: Colliding geometry contractions are ordered lexicographically
+	//
+	//#endif // dLIBCCD_ENABLED
+
 //	if (dTLS_ENABLED) {
 //		REGISTER_EXTENSION( "ODE_EXT_mt_collisions" );
 //	} // dTLS_ENABLED
@@ -437,6 +481,8 @@ public class OdeFactoryImpl extends OdeJointsFactoryImpl {
 //	REGISTER_EXTENSION( ODE_THR_builtin_impl )
 //	#endif // #if dBUILTIN_THREADING_IMPL_ENABLED
 //	#endif // #if !dTHREADING_INTF_DISABLED
+
+	REGISTER_EXTENSION("ODE_EXT_inelastic_collisions");
 
 	//**********************************
 	// EXTENSION LIST END

--- a/core/src/main/java/org/ode4j/ode/internal/OdeInit.java
+++ b/core/src/main/java/org/ode4j/ode/internal/OdeInit.java
@@ -627,7 +627,7 @@ public class OdeInit {
      * in advance. If collision detection is not going to be used, it is not necessary
      * to specify this flag.
      *
-     * {@code dAllocateMaskAll} is a mask that can be used for for allocating all possible 
+     * {@code dAllocateMaskAll} is a mask that can be used for allocating all possible
      * data in cases when it is not known what exactly features of ODE will be used.
      * The mask may not be used in combination with other flags. It is guaranteed to
      * include all the current and future legal allocation flags. However, mature 

--- a/core/src/main/java/org/ode4j/ode/internal/QuickStepEnums.java
+++ b/core/src/main/java/org/ode4j/ode/internal/QuickStepEnums.java
@@ -26,8 +26,7 @@ package org.ode4j.ode.internal;
 
 import static org.ode4j.ode.internal.Common.dSASSERT;
 import static org.ode4j.ode.internal.CommonEnums.*;
-import static org.ode4j.ode.internal.processmem.DxUtil.EFFICIENT_ALIGNMENT;
-import static org.ode4j.ode.internal.processmem.DxUtil.dMAX;
+import static org.ode4j.ode.internal.processmem.DxUtil.*;
 
 import org.ode4j.ode.internal.joints.JointEnums;
 
@@ -143,29 +142,35 @@ class QuickStepEnums {
 	// dxInvMJTElement
 	public static final int IMJ__MIN = 0;
 	public static final int IMJ__1_MIN = IMJ__MIN;
-	public static final int IMJ__1L_MIN = IMJ__1_MIN + JVE__L_MIN;
-	public static final int IMJ_1LX = IMJ__1_MIN + JVE_LX;
-	public static final int IMJ_1LY = IMJ__1_MIN + JVE_LY;
-	public static final int IMJ_1LZ = IMJ__1_MIN + JVE_LZ;
-	public static final int IMJ__1L_MAX = IMJ__1_MIN + JVE__L_MAX;
-	public static final int IMJ__1A_MIN = IMJ__1_MIN + JVE__A_MIN;
-	public static final int IMJ_1AX = IMJ__1_MIN + JVE_AX;
-	public static final int IMJ_1AY = IMJ__1_MIN + JVE_AY;
-	public static final int IMJ_1AZ = IMJ__1_MIN + JVE_AZ;
-	public static final int IMJ__1A_MAX = IMJ__1_MIN + JVE__A_MAX;
-	public static final int IMJ__1_MAX = IMJ__1_MIN + JVE__MAX;
+	public static final int IMJ__1JVE_MIN = IMJ__1_MIN;
+	public static final int IMJ__1L_MIN = IMJ__1JVE_MIN + JVE__L_MIN;
+	public static final int IMJ_1LX = IMJ__1JVE_MIN + JVE_LX;
+	public static final int IMJ_1LY = IMJ__1JVE_MIN + JVE_LY;
+	public static final int IMJ_1LZ = IMJ__1JVE_MIN + JVE_LZ;
+	public static final int IMJ__1L_MAX = IMJ__1JVE_MIN + JVE__L_MAX;
+	public static final int IMJ__1A_MIN = IMJ__1JVE_MIN + JVE__A_MIN;
+	public static final int IMJ_1AX = IMJ__1JVE_MIN + JVE_AX;
+	public static final int IMJ_1AY = IMJ__1JVE_MIN + JVE_AY;
+	public static final int IMJ_1AZ = IMJ__1JVE_MIN + JVE_AZ;
+	public static final int IMJ__1A_MAX = IMJ__1JVE_MIN + JVE__A_MAX;
+	public static final int IMJ__1JVE_MAX = IMJ__1JVE_MIN + JVE__MAX;
+	public static final int	IMJ_1JVE_MAXABS = IMJ__1JVE_MAX + 1;
+	public static final int IMJ__1_MAX = IMJ_1JVE_MAXABS + 1;
 	public static final int IMJ__2_MIN = IMJ__1_MAX;
-	public static final int IMJ__2L_MIN = IMJ__2_MIN + JVE__L_MIN;
-	public static final int IMJ_2LX = IMJ__2_MIN + JVE_LX;
-	public static final int IMJ_2LY = IMJ__2_MIN + JVE_LY;
-	public static final int IMJ_2LZ = IMJ__2_MIN + JVE_LZ;
-	public static final int IMJ__2L_MAX = IMJ__2_MIN + JVE__L_MAX;
-	public static final int IMJ__2A_MIN = IMJ__2_MIN + JVE__A_MIN;
-	public static final int IMJ_2AX = IMJ__2_MIN + JVE_AX;
-	public static final int IMJ_2AY = IMJ__2_MIN + JVE_AY;
-	public static final int IMJ_2AZ = IMJ__2_MIN + JVE_AZ;
-	public static final int IMJ__2A_MAX = IMJ__2_MIN + JVE__A_MAX;
-	public static final int IMJ__2_MAX = IMJ__2_MIN + JVE__MAX;
+	public static final int IMJ__2JVE_MIN = IMJ__2_MIN;
+	public static final int IMJ__2L_MIN = IMJ__2JVE_MIN + JVE__L_MIN;
+	public static final int IMJ_2LX = IMJ__2JVE_MIN + JVE_LX;
+	public static final int IMJ_2LY = IMJ__2JVE_MIN + JVE_LY;
+	public static final int IMJ_2LZ = IMJ__2JVE_MIN + JVE_LZ;
+	public static final int IMJ__2L_MAX = IMJ__2JVE_MIN + JVE__L_MAX;
+	public static final int IMJ__2A_MIN = IMJ__2JVE_MIN + JVE__A_MIN;
+	public static final int IMJ_2AX = IMJ__2JVE_MIN + JVE_AX;
+	public static final int IMJ_2AY = IMJ__2JVE_MIN + JVE_AY;
+	public static final int IMJ_2AZ = IMJ__2JVE_MIN + JVE_AZ;
+	public static final int IMJ__2A_MAX = IMJ__2JVE_MIN + JVE__A_MAX;
+	public static final int IMJ__2JVE_MAX = IMJ__2JVE_MIN + JVE__MAX;
+	public static final int IMJ_2JVE_MAXABS = IMJ__2JVE_MAX + 1;
+	public static final int IMJ__2_MAX = IMJ_2JVE_MAXABS + 1;
 	public static final int IMJ__MAX = IMJ__2_MAX;
 
 	// dxContactForceElement
@@ -183,6 +188,20 @@ class QuickStepEnums {
 	public static final int CFE__A_MAX = CFE__DYNAMICS_MIN + dDA__A_MAX;
 	public static final int CFE__DYNAMICS_MAX = CFE__DYNAMICS_MIN + dDA__MAX;
 	public static final int CFE__MAX = CFE__DYNAMICS_MAX;
+
+	// dxForceAdjustmentElement
+	public static final int	FAE__MIN = 0;
+	public static final int	FAE_NEGATIVE = FAE__MIN;
+	public static final int	FAE_POSITIVE = FAE_NEGATIVE + 1;
+	public static final int	FAE__MAX = FAE_POSITIVE + 1;
+
+	// #define ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(positive) ((dxForceAdjustmentElement)(int)(positive))
+	private static int ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(boolean positive) { return positive ? 1 : 0; }
+	static {
+		dSASSERT(FAE_NEGATIVE == ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(false));
+		dSASSERT(FAE_POSITIVE == ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(true));
+		dSASSERT(FAE__MAX == 2);
+	}
 
 	// dxRHSElement
 	public static final int RHS__MIN = 0;
@@ -210,7 +229,7 @@ class QuickStepEnums {
 	static {
 		dSASSERT(((JME__MAX - 1) & JME__MAX) == 0); // Otherwise there is no reason to over-align the Jacobian
 	}
-	public static final int JCOPY_ALIGNMENT = dMAX(32, EFFICIENT_ALIGNMENT);
-	public static final int INVI_ALIGNMENT  = dMAX(32, EFFICIENT_ALIGNMENT);
-	public static final int INVMJ_ALIGNMENT = dMAX(32, EFFICIENT_ALIGNMENT);
+	public static final int JCOPY_ALIGNMENT = dMAX(COMMON_CACHELINE_SIZE, EFFICIENT_ALIGNMENT);
+	public static final int INVI_ALIGNMENT  = dMAX(COMMON_CACHELINE_SIZE, EFFICIENT_ALIGNMENT);
+	public static final int INVMJ_ALIGNMENT = dMAX(COMMON_CACHELINE_SIZE, EFFICIENT_ALIGNMENT);
 }

--- a/core/src/main/java/org/ode4j/ode/internal/QuickStepEnums.java
+++ b/core/src/main/java/org/ode4j/ode/internal/QuickStepEnums.java
@@ -196,7 +196,7 @@ class QuickStepEnums {
 	public static final int	FAE__MAX = FAE_POSITIVE + 1;
 
 	// #define ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(positive) ((dxForceAdjustmentElement)(int)(positive))
-	private static int ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(boolean positive) { return positive ? 1 : 0; }
+	static int ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(boolean positive) { return positive ? 1 : 0; }
 	static {
 		dSASSERT(FAE_NEGATIVE == ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(false));
 		dSASSERT(FAE_POSITIVE == ENCODE_SIGNUM_AS_FORCE_ADJUSTMENT_ELEMENT(true));

--- a/core/src/main/java/org/ode4j/ode/internal/cpp4j/java/RefInt.java
+++ b/core/src/main/java/org/ode4j/ode/internal/cpp4j/java/RefInt.java
@@ -32,16 +32,17 @@ public final class RefInt {
 		i = v;
 	}
 
-	public final void set(int v) {
+	public void set(int v) {
 		i = v;
 	}
 
-	public final int get() {
+	public int get() {
 		return i;
 	}
 
-	public final void inc() {
+	public int inc() {
 		i++;
+		return i;
 	}
 
 	public void add(int j) {

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimAABBSet.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimAABBSet.java
@@ -124,17 +124,17 @@ public class GimAABBSet { //Formerly GimBoxPruning
 	/*
 	                Brute-Force Vs Sorted pruning
 	Different approaches must be applied when colliding sets with different number of
-	elements. When sets have less of 100 boxes, is often better to apply force brute
+	elements. When sets have less of 100 boxes, it is often better to apply brute force
 	approach instead of sorted methods, because at lowlevel bruteforce routines gives
-	better perormance and consumes less resources, due of their simplicity.
-	But when sets are larger, the complexiity of bruteforce increases exponencially.
+	better performance and consumes less resources, due of their simplicity.
+	But when sets are larger, the complexiity of bruteforce increases exponentially.
 	In the case of large sets, sorted approach is applied. So GIMPACT has the following
 	strategies:
 
 	On Sorting sets:
 	!) When sets have more of 140 boxes, the boxes are sorted by its coded min coord
 	and the global box is calculated. But when sets are smaller (less of 140 boxes),
-	Is convenient to apply brute force approach.
+	It is convenient to apply brute force approach.
 
 	 *******************************************************************************/
 
@@ -673,7 +673,7 @@ public class GimAABBSet { //Formerly GimBoxPruning
 	//Use these functions for general initialization
 
 	/**
-	 * Initalizes the set. Sort Boxes if needed.
+	 * Initalizes the set. Sort boxes if needed.
 	 * @pre aabbset must be allocated. And the boxes must be already set.
 	 * @post If the set has less of GIM_MIN_SORTED_BIPARTITE_PRUNING_BOXES boxes, only calcs the global box,
 	 * else it Sorts the entire set( Only applicable for large sets)
@@ -722,7 +722,7 @@ public class GimAABBSet { //Formerly GimBoxPruning
 	 * @param test_aabb Box for collision query
 	 * @param collided Array of GUINT elements, indices of boxes. Must be initialized before (Reserve size ~ 100)
 	 */
-	//* @param aabbset Set of boxes .Global bound is required.
+	//* @param aabbset Set of boxes. Global bound is required.
 	//void gim_aabbset_box_collision(aabb3f *test_aabb, GIM_AABB_SET * aabbset, GDYNAMIC_ARRAY * collided)
 	public void gim_aabbset_box_collision(aabb3f test_aabb, GimDynArrayInt collided)
 	{
@@ -752,7 +752,7 @@ public class GimAABBSet { //Formerly GimBoxPruning
 	 * @param vorigin Origin point of ray.
 	 * @param vdir Direction vector of ray.
 	 * @param tmax Max distance param for ray.
-	 * // @param aabbset Set of boxes .Global bound is required.
+	 * // @param aabbset Set of boxes. Global bound is required.
 	 * @param collided Array of GUINT elements, indices of boxes. Must be initialized before (Reserve size ~ 100)
 	 */
 	//void gim_aabbset_ray_collision(vec3f vorigin,vec3f vdir, GREAL tmax, GIM_AABB_SET * aabbset, GDYNAMIC_ARRAY * collided)

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimContact.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimContact.java
@@ -49,9 +49,9 @@ import org.ode4j.ode.internal.gimpact.GimRadixSort.GIM_RSORT_TOKEN;
  * 
  * Functions for managing and sorting contacts resulting from a collision query.
  * <ul>
- * <li> Contact lists must be create by calling \ref GIM_CREATE_CONTACT_LIST
+ * <li> Contact lists must be created by calling \ref GIM_CREATE_CONTACT_LIST
  * <li> After querys, contact lists must be destroy by calling \ref GIM_DYNARRAY_DESTROY
- * <li> Contacts can be merge for avoid duplicate results by calling \ref gim_merge_contacts
+ * <li> Contacts can be merged to avoid duplicate results by calling \ref gim_merge_contacts
  * </ul>
  *
  * Ported to Java by Tilmann Zaeschke

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimGeometry.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimGeometry.java
@@ -208,7 +208,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector difference
-	static final void VEC_DIFF_4(vec4f v21, vec4f v2, vec4f v1)			
+	static void VEC_DIFF_4(vec4f v21, vec4f v2, vec4f v1)
 	{						
 	   (v21).f[0] = (v2).f[0] - (v1).f[0];		
 	   (v21).f[1] = (v2).f[1] - (v1).f[1];		
@@ -218,7 +218,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector sum
-	static final void VEC_SUM_2(vec2f v21, vec2f v2, vec2f v1)			
+	static void VEC_SUM_2(vec2f v21, vec2f v2, vec2f v1)
 	{						
 	   (v21).f[0] = (v2).f[0] + (v1).f[0];		
 	   (v21).f[1] = (v2).f[1] + (v1).f[1];		
@@ -226,7 +226,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector sum
-	static final void VEC_SUM(vec3f v21, vec3f v2, vec3f v1)			
+	static void VEC_SUM(vec3f v21, vec3f v2, vec3f v1)
 	{						
 	   (v21).f[0] = (v2).f[0] + (v1).f[0];		
 	   (v21).f[1] = (v2).f[1] + (v1).f[1];		
@@ -235,7 +235,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector sum
-	static final void VEC_SUM_4(vec4f v21, vec4f v2, vec4f v1)			
+	static void VEC_SUM_4(vec4f v21, vec4f v2, vec4f v1)
 	{						
 	   (v21).f[0] = (v2).f[0] + (v1).f[0];		
 	   (v21).f[1] = (v2).f[1] + (v1).f[1];		
@@ -245,7 +245,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// scalar times vector
-	static final void VEC_SCALE_2(vec2f c, final float a, vec2f b)			
+	static void VEC_SCALE_2(vec2f c, final float a, vec2f b)
 	{						
 	   (c).f[0] = (a)*(b).f[0];				
 	   (c).f[1] = (a)*(b).f[1];				
@@ -253,13 +253,13 @@ public class GimGeometry extends GimMath {
 
 
 	/// scalar times vector
-	static final void VEC_SCALE(vec3f c, final float a, vec3f b)			
+	static void VEC_SCALE(vec3f c, final float a, vec3f b)
 	{						
 	   (c).f[0] = (a)*(b).f[0];				
 	   (c).f[1] = (a)*(b).f[1];				
 	   (c).f[2] = (a)*(b).f[2];				
 	}
-	static final void VEC_SCALE(vec3f c, final float a, vec4f b)			
+	static void VEC_SCALE(vec3f c, final float a, vec4f b)
 	{						
 	   (c).f[0] = (a)*(b).f[0];				
 	   (c).f[1] = (a)*(b).f[1];				
@@ -268,7 +268,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// scalar times vector
-	static final void VEC_SCALE_4(vec4f c, final float a, vec4f b)			
+	static void VEC_SCALE_4(vec4f c, final float a, vec4f b)
 	{						
 	   (c).f[0] = (a)*(b).f[0];				
 	   (c).f[1] = (a)*(b).f[1];				
@@ -278,7 +278,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// accumulate scaled vector
-	static final void VEC_ACCUM_2(vec2f c, final float a, vec2f b)			
+	static void VEC_ACCUM_2(vec2f c, final float a, vec2f b)
 	{						
 	   (c).f[0] += (a)*(b).f[0];			
 	   (c).f[1] += (a)*(b).f[1];			
@@ -286,7 +286,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// accumulate scaled vector
-	static final void VEC_ACCUM(vec3f c, final float a, vec3f b)			
+	static void VEC_ACCUM(vec3f c, final float a, vec3f b)
 	{						
 	   (c).f[0] += (a)*(b).f[0];			
 	   (c).f[1] += (a)*(b).f[1];			
@@ -295,7 +295,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// accumulate scaled vector
-	static final void VEC_ACCUM_4(vec4f c, final float a, vec4f b)			
+	static void VEC_ACCUM_4(vec4f c, final float a, vec4f b)
 	{						
 	   (c).f[0] += (a)*(b).f[0];			
 	   (c).f[1] += (a)*(b).f[1];			
@@ -305,45 +305,45 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector dot product
-	static final float VEC_DOT_2(vec2f a, vec2f b) { return ((a).f[0]*(b).f[0] + (a).f[1]*(b).f[1]); }
+	static float VEC_DOT_2(vec2f a, vec2f b) { return ((a).f[0]*(b).f[0] + (a).f[1]*(b).f[1]); }
 
 
 	/// Vector dot product
-	static final float VEC_DOT(vec3f a, vec3f b) { return a.f[0]*b.f[0] + a.f[1]*b.f[1] + a.f[2]*b.f[2]; }
-	static final float VEC_DOT(vec4f a, vec3f b) { return a.f[0]*b.f[0] + a.f[1]*b.f[1] + a.f[2]*b.f[2]; }
-	static final float VEC_DOT(vec3f a, vec4f b) { return a.f[0]*b.f[0] + a.f[1]*b.f[1] + a.f[2]*b.f[2]; }
-	static final float VEC_DOT(vec4f a, vec4f b) { return a.f[0]*b.f[0] + a.f[1]*b.f[1] + a.f[2]*b.f[2]; }
-	static final float VEC_DOT(vec4f a, float[] b) { return a.f[0]*b[0] + a.f[1]*b[1] + a.f[2]*b[2]; }
+	static float VEC_DOT(vec3f a, vec3f b) { return a.f[0]*b.f[0] + a.f[1]*b.f[1] + a.f[2]*b.f[2]; }
+	static float VEC_DOT(vec4f a, vec3f b) { return a.f[0]*b.f[0] + a.f[1]*b.f[1] + a.f[2]*b.f[2]; }
+	static float VEC_DOT(vec3f a, vec4f b) { return a.f[0]*b.f[0] + a.f[1]*b.f[1] + a.f[2]*b.f[2]; }
+	static float VEC_DOT(vec4f a, vec4f b) { return a.f[0]*b.f[0] + a.f[1]*b.f[1] + a.f[2]*b.f[2]; }
+	static float VEC_DOT(vec4f a, float[] b) { return a.f[0]*b[0] + a.f[1]*b[1] + a.f[2]*b[2]; }
 
 	/// Vector dot product
-	static final float VEC_DOT_4(vec4f a, vec4f b) { return ((a).f[0]*(b).f[0] + (a).f[1]*(b).f[1] + (a).f[2]*(b).f[2] + (a).f[3]*(b).f[3]); }
+	static float VEC_DOT_4(vec4f a, vec4f b) { return ((a).f[0]*(b).f[0] + (a).f[1]*(b).f[1] + (a).f[2]*(b).f[2] + (a).f[3]*(b).f[3]); }
 
 	/// vector impact parameter (squared)
-	static final void VEC_IMPACT_SQ(final RefFloat bsq, final vec3f direction, 
+	static void VEC_IMPACT_SQ(final RefFloat bsq, final vec3f direction,
 			final vec3f position) {
 		   float _llel_ = VEC_DOT(direction, position);
 		   bsq.d = VEC_DOT(position, position) - _llel_*_llel_;
 	}
-	static final float VEC_IMPACT_SQ(final vec3f direction, final vec3f position) {
+	static float VEC_IMPACT_SQ(final vec3f direction, final vec3f position) {
 		   float _llel_ = VEC_DOT(direction, position);
 		   return VEC_DOT(position, position) - _llel_*_llel_;
 		}
 
 
 	/// vector impact parameter
-	static final void VEC_IMPACT(final RefFloat bsq, final vec3f direction, 
+	static void VEC_IMPACT(final RefFloat bsq, final vec3f direction,
 			final vec3f position)	{
 		   VEC_IMPACT_SQ(bsq,direction,position);		
 		   bsq.d = GIM_SQRT(bsq.d);					
 	}
-	static final float VEC_IMPACT(final vec3f direction, final vec3f position)	{
+	static float VEC_IMPACT(final vec3f direction, final vec3f position)	{
 		   float bsq = VEC_IMPACT_SQ(direction,position);		
 		   bsq = GIM_SQRT(bsq);
 		   return bsq;
 		}
 
 	/// Vector length
-	static final void VEC_LENGTH_2(final vec2f  a, final RefFloat l)
+	static void VEC_LENGTH_2(final vec2f  a, final RefFloat l)
 	{
 	    float _pp = VEC_DOT_2(a,a);
 	    l.d = GIM_SQRT(_pp);
@@ -351,12 +351,12 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector length
-	static final void VEC_LENGTH(final vec3f a, final RefFloat l)
+	static void VEC_LENGTH(final vec3f a, final RefFloat l)
 	{
 	    float _pp = VEC_DOT(a,a);
 	    l.d = GIM_SQRT(_pp);
 	}
-	static final float VEC_LENGTH(final vec3f a)
+	static float VEC_LENGTH(final vec3f a)
 	{
 	    float _pp = VEC_DOT(a,a);
 	    return GIM_SQRT(_pp);
@@ -364,14 +364,14 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector length
-	static final void VEC_LENGTH_4(final vec4f a, final RefFloat l)
+	static void VEC_LENGTH_4(final vec4f a, final RefFloat l)
 	{
 	    float _pp = VEC_DOT_4(a,a);
 	    l.d = GIM_SQRT(_pp);
 	}
 
 	/// Vector inv length
-	static final void VEC_INV_LENGTH_2(final vec2f a, final RefFloat l)
+	static void VEC_INV_LENGTH_2(final vec2f a, final RefFloat l)
 	{
 	    float _pp = VEC_DOT_2(a,a);
 	    l.d = GIM_INV_SQRT(_pp);
@@ -379,12 +379,12 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector inv length
-	static final float VEC_INV_LENGTH(final vec3f a)
+	static float VEC_INV_LENGTH(final vec3f a)
 	{
 	    float _pp = VEC_DOT(a,a);
 	    return GIM_INV_SQRT(_pp);
 	}
-	static final float VEC_INV_LENGTH(final vec4f a)
+	static float VEC_INV_LENGTH(final vec4f a)
 	{
 	    float _pp = VEC_DOT(a,a);
 	    return GIM_INV_SQRT(_pp);
@@ -392,7 +392,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector inv length
-	static final void VEC_INV_LENGTH_4(final vec4f a, final RefFloat l)
+	static void VEC_INV_LENGTH_4(final vec4f a, final RefFloat l)
 	{
 	    float _pp = VEC_DOT_4(a,a);
 	    l.d = GIM_INV_SQRT(_pp);
@@ -410,7 +410,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector length
-	static final void VEC_CONJUGATE_LENGTH(final vec3f a, final RefFloat l)
+	static void VEC_CONJUGATE_LENGTH(final vec3f a, final RefFloat l)
 	{
 	    float _pp = 1.0f - a.f[0]*a.f[0] - a.f[1]*a.f[1] - a.f[2]*a.f[2];
 	    l.d = GIM_SQRT(_pp);
@@ -418,7 +418,7 @@ public class GimGeometry extends GimMath {
 
 
 	/// Vector length
-	static final void VEC_NORMALIZE(vec3f a) {	
+	static void VEC_NORMALIZE(vec3f a) {
 	    float len = VEC_INV_LENGTH(a); 
 	    if(len<G_REAL_INFINITY)
 	    {
@@ -427,7 +427,7 @@ public class GimGeometry extends GimMath {
 	        a.f[2] *= len;				
 	    }						
 	}
-	static final void VEC_NORMALIZE(vec4f a) {	
+	static void VEC_NORMALIZE(vec4f a) {
 	    float len = VEC_INV_LENGTH(a); 
 	    if(len<G_REAL_INFINITY)
 	    {
@@ -438,7 +438,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	/// Set Vector size
-	static final void VEC_RENORMALIZE(vec3f a, final float newlen) {	
+	static void VEC_RENORMALIZE(vec3f a, final float newlen) {
 	    float len = VEC_INV_LENGTH(a); 
 	    if(len<G_REAL_INFINITY)
 	    {
@@ -450,25 +450,25 @@ public class GimGeometry extends GimMath {
 	}
 
 	/// Vector cross
-	static final void VEC_CROSS(vec3f c, vec3f a, vec3f b)		
+	static void VEC_CROSS(vec3f c, vec3f a, vec3f b)
 	{						
 	   c.f[0] = (a).f[1] * (b).f[2] - (a).f[2] * (b).f[1];	
 	   c.f[1] = (a).f[2] * (b).f[0] - (a).f[0] * (b).f[2];	
 	   c.f[2] = (a).f[0] * (b).f[1] - (a).f[1] * (b).f[0];	
 	}
-	static final void VEC_CROSS(vec4f c, vec3f a, vec3f b)		
+	static void VEC_CROSS(vec4f c, vec3f a, vec3f b)
 	{						
 	   c.f[0] = (a).f[1] * (b).f[2] - (a).f[2] * (b).f[1];	
 	   c.f[1] = (a).f[2] * (b).f[0] - (a).f[0] * (b).f[2];	
 	   c.f[2] = (a).f[0] * (b).f[1] - (a).f[1] * (b).f[0];	
 	}
-	static final void VEC_CROSS(vec4f c, vec3f a, vec4f b)		
+	static void VEC_CROSS(vec4f c, vec3f a, vec4f b)
 	{						
 	   c.f[0] = (a).f[1] * (b).f[2] - (a).f[2] * (b).f[1];	
 	   c.f[1] = (a).f[2] * (b).f[0] - (a).f[0] * (b).f[2];	
 	   c.f[2] = (a).f[0] * (b).f[1] - (a).f[1] * (b).f[0];	
 	}
-	static final void VEC_CROSS(vec3f c, vec4f a, vec4f b)		
+	static void VEC_CROSS(vec3f c, vec4f a, vec4f b)
 	{						
 	   c.f[0] = (a).f[1] * (b).f[2] - (a).f[2] * (b).f[1];	
 	   c.f[1] = (a).f[2] * (b).f[0] - (a).f[0] * (b).f[2];	
@@ -478,7 +478,7 @@ public class GimGeometry extends GimMath {
 
 	/*! Vector perp -- assumes that n is of unit length
 	 * accepts vector v, subtracts out any component parallel to n */
-	static final void VEC_PERPENDICULAR(vec3f vp, vec3f v, vec3f n)			
+	static void VEC_PERPENDICULAR(vec3f vp, vec3f v, vec3f n)
 	{						
 	   float dot = VEC_DOT(v, n);			
 	   vp.f[0] = (v).f[0] - dot*(n).f[0];		
@@ -488,7 +488,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! Vector parallel -- assumes that n is of unit length */
-	static final void VEC_PARALLEL(vec3f vp, vec3f v, vec3f n)			
+	static void VEC_PARALLEL(vec3f vp, vec3f v, vec3f n)
 	{						
 	   float dot = VEC_DOT(v, n);			
 	   vp.f[0] = (dot) * (n).f[0];			
@@ -498,7 +498,7 @@ public class GimGeometry extends GimMath {
 
 	/*! Same as Vector parallel --  n can have any length
 	 * accepts vector v, subtracts out any component perpendicular to n */
-	static final void VEC_PROJECT(vec3f vp, vec3f v, vec3f n)			
+	static void VEC_PROJECT(vec3f vp, vec3f v, vec3f n)
 	{ 
 		float scalar = VEC_DOT(v, n);			
 		scalar/= VEC_DOT(n, n); 
@@ -509,7 +509,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! accepts vector v*/
-	static final void VEC_UNPROJECT(vec3f vp, vec3f v, vec3f n)			
+	static void VEC_UNPROJECT(vec3f vp, vec3f v, vec3f n)
 	{ 
 		float scalar = VEC_DOT(v, n);			
 		scalar = VEC_DOT(n, n)/scalar; 
@@ -521,7 +521,7 @@ public class GimGeometry extends GimMath {
 
 	/*! Vector reflection -- assumes n is of unit length
 	 Takes vector v, reflects it against reflector n, and returns vr */
-	static final void VEC_REFLECT(vec3f vr, vec3f v, vec3f n)			
+	static void VEC_REFLECT(vec3f vr, vec3f v, vec3f n)
 	{						
 	   float dot = VEC_DOT(v, n);			
 	   vr.f[0] = (v).f[0] - 2.0f * (dot) * (n).f[0];	
@@ -532,7 +532,7 @@ public class GimGeometry extends GimMath {
 
 	/*! Vector blending
 	Takes two vectors a, b, blends them together with two scalars */
-	static final void VEC_BLEND_AB(vec3f vr, final float sa, vec3f a, final float sb, vec3f b)			
+	static void VEC_BLEND_AB(vec3f vr, final float sa, vec3f a, final float sb, vec3f b)
 	{						
 	   vr.f[0] = (sa) * (a).f[0] + (sb) * (b).f[0];	
 	   vr.f[1] = (sa) * (a).f[1] + (sb) * (b).f[1];	
@@ -553,7 +553,7 @@ public class GimGeometry extends GimMath {
 	//! @{
 
 	/// initialize matrix
-	static final void IDENTIFY_MATRIX_3X3(mat3f m)			
+	static void IDENTIFY_MATRIX_3X3(mat3f m)
 	{						
 	   m.f[M(0,0)] = 1.0f;				
 	   m.f[M(0,1)] = 0.0f;				
@@ -569,7 +569,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	/*! initialize matrix */
-	public static final void IDENTIFY_MATRIX_4X4(mat4f m)			
+	public static void IDENTIFY_MATRIX_4X4(mat4f m)
 	{						
 	   m.f[M(0,0)] = 1.0f;				
 	   m.f[M(0,1)] = 0.0f;				
@@ -593,7 +593,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	/*! initialize matrix */
-	static final void ZERO_MATRIX_4X4(mat4f m)			
+	static void ZERO_MATRIX_4X4(mat4f m)
 	{						
 	   m.f[M(0,0)] = 0.0f;				
 	   m.f[M(0,1)] = 0.0f;				
@@ -617,7 +617,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	/*! matrix rotation  X */
-	static final void ROTX_CS(mat4f m, final float cosine, final float sine)		
+	static void ROTX_CS(mat4f m, final float cosine, final float sine)
 	{					
 	   /* rotation about the x-axis */	
 						
@@ -643,7 +643,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	/*! matrix rotation  Y */
-	static final void ROTY_CS(mat4f m, final float cosine, final float sine)		
+	static void ROTY_CS(mat4f m, final float cosine, final float sine)
 	{					
 	   /* rotation about the y-axis */	
 						
@@ -669,7 +669,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	/*! matrix rotation  Z */
-	static final void ROTZ_CS(mat4f m, final float cosine, final float sine)		
+	static void ROTZ_CS(mat4f m, final float cosine, final float sine)
 	{					
 	   /* rotation about the z-axis */	
 						
@@ -695,7 +695,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	/*! matrix copy */
-	static final void COPY_MATRIX_2X2(mat2f b, mat2f a)	
+	static void COPY_MATRIX_2X2(mat2f b, mat2f a)
 	{				
 	   b.f[M(0,0)] = a.f[M(0,0)];		
 	   b.f[M(0,1)] = a.f[M(0,1)];		
@@ -707,7 +707,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! matrix copy */
-/*	static final void COPY_MATRIX_2X3(b,a)	
+/*	static void COPY_MATRIX_2X3(b,a)
 	{				
 	   b.f[M(0,0)] = a.f[M(0,0)];		
 	   b.f[M(0,1)] = a.f[M(0,1)];		
@@ -720,7 +720,7 @@ public class GimGeometry extends GimMath {
 */
 
 	/*! matrix copy */
-	static final void COPY_MATRIX_3X3(mat3f b, mat3f a)	
+	static void COPY_MATRIX_3X3(mat3f b, mat3f a)
 	{				
 	   b.f[M(0,0)] = a.f[M(0,0)];		
 	   b.f[M(0,1)] = a.f[M(0,1)];		
@@ -737,7 +737,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! matrix copy */
-	static final void COPY_MATRIX_4X4(mat4f b, mat4f a)	
+	static void COPY_MATRIX_4X4(mat4f b, mat4f a)
 	{				
 	   b.f[M(0,0)] = a.f[M(0,0)];		
 	   b.f[M(0,1)] = a.f[M(0,1)];		
@@ -762,7 +762,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! matrix transpose */
-	static final void TRANSPOSE_MATRIX_2X2(mat2f b, mat2f a)	
+	static void TRANSPOSE_MATRIX_2X2(mat2f b, mat2f a)
 	{				
 	   b.f[M(0,0)] = a.f[M(0,0)];		
 	   b.f[M(0,1)] = a.f[M(1,0)];		
@@ -773,7 +773,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! matrix transpose */
-	static final void TRANSPOSE_MATRIX_3X3(mat3f b, mat3f a)	
+	static void TRANSPOSE_MATRIX_3X3(mat3f b, mat3f a)
 	{				
 	   b.f[M(0,0)] = a.f[M(0,0)];		
 	   b.f[M(0,1)] = a.f[M(1,0)];		
@@ -790,7 +790,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! matrix transpose */
-	static final void TRANSPOSE_MATRIX_4X4(mat4f b, mat4f a)	
+	static void TRANSPOSE_MATRIX_4X4(mat4f b, mat4f a)
 	{				
 	   b.f[M(0,0)] = a.f[M(0,0)];		
 	   b.f[M(0,1)] = a.f[M(1,0)];		
@@ -815,7 +815,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! multiply matrix by scalar */
-	static final void SCALE_MATRIX_2X2(mat2f b, final float s, mat2f a)		
+	static void SCALE_MATRIX_2X2(mat2f b, final float s, mat2f a)
 	{					
 	   b.f[M(0,0)] = (s) * a.f[M(0,0)];		
 	   b.f[M(0,1)] = (s) * a.f[M(0,1)];		
@@ -826,7 +826,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! multiply matrix by scalar */
-	static final void SCALE_MATRIX_3X3(mat3f b, final float s, mat3f a)		
+	static void SCALE_MATRIX_3X3(mat3f b, final float s, mat3f a)
 	{					
 	   b.f[M(0,0)] = (s) * a.f[M(0,0)];		
 	   b.f[M(0,1)] = (s) * a.f[M(0,1)];		
@@ -843,7 +843,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! multiply matrix by scalar */
-	static final void SCALE_MATRIX_4X4(mat4f b, final float s, mat4f a)		
+	static void SCALE_MATRIX_4X4(mat4f b, final float s, mat4f a)
 	{					
 	   b.f[M(0,0)] = (s) * a.f[M(0,0)];		
 	   b.f[M(0,1)] = (s) * a.f[M(0,1)];		
@@ -868,7 +868,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! multiply matrix by scalar */
-	static final void ACCUM_SCALE_MATRIX_2X2(mat2f b, final float s, mat2f a)		
+	static void ACCUM_SCALE_MATRIX_2X2(mat2f b, final float s, mat2f a)
 	{					
 	   b.f[M(0,0)] += (s) * a.f[M(0,0)];		
 	   b.f[M(0,1)] += (s) * a.f[M(0,1)];		
@@ -879,7 +879,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! multiply matrix by scalar */
-	static final void ACCUM_SCALE_MATRIX_3X3(mat3f b, final float s, mat3f a)		
+	static void ACCUM_SCALE_MATRIX_3X3(mat3f b, final float s, mat3f a)
 	{					
 	   b.f[M(0,0)] += (s) * a.f[M(0,0)];		
 	   b.f[M(0,1)] += (s) * a.f[M(0,1)];		
@@ -896,7 +896,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! multiply matrix by scalar */
-	static final void ACCUM_SCALE_MATRIX_4X4(mat4f b, final float s, mat4f a)		
+	static void ACCUM_SCALE_MATRIX_4X4(mat4f b, final float s, mat4f a)
 	{					
 	   b.f[M(0,0)] += (s) * a.f[M(0,0)];		
 	   b.f[M(0,1)] += (s) * a.f[M(0,1)];		
@@ -921,7 +921,7 @@ public class GimGeometry extends GimMath {
 
 	/*! matrix product */
 	/*! c[x][y] = a[x][0]*b[0][y]+a[x][1]*b[1][y]+a[x][2]*b[2][y]+a[x][3]*b[3][y];*/
-	static final void MATRIX_PRODUCT_2X2(mat2f c, mat2f a, mat2f b)		
+	static void MATRIX_PRODUCT_2X2(mat2f c, mat2f a, mat2f b)
 	{						
 	   c.f[M(0,0)] = a.f[M(0,0)]*b.f[M(0,0)]+a.f[M(0,1)]*b.f[M(1,0)];	
 	   c.f[M(0,1)] = a.f[M(0,0)]*b.f[M(0,1)]+a.f[M(0,1)]*b.f[M(1,1)];	
@@ -933,7 +933,7 @@ public class GimGeometry extends GimMath {
 
 	/*! matrix product */
 	/*! c[x][y] = a[x][0]*b[0][y]+a[x][1]*b[1][y]+a[x][2]*b[2][y]+a[x][3]*b[3][y];*/
-	static final void MATRIX_PRODUCT_3X3(mat3f c, mat3f a, mat3f b)				
+	static void MATRIX_PRODUCT_3X3(mat3f c, mat3f a, mat3f b)
 	{								
 	   c.f[M(0,0)] = a.f[M(0,0)]*b.f[M(0,0)]+a.f[M(0,1)]*b.f[M(1,0)]+a.f[M(0,2)]*b.f[M(2,0)];	
 	   c.f[M(0,1)] = a.f[M(0,0)]*b.f[M(0,1)]+a.f[M(0,1)]*b.f[M(1,1)]+a.f[M(0,2)]*b.f[M(2,1)];	
@@ -951,7 +951,7 @@ public class GimGeometry extends GimMath {
 
 	/*! matrix product */
 	/*! c[x][y] = a[x][0]*b[0][y]+a[x][1]*b[1][y]+a[x][2]*b[2][y]+a[x][3]*b[3][y];*/
-	static final void MATRIX_PRODUCT_4X4(mat4f c, mat4f a, mat4f b)		
+	static void MATRIX_PRODUCT_4X4(mat4f c, mat4f a, mat4f b)
 	{						
 	   c.f[M(0,0)] = a.f[M(0,0)]*b.f[M(0,0)]+a.f[M(0,1)]*b.f[M(1,0)]+a.f[M(0,2)]*b.f[M(2,0)]+a.f[M(0,3)]*b.f[M(3,0)];
 	   c.f[M(0,1)] = a.f[M(0,0)]*b.f[M(0,1)]+a.f[M(0,1)]*b.f[M(1,1)]+a.f[M(0,2)]*b.f[M(2,1)]+a.f[M(0,3)]*b.f[M(3,1)];
@@ -976,7 +976,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! matrix times vector */
-	static final void MAT_DOT_VEC_2X2(vec2f p, mat2f m, vec2f v)					
+	static void MAT_DOT_VEC_2X2(vec2f p, mat2f m, vec2f v)
 	{								
 	   p.f[0] = m.f[M(0,0)]*v.f[0] + m.f[M(0,1)]*v.f[1];				
 	   p.f[1] = m.f[M(1,0)]*v.f[0] + m.f[M(1,1)]*v.f[1];				
@@ -984,7 +984,7 @@ public class GimGeometry extends GimMath {
 
 
 	/*! matrix times vector */
-	static final void MAT_DOT_VEC_3X3(vec3f p,mat3f m, vec3f v)					
+	static void MAT_DOT_VEC_3X3(vec3f p,mat3f m, vec3f v)
 	{								
 	   p.f[0] = m.f[M(0,0)]*v.f[0] + m.f[M(0,1)]*v.f[1] + m.f[M(0,2)]*v.f[2];		
 	   p.f[1] = m.f[M(1,0)]*v.f[0] + m.f[M(1,1)]*v.f[1] + m.f[M(1,2)]*v.f[2];		
@@ -995,7 +995,7 @@ public class GimGeometry extends GimMath {
 	/*! matrix times vector
 	v is a vec4f
 	*/
-	static final void MAT_DOT_VEC_4X4(vec4f p, mat4f m, vec4f v)					
+	static void MAT_DOT_VEC_4X4(vec4f p, mat4f m, vec4f v)
 	{								
 	   p.f[0] = m.f[M(0,0)]*v.f[0] + m.f[M(0,1)]*v.f[1] + m.f[M(0,2)]*v.f[2] + m.f[M(0,3)]*v.f[3];	
 	   p.f[1] = m.f[M(1,0)]*v.f[0] + m.f[M(1,1)]*v.f[1] + m.f[M(1,2)]*v.f[2] + m.f[M(1,3)]*v.f[3];	
@@ -1008,13 +1008,13 @@ public class GimGeometry extends GimMath {
 	and m is a mat4f<br>
 	Last column is added as the position
 	*/
-	static final void MAT_DOT_VEC_3X4(vec3f p, mat4f m, vec3f v)					
+	static void MAT_DOT_VEC_3X4(vec3f p, mat4f m, vec3f v)
 	{								
 	   p.f[0] = m.f[M(0,0)]*v.f[0] + m.f[M(0,1)]*v.f[1] + m.f[M(0,2)]*v.f[2] + m.f[M(0,3)];	
 	   p.f[1] = m.f[M(1,0)]*v.f[0] + m.f[M(1,1)]*v.f[1] + m.f[M(1,2)]*v.f[2] + m.f[M(1,3)];	
 	   p.f[2] = m.f[M(2,0)]*v.f[0] + m.f[M(2,1)]*v.f[1] + m.f[M(2,2)]*v.f[2] + m.f[M(2,3)];	
 	}
-	static final void MAT_DOT_VEC_3X4(FloatArray p, mat4f m, FloatArray v)					
+	static void MAT_DOT_VEC_3X4(FloatArray p, mat4f m, FloatArray v)
 	{								
 	   p.setAt(0, m.f[M(0,0)]*v.at(0) + m.f[M(0,1)]*v.at(1) + m.f[M(0,2)]*v.at(2) + m.f[M(0,3)] );	
 	   p.setAt(1, m.f[M(1,0)]*v.at(0) + m.f[M(1,1)]*v.at(1) + m.f[M(1,2)]*v.at(2) + m.f[M(1,3)] );	
@@ -1023,7 +1023,7 @@ public class GimGeometry extends GimMath {
 
 	/*! vector transpose times matrix */
 	/*! p.f[j] = v.f[0]*m[0][j] + v.f[1]*m[1][j] + v.f[2]*m[2][j]; */
-	static final void VEC_DOT_MAT_3X3(vec3f p, vec3f v, mat3f m)					
+	static void VEC_DOT_MAT_3X3(vec3f p, vec3f v, mat3f m)
 	{								
 	   p.f[0] = v.f[0]*m.f[M(0,0)] + v.f[1]*m.f[M(1,0)] + v.f[2]*m.f[M(2,0)];		
 	   p.f[1] = v.f[0]*m.f[M(0,1)] + v.f[1]*m.f[M(1,1)] + v.f[2]*m.f[M(2,1)];		
@@ -1034,7 +1034,7 @@ public class GimGeometry extends GimMath {
 	/*! affine matrix times vector */
 	/** The matrix is assumed to be an affine matrix, with last two
 	 * entries representing a translation */
-	static final void MAT_DOT_VEC_2X3(vec2f p, mat3f m, vec2f v)					
+	static void MAT_DOT_VEC_2X3(vec2f p, mat3f m, vec2f v)
 	{								
 	   p.f[0] = m.f[M(0,0)]*v.f[0] + m.f[M(0,1)]*v.f[1] + m.f[M(0,2)];		
 	   p.f[1] = m.f[M(1,0)]*v.f[0] + m.f[M(1,1)]*v.f[1] + m.f[M(1,2)];		
@@ -1042,15 +1042,15 @@ public class GimGeometry extends GimMath {
 
 
 	/** inverse transpose of matrix times vector
-	 *
+	 * <p>
 	 * This macro computes inverse transpose of matrix m,
-	 * and multiplies vector v into it, to yeild vector p
-	 *
-	 * DANGER !!! Do Not use this on normal vectors!!!
+	 * and multiplies vector v into it, to yield vector p
+	 * <p>
+	 * DANGER !!! Do not use this on normal vectors!!!
 	 * It will leave normals the wrong length !!!
 	 * See macro below for use on normals.
 	 */
-	static final void INV_TRANSP_MAT_DOT_VEC_2X2(final vec2f p, final mat2f m, final vec2f v)			
+	static void INV_TRANSP_MAT_DOT_VEC_2X2(final vec2f p, final mat2f m, final vec2f v)
 	{								
 	   float det;						
 									
@@ -1058,7 +1058,7 @@ public class GimGeometry extends GimMath {
 	   p.f[0] = m.f[M(1,1)]*v.f[0] - m.f[M(1,0)]*v.f[1];				
 	   p.f[1] = - m.f[M(0,1)]*v.f[0] + m.f[M(0,0)]*v.f[1];			
 									
-	   /* if matrix not singular, and not orthonormal, then renormalize */ 
+	   /* if matrix is not singular, and not orthonormal, then renormalize */
 	   if ((det!=1.0f) && (det != 0.0f)) {				
 	      det = 1.0f / det;						
 	      p.f[0] *= det;						
@@ -1069,12 +1069,12 @@ public class GimGeometry extends GimMath {
 
 	/** transform normal vector by inverse transpose of matrix
 	 * and then renormalize the vector
-	 *
+	 * <p>
 	 * This macro computes inverse transpose of matrix m,
-	 * and multiplies vector v into it, to yeild vector p
+	 * and multiplies vector v into it, to yield vector p
 	 * Vector p is then normalized.
 	 */
-	static final void NORM_XFORM_2X2(final vec2f p, final mat2f m, final vec2f v)					
+	static void NORM_XFORM_2X2(final vec2f p, final mat2f m, final vec2f v)
 	{								
 	   double len;							
 									
@@ -1095,11 +1095,11 @@ public class GimGeometry extends GimMath {
 
 
 	/** outer product of vector times vector transpose
-	 *
-	 * The outer product of vector v and vector transpose t yeilds
+	 * <p>
+	 * The outer product of vector v and vector transpose t yields
 	 * dyadic matrix m.
 	 */
-	static final void OUTER_PRODUCT_2X2(final mat2f m, final vec2f v, final vec2f t)				
+	static void OUTER_PRODUCT_2X2(final mat2f m, final vec2f v, final vec2f t)
 	{								
 	   m.f[M(0,0)] = v.f[0] * t.f[0];					
 	   m.f[M(0,1)] = v.f[0] * t.f[1];					
@@ -1110,11 +1110,11 @@ public class GimGeometry extends GimMath {
 
 
 	/** outer product of vector times vector transpose
-	 *
-	 * The outer product of vector v and vector transpose t yeilds
+	 * <p>
+	 * The outer product of vector v and vector transpose t yields
 	 * dyadic matrix m.
 	 */
-	static final void OUTER_PRODUCT_3X3(mat3f m, vec3f v, vec3f t)				
+	static void OUTER_PRODUCT_3X3(mat3f m, vec3f v, vec3f t)
 	{								
 	   m.f[M(0,0)] = v.f[0] * t.f[0];					
 	   m.f[M(0,1)] = v.f[0] * t.f[1];					
@@ -1131,11 +1131,11 @@ public class GimGeometry extends GimMath {
 
 
 	/** outer product of vector times vector transpose
-	 *
-	 * The outer product of vector v and vector transpose t yeilds
+	 * <p>
+	 * The outer product of vector v and vector transpose t yields
 	 * dyadic matrix m.
 	 */
-	static final void OUTER_PRODUCT_4X4(mat4f m, vec4f v, vec4f t)				
+	static void OUTER_PRODUCT_4X4(mat4f m, vec4f v, vec4f t)
 	{								
 	   m.f[M(0,0)] = v.f[0] * t.f[0];					
 	   m.f[M(0,1)] = v.f[0] * t.f[1];					
@@ -1160,11 +1160,11 @@ public class GimGeometry extends GimMath {
 
 
 	/** outer product of vector times vector transpose
-	 *
-	 * The outer product of vector v and vector transpose t yeilds
+	 * <p>
+	 * The outer product of vector v and vector transpose t yields
 	 * dyadic matrix m.
 	 */
-	static final void ACCUM_OUTER_PRODUCT_2X2(mat2f m, vec2f v, vec2f t)				
+	static void ACCUM_OUTER_PRODUCT_2X2(mat2f m, vec2f v, vec2f t)
 	{								
 	   m.f[M(0,0)] += v.f[0] * t.f[0];					
 	   m.f[M(0,1)] += v.f[0] * t.f[1];					
@@ -1175,11 +1175,11 @@ public class GimGeometry extends GimMath {
 
 
 	/** outer product of vector times vector transpose
-	 *
-	 * The outer product of vector v and vector transpose t yeilds
+	 * <p>
+	 * The outer product of vector v and vector transpose t yields
 	 * dyadic matrix m.
 	 */
-	static final void ACCUM_OUTER_PRODUCT_3X3(mat3f m, vec3f v, vec3f t)				
+	static void ACCUM_OUTER_PRODUCT_3X3(mat3f m, vec3f v, vec3f t)
 	{								
 	   m.f[M(0,0)] += v.f[0] * t.f[0];					
 	   m.f[M(0,1)] += v.f[0] * t.f[1];					
@@ -1196,11 +1196,11 @@ public class GimGeometry extends GimMath {
 
 
 	/** outer product of vector times vector transpose
-	 *
-	 * The outer product of vector v and vector transpose t yeilds
+	 * <p>
+	 * The outer product of vector v and vector transpose t yields
 	 * dyadic matrix m.
 	 */
-	static final void ACCUM_OUTER_PRODUCT_4X4(mat4f m, vec4f v, vec4f t)				
+	static void ACCUM_OUTER_PRODUCT_4X4(mat4f m, vec4f v, vec4f t)
 	{								
 	   m.f[M(0,0)] += v.f[0] * t.f[0];					
 	   m.f[M(0,1)] += v.f[0] * t.f[1];					
@@ -1225,20 +1225,20 @@ public class GimGeometry extends GimMath {
 
 
 	/** determinant of matrix
-	 *
+	 * <p>
 	 * Computes determinant of matrix m, returning d
 	 */
-	static final void DETERMINANT_2X2(final RefFloat d, mat2f m)					
+	static void DETERMINANT_2X2(final RefFloat d, mat2f m)
 	{								
 	   d.d = m.f[M(0,0)] * m.f[M(1,1)] - m.f[M(0,1)] * m.f[M(1,0)];			
 	}
 
 
 	/** determinant of matrix
-	 *
+	 * <p>
 	 * Computes determinant of matrix m, returning d
 	 */
-	static final void DETERMINANT_3X3(final RefFloat d, mat3f m)					
+	static void DETERMINANT_3X3(final RefFloat d, mat3f m)
 	{								
 	   d.d = m.f[M(0,0)] * (m.f[M(1,1)]*m.f[M(2,2)] - m.f[M(1,2)] * m.f[M(2,1)]);		
 	   d.d -= m.f[M(0,1)] * (m.f[M(1,0)]*m.f[M(2,2)] - m.f[M(1,2)] * m.f[M(2,0)]);	
@@ -1247,9 +1247,9 @@ public class GimGeometry extends GimMath {
 
 
 	/** i,j,th cofactor of a 4x4 matrix
-	 *
+	 * <p>
 	 */
-	static final float COFACTOR_4X4_IJ(final mat4f m, final int i, final int j) 				
+	static float COFACTOR_4X4_IJ(final mat4f m, final int i, final int j)
 	{			
 		float fac = 0;
 	   int __ii[]=new int[4], __jj[]=new int[4], __k;						
@@ -1275,10 +1275,10 @@ public class GimGeometry extends GimMath {
 
 
 	/** determinant of matrix
-	 *
+	 * <p>
 	 * Computes determinant of matrix m, returning d
 	 */
-	static final void DETERMINANT_4X4(final RefFloat d, final mat4f m)					
+	static void DETERMINANT_4X4(final RefFloat d, final mat4f m)
 	{								
 	   double cofac;						
 	   cofac = COFACTOR_4X4_IJ (m, 0, 0);				
@@ -1293,10 +1293,10 @@ public class GimGeometry extends GimMath {
 
 
 	/** cofactor of matrix
-	 *
+	 * <p>
 	 * Computes cofactor of matrix m, returning a
 	 */
-	static final void COFACTOR_2X2(mat2f a, mat2f m)					
+	static void COFACTOR_2X2(mat2f a, mat2f m)
 	{								
 	   a.f[M(0,0)] = (m).f[M(1,1)];						
 	   a.f[M(0,1)] = - (m).f[M(1,0)];						
@@ -1309,7 +1309,7 @@ public class GimGeometry extends GimMath {
 //	 *
 //	 * Computes cofactor of matrix m, returning a
 //	 */
-//	private static final void COFACTOR_3X3(mat3f a, mat3f m)					
+//	private static void COFACTOR_3X3(mat3f a, mat3f m)
 //	{								
 //	   a.f[M(0,0)] = m.f[M(1,1)]*m.f[M(2,2)] - m.f[M(1,2)]*m.f[M(2,1)];			
 //	   a.f[M(0,1)] = - (m.f[M(1,0)]*m.f[M(2,2)] - m.f[M(2,0)]*m.f[M(1,2)]);		
@@ -1324,10 +1324,10 @@ public class GimGeometry extends GimMath {
 
 
 	/** cofactor of matrix
-	 *
+	 * <p>
 	 * Computes cofactor of matrix m, returning a
 	 */
-	static final void COFACTOR_4X4(final mat4f a, final mat4f m)					
+	static void COFACTOR_4X4(final mat4f a, final mat4f m)
 	{								
 	   int i,j;							
 									
@@ -1340,11 +1340,11 @@ public class GimGeometry extends GimMath {
 
 
 	/** adjoint of matrix
-	 *
+	 * <p>
 	 * Computes adjoint of matrix m, returning a
 	 * (Note that adjoint is just the transpose of the cofactor matrix)
 	 */
-	static final void ADJOINT_2X2(mat2f a, mat2f m)					
+	static void ADJOINT_2X2(mat2f a, mat2f m)
 	{								
 	   a.f[M(0,0)] = (m).f[M(1,1)];						
 	   a.f[M(1,0)] = - (m).f[M(1,0)];						
@@ -1358,7 +1358,7 @@ public class GimGeometry extends GimMath {
 //	 * Computes adjoint of matrix m, returning a
 //	 * (Note that adjoint is just the transpose of the cofactor matrix)
 //	 */
-//	private static final void ADJOINT_3X3(mat3f a, mat3f m)					
+//	private static void ADJOINT_3X3(mat3f a, mat3f m)
 //	{								
 //	   a.f[M(0,0)] = m.f[M(1,1)]*m.f[M(2,2)] - m.f[M(1,2)]*m.f[M(2,1)];			
 //	   a.f[M(1,0)] = - (m.f[M(1,0)]*m.f[M(2,2)] - m.f[M(2,0)]*m.f[M(1,2)]);		
@@ -1373,13 +1373,13 @@ public class GimGeometry extends GimMath {
 
 
 	/** adjoint of matrix
-	 *
+	 * <p>
 	 * Computes adjoint of matrix m, returning a
 	 * (Note that adjoint is just the transpose of the cofactor matrix)
 	 */
-	static final void ADJOINT_4X4(mat4f a, mat4f m)					
+	static void ADJOINT_4X4(mat4f a, mat4f m)
 	{								
-	   char _i_,_j_;							
+	   int _i_,_j_;
 									
 	   for (_i_=0; _i_<4; _i_++) {					
 	      for (_j_=0; _j_<4; _j_++) {					
@@ -1390,10 +1390,10 @@ public class GimGeometry extends GimMath {
 
 
 	/** compute adjoint of matrix and scale
-	 *
+	 * <p>
 	 * Computes adjoint of matrix m, scales it by s, returning a
 	 */
-	static final void SCALE_ADJOINT_2X2(mat2f a, final float s, mat2f m)				
+	static void SCALE_ADJOINT_2X2(mat2f a, final float s, mat2f m)
 	{								
 	   a.f[M(0,0)] = (s) * m.f[M(1,1)];					
 	   a.f[M(1,0)] = - (s) * m.f[M(1,0)];					
@@ -1403,10 +1403,10 @@ public class GimGeometry extends GimMath {
 
 
 	/** compute adjoint of matrix and scale
-	 *
+	 * <p>
 	 * Computes adjoint of matrix m, scales it by s, returning a
 	 */
-	static final void SCALE_ADJOINT_3X3(mat3f a, final float s, mat3f m)				
+	static void SCALE_ADJOINT_3X3(mat3f a, final float s, mat3f m)
 	{								
 	   a.f[M(0,0)] = (s) * (m.f[M(1,1)] * m.f[M(2,2)] - m.f[M(1,2)] * m.f[M(2,1)]);	
 	   a.f[M(1,0)] = (s) * (m.f[M(1,2)] * m.f[M(2,0)] - m.f[M(1,0)] * m.f[M(2,2)]);	
@@ -1423,12 +1423,12 @@ public class GimGeometry extends GimMath {
 
 
 	/** compute adjoint of matrix and scale
-	 *
+	 * <p>
 	 * Computes adjoint of matrix m, scales it by s, returning a
 	 */
-	static final void SCALE_ADJOINT_4X4(mat4f a, final float s, mat4f m)				
+	static void SCALE_ADJOINT_4X4(mat4f a, final float s, mat4f m)
 	{								
-	   char _i_,_j_; 
+	   int _i_,_j_;
 	   for (_i_=0; _i_<4; _i_++) {					
 	      for (_j_=0; _j_<4; _j_++) {					
 	    	  a.f[M(_j_,_i_)] = COFACTOR_4X4_IJ (m, _i_, _j_);			
@@ -1438,11 +1438,11 @@ public class GimGeometry extends GimMath {
 	}
 
 	/** inverse of matrix
-	 *
+	 * <p>
 	 * Compute inverse of matrix a, returning determinant m and
 	 * inverse b
 	 */
-	static final void INVERT_2X2(final mat2f b, final RefFloat det, final mat2f a)			
+	static void INVERT_2X2(final mat2f b, final RefFloat det, final mat2f a)
 	{						
 	   float _tmp_;					
 	   DETERMINANT_2X2 (det, a);			
@@ -1452,11 +1452,11 @@ public class GimGeometry extends GimMath {
 
 
 	/** inverse of matrix
-	 *
+	 * <p>
 	 * Compute inverse of matrix a, returning determinant m and
 	 * inverse b
 	 */
-	static final void INVERT_3X3(final mat3f b, final RefFloat det, final mat3f a)			
+	static void INVERT_3X3(final mat3f b, final RefFloat det, final mat3f a)
 	{						
 	   float _tmp_;					
 	   DETERMINANT_3X3 (det, a);			
@@ -1466,11 +1466,11 @@ public class GimGeometry extends GimMath {
 
 
 	/** inverse of matrix
-	 *
+	 * <p>
 	 * Compute inverse of matrix a, returning determinant m and
 	 * inverse b
 	 */
-	static final void INVERT_4X4(final mat4f b, final RefFloat det, final mat4f a)			
+	static void INVERT_4X4(final mat4f b, final RefFloat det, final mat4f a)
 	{						
 	   float _tmp_;					
 	   DETERMINANT_4X4 (det, a);			
@@ -1485,7 +1485,7 @@ public class GimGeometry extends GimMath {
 	//! @{
 
 	//!Initializes an AABB
-	static final void INVALIDATE_AABB(aabb3f aabb) {
+	static void INVALIDATE_AABB(aabb3f aabb) {
 	    (aabb).minX = G_REAL_INFINITY;
 	    (aabb).maxX = G_REAL_INFINITY_N;
 	    (aabb).minY = G_REAL_INFINITY;
@@ -1494,20 +1494,20 @@ public class GimGeometry extends GimMath {
 	    (aabb).maxZ = G_REAL_INFINITY_N;
 	}
 
-	static final void AABB_GET_MIN(aabb3f aabb, vec3f vmin) {
+	static void AABB_GET_MIN(aabb3f aabb, vec3f vmin) {
 	    vmin.f[0] = (aabb).minX;
 	    vmin.f[1] = (aabb).minY;
 	    vmin.f[2] = (aabb).minZ;
 	}
 
-	static final void AABB_GET_MAX(aabb3f aabb, vec3f vmax) {
+	static void AABB_GET_MAX(aabb3f aabb, vec3f vmax) {
 	    vmax.f[0] = (aabb).maxX;
 	    vmax.f[1] = (aabb).maxY;
 	    vmax.f[2] = (aabb).maxZ;
 	}
 
 	//!Copy boxes
-	static final void AABB_COPY(aabb3f dest_aabb, aabb3f src_aabb)
+	static void AABB_COPY(aabb3f dest_aabb, aabb3f src_aabb)
 	{
 	    (dest_aabb).minX = (src_aabb).minX;
 	    (dest_aabb).maxX = (src_aabb).maxX;
@@ -1517,8 +1517,8 @@ public class GimGeometry extends GimMath {
 	    (dest_aabb).maxZ = (src_aabb).maxZ;
 	}
 
-	//! Computes an Axis aligned box from  a triangle
-	static final void COMPUTEAABB_FOR_TRIANGLE(aabb3f aabb, vec3f V1, vec3f V2, vec3f V3) {
+	//! Computes an Axis aligned box from a triangle
+	static void COMPUTEAABB_FOR_TRIANGLE(aabb3f aabb, vec3f V1, vec3f V2, vec3f V3) {
 	    (aabb).minX = MIN3(V1.f[0],V2.f[0],V3.f[0]);
 	    (aabb).maxX = MAX3(V1.f[0],V2.f[0],V3.f[0]);
 	    (aabb).minY = MIN3(V1.f[1],V2.f[1],V3.f[1]);
@@ -1526,7 +1526,7 @@ public class GimGeometry extends GimMath {
 	    (aabb).minZ = MIN3(V1.f[2],V2.f[2],V3.f[2]);
 	    (aabb).maxZ = MAX3(V1.f[2],V2.f[2],V3.f[2]);
 	}
-	static final void COMPUTEAABB_FOR_TRIANGLE(aabb3f aabb, FloatArray V1, int o1, 
+	static void COMPUTEAABB_FOR_TRIANGLE(aabb3f aabb, FloatArray V1, int o1,
 			FloatArray V2, int o2, FloatArray V3, int o3) {
 	    (aabb).minX = MIN3(V1.at(o1+0),V2.at(o2+0),V3.at(o3+0));
 	    (aabb).maxX = MAX3(V1.at(o1+0),V2.at(o2+0),V3.at(o3+0));
@@ -1537,7 +1537,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	//! Merge two boxes to destaabb
-	static final void MERGEBOXES(aabb3f destaabb, aabb3f aabb) {
+	static void MERGEBOXES(aabb3f destaabb, aabb3f aabb) {
 	    (destaabb).minX = MIN((aabb).minX,(destaabb).minX);
 	    (destaabb).minY = MIN((aabb).minY,(destaabb).minY);
 	    (destaabb).minZ = MIN((aabb).minZ,(destaabb).minZ);
@@ -1547,7 +1547,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	//! Extends the box
-	static final void AABB_POINT_EXTEND(aabb3f destaabb, vec3f p) {
+	static void AABB_POINT_EXTEND(aabb3f destaabb, vec3f p) {
 	    (destaabb).minX = MIN(p.f[0],(destaabb).minX);
 	    (destaabb).maxX = MAX(p.f[0],(destaabb).maxX);
 	    (destaabb).minY = MIN(p.f[1],(destaabb).minY);
@@ -1557,7 +1557,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	//! Finds the intersection box of two boxes
-	static final void BOXINTERSECTION(aabb3f aabb1, aabb3f aabb2, aabb3f iaabb) {
+	static void BOXINTERSECTION(aabb3f aabb1, aabb3f aabb2, aabb3f iaabb) {
 	    (iaabb).minX = MAX((aabb1).minX,(aabb2).minX);
 	    (iaabb).minY = MAX((aabb1).minY,(aabb2).minY);
 	    (iaabb).minZ = MAX((aabb1).minZ,(aabb2).minZ);
@@ -1567,7 +1567,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	//! Determines if two aligned boxes do intersect
-	static final boolean AABBCOLLISION(aabb3f aabb1, aabb3f aabb2) {
+	static boolean AABBCOLLISION(aabb3f aabb1, aabb3f aabb2) {
 		//intersected.i = 1;
 		if ((aabb1).minX > (aabb2).maxX ||
 	        (aabb1).maxX < (aabb2).minX ||
@@ -1581,7 +1581,7 @@ public class GimGeometry extends GimMath {
 		return true;
 	}
 
-	static final void AXIS_INTERSECT(final float min, final float max, 
+	static void AXIS_INTERSECT(final float min, final float max,
 			final float a, final float d, 
 			final RefFloat tfirst, final RefFloat tlast, final RefBoolean is_intersected) {
 		if(IS_ZERO(d))
@@ -1617,7 +1617,7 @@ public class GimGeometry extends GimMath {
 	 * @param tmax Max lenght of the ray
 	 * @param is_intersected 1 if the ray collides the box, else false
  	 */
-	static final void BOX_INTERSECTS_RAY(final aabb3f aabb, final vec3f vorigin, 
+	static void BOX_INTERSECTS_RAY(final aabb3f aabb, final vec3f vorigin,
 			final vec3f vdir, final RefFloat tparam, final float tmax, 
 			final RefBoolean is_intersected) { 
 		//float _tfirst = 0.0f, _tlast = tmax;
@@ -1634,7 +1634,7 @@ public class GimGeometry extends GimMath {
 		tparam.d = _tfirst.d;
 	}
 
-	static final void AABB_PROJECTION_INTERVAL(final aabb3f aabb, 
+	static void AABB_PROJECTION_INTERVAL(final aabb3f aabb,
 			final vec4f direction, final RefFloat vmin, final RefFloat vmax)
 	{
 	    float _center[] = { //TODO TZ optimize? use primitive variables? Store extent/centre in AABB?
@@ -1663,7 +1663,7 @@ public class GimGeometry extends GimMath {
 //	 * <li> 2 : In front of
 //	 * </ol>
 //	 */
-//	private static final void PLANE_CLASSIFY_BOX(final vec4f plane, 
+//	private static void PLANE_CLASSIFY_BOX(final vec4f plane,
 //			final aabb3f aabb, final RefInt classify)
 //	{
 //		RefFloat _fmin = new RefFloat(),_fmax = new RefFloat(); 
@@ -1684,28 +1684,7 @@ public class GimGeometry extends GimMath {
 //			} 
 //		} 
 //	}
-	static final int PLANE_CLASSIFY_BOX(final vec4f plane, final aabb3f aabb)
-	{
-		RefFloat _fmin = new RefFloat(),_fmax = new RefFloat(); 
-		AABB_PROJECTION_INTERVAL(aabb,plane, _fmin, _fmax); 
-		if(plane.f[3] >= _fmax.d) 
-		{ 
-			return 0;/*In back of*/ 
-		} 
-		else 
-		{ 
-			if(plane.f[3]+0.000001f>=_fmin.d) 
-			{ 
-				return 1;/*Spanning*/ 
-			} 
-			else 
-			{ 
-				return 2;/*In front of*/ 
-			} 
-		} 
-	}
-	//TODO remove
-	static final int PLANE_CLASSIFY_BOX_TZ(final vec4f plane, final aabb3f aabb)
+	static int PLANE_CLASSIFY_BOX(final vec4f plane, final aabb3f aabb)
 	{
 		RefFloat _fmin = new RefFloat(),_fmax = new RefFloat(); 
 		AABB_PROJECTION_INTERVAL(aabb,plane, _fmin, _fmax); 
@@ -1735,7 +1714,7 @@ public class GimGeometry extends GimMath {
 	static final float PLANEDIREPSILON = 0.0000001f;
 	static final float PARALELENORMALS = 0.000001f;
 
-	static final void TRIANGLE_NORMAL(final vec3f v1,final  vec3f v2, 
+	static void TRIANGLE_NORMAL(final vec3f v1,final  vec3f v2,
 			final vec3f v3, final vec4f n){
 	    vec3f _dif1 = new vec3f(),_dif2 = new vec3f(); 
 	    VEC_DIFF(_dif1,v2,v1); 
@@ -1745,13 +1724,13 @@ public class GimGeometry extends GimMath {
 	}
 
 	/// plane is a vec4f
-	static final void TRIANGLE_PLANE(final vec3f v1, final vec3f v2, final vec3f v3, final vec4f plane) {
+	static void TRIANGLE_PLANE(final vec3f v1, final vec3f v2, final vec3f v3, final vec4f plane) {
 	    TRIANGLE_NORMAL(v1,v2,v3,plane);
 	    plane.f[3] = VEC_DOT(plane,v1);//,plane);
 	}
 
 	/// Calc a plane from an edge an a normal. plane is a vec4f
-	static final void EDGE_PLANE(final vec3f e1, final vec3f e2, final vec4f n, final vec4f plane) {
+	static void EDGE_PLANE(final vec3f e1, final vec3f e2, final vec4f n, final vec4f plane) {
 	    vec3f _dif = new vec3f(); 
 	    VEC_DIFF(_dif,e2,e1); 
 	    VEC_CROSS(plane,_dif,n); 
@@ -1759,11 +1738,11 @@ public class GimGeometry extends GimMath {
 	    plane.f[3] = VEC_DOT(plane,e1);//,plane);
 	}
 
-	static final float DISTANCE_PLANE_POINT(final vec4f plane, final vec3f point) { 
+	static float DISTANCE_PLANE_POINT(final vec4f plane, final vec3f point) {
 		return (VEC_DOT(plane,point) - plane.f[3]); 
 	}
 
-	static final void PROJECT_POINT_PLANE(final vec3f point, final vec4f plane, final vec3f projected) {
+	static void PROJECT_POINT_PLANE(final vec3f point, final vec4f plane, final vec3f projected) {
 		float _dis;
 		_dis = DISTANCE_PLANE_POINT(plane,point);
 		VEC_SCALE(projected,-_dis,plane);
@@ -1771,7 +1750,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	//static final void POINT_IN_HULL(vec3f point, vec4f[] planes, final int plane_count, RefInt outside)
-	static final int POINT_IN_HULL(final vec3f point, final vec4f[] planes, final int plane_count)
+	static int POINT_IN_HULL(final vec3f point, final vec4f[] planes, final int plane_count)
 	{
 		float _dis;
 		int outside = 0;
@@ -1784,7 +1763,7 @@ public class GimGeometry extends GimMath {
 		}while(_i<plane_count&&outside==0);
 		return outside;
 	}
-	static final int POINT_IN_HULL_TZ(final vec3f point, final vec4f[] planes, 
+	static int POINT_IN_HULL_TZ(final vec3f point, final vec4f[] planes,
 			final int pos, final int plane_count)
 	{
 		float _dis;
@@ -1800,7 +1779,7 @@ public class GimGeometry extends GimMath {
 	}
 
 
-	static final void PLANE_CLIP_SEGMENT(final vec3f s1, final vec3f s2, 
+	static void PLANE_CLIP_SEGMENT(final vec3f s1, final vec3f s2,
 			final vec4f plane, final vec3f clipped) {
 		float _dis1,_dis2;
 		_dis1 = DISTANCE_PLANE_POINT(plane,s1);
@@ -1810,7 +1789,7 @@ public class GimGeometry extends GimMath {
 		VEC_SUM(clipped,clipped,s1);	
 	}
 
-	//! Confirms if the plane intersect the edge or nor
+	//! Confirms if the plane intersects the edge or not
 	/*!
 	intersection type must have the following values
 	<ul>
@@ -1823,7 +1802,7 @@ public class GimGeometry extends GimMath {
 	</ul>
 	*/
 	//static final void PLANE_CLIP_SEGMENT2(vec3f s1, vec3f s2, vec4f plane, vec3f clipped, RefInt intersection_type) 
-	static final int PLANE_CLIP_SEGMENT2(final vec3f s1, final vec3f s2, 
+	static int PLANE_CLIP_SEGMENT2(final vec3f s1, final vec3f s2,
 			final vec4f plane, final vec3f clipped)
 	{
 		int intersection_type;
@@ -1869,7 +1848,7 @@ public class GimGeometry extends GimMath {
 	*/
 //	static final void PLANE_CLIP_SEGMENT_CLOSEST(vec3f s1, vec3f s2, vec4f plane, vec3f clipped1,
 //			vec3f clipped2, RefInt intersection_type)
-	static final int PLANE_CLIP_SEGMENT_CLOSEST(final vec3f s1, 
+	static int PLANE_CLIP_SEGMENT_CLOSEST(final vec3f s1,
 			final vec3f s2, final vec4f plane, final vec3f clipped1,
 			final vec3f clipped2)
 	{
@@ -1907,7 +1886,7 @@ public class GimGeometry extends GimMath {
 
 
 	//! Finds the 2 smallest cartesian coordinates of a plane normal
-	static final void PLANE_MINOR_AXES(final vec4f plane, 
+	static void PLANE_MINOR_AXES(final vec4f plane,
 			final RefInt i0, final RefInt i1)
 	{
 	    float A[] = {Math.abs(plane.f[0]),Math.abs(plane.f[1]),Math.abs(plane.f[2])};
@@ -1940,7 +1919,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	//! Ray plane collision
-	static final void RAY_PLANE_COLLISION(final vec4f plane, final vec3f vDir, 
+	static void RAY_PLANE_COLLISION(final vec4f plane, final vec3f vDir,
 			final vec3f vPoint, final vec3f pout, 
 			final RefFloat tparam, final RefBoolean does_intersect)
 	{
@@ -1961,7 +1940,7 @@ public class GimGeometry extends GimMath {
 	}
 
 	//! Bidireccional ray
-	static final void LINE_PLANE_COLLISION(final vec4f plane, final vec3f vDir, 
+	static void LINE_PLANE_COLLISION(final vec4f plane, final vec3f vDir,
 			final vec3f vPoint, final vec3f pout, final RefFloat tparam, 
 			final float tmin, final float tmax)
 	{
@@ -1979,10 +1958,10 @@ public class GimGeometry extends GimMath {
 //	  \param p2 Plane 2
 //	  \param p Contains the origin of the ray upon returning if planes intersect
 //	  \param d Contains the direction of the ray upon returning if planes intersect
-//	  \param dointersect 1 if the planes intersect, 0 if paralell.
+//	  \param dointersect 1 if the planes intersect, 0 if parallel.
 //
 //	*/
-//	private static final void INTERSECT_PLANES(final vec3f p1, final vec3f p2, 
+//	private final void INTERSECT_PLANES(final vec3f p1, final vec3f p2,
 //			final vec3f p, final vec3f d, final RefBoolean dointersect) 
 //	{ 
 //	  VEC_CROSS(d,p1,p2); 
@@ -2009,7 +1988,7 @@ public class GimGeometry extends GimMath {
 
 	/*! Finds the closest point(cp) to (v) on a segment (e1,e2)
 	 */
-	static final void CLOSEST_POINT_ON_SEGMENT(final vec3f cp, final vec3f v, 
+	static void CLOSEST_POINT_ON_SEGMENT(final vec3f cp, final vec3f v,
 			final vec3f e1, final vec3f e2)			
 	{ 
 	    vec3f _n = new vec3f();
@@ -2041,10 +2020,10 @@ public class GimGeometry extends GimMath {
 //	\param point2 Point of line 2
 //	\param t1 Result Parameter for line 1
 //	\param t2 Result Parameter for line 2
-//	\param dointersect  0  if the lines won't intersect, else 1
+//	\param dointersect  0 if the lines won't intersect, else 1
 //
 //	*/
-//	private static final void LINE_INTERSECTION_PARAMS(final vec3f dir1, 
+//	private static void LINE_INTERSECTION_PARAMS(final vec3f dir1,
 //			final vec3f point1, final vec3f dir2, final vec3f point2, 
 //			final RefFloat t1, final RefFloat t2, final RefBoolean dointersect) {
 //	    float det;

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimMath.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimMath.java
@@ -65,6 +65,8 @@ public class GimMath {
 	//! @{
 	/*! Types */
 //	#define GREAL float
+//	#define GIM_FABS_FN(va) fabsf(va)
+//	#define GIM_SQRT_FN(va) sqrtf(va)
 //	#define GINT32 int32_t
 //	#define GUINT32 uint32_t
 //
@@ -101,23 +103,23 @@ public class GimMath {
 //	//#define G_RADTODEG(X) ((X)*180.0f/3.1415926f)
 //	private static final float  G_RADTODEG(float X) { return ((X)*180.0f/3.1415926f); };
 //
-//	//! Integer representation of a floating-point value.
-//	//#define IR(x)					((GUINT32&)(x))
+// ! Integer representation of a floating-point value.
+//  #define IR(x)					((GUINT32&)(x)) -- Type aliasing
 //	/** @deprecated */
 //	private static int IR(float x) {return Float.floatToRawIntBits(x);}
 //
-//	//! Signed integer representation of a floating-point value.
-//	//#define SIR(x)					((GINT32&)(x))
+//	! Signed integer representation of a floating-point value.
+//	#define SIR(x)					((GINT32&)(x)) -- Type aliasing
 //	/** @deprecated */
 //	private int SIR(float x) {return Float.floatToIntBits(x);}
 //
-//	//! Absolute integer representation of a floating-point value
-//	//#define AIR(x)					(IR(x)&0x7fffffff)
+//	! Absolute integer representation of a floating-point value
+//	#define AIR(x)					(IR(x)&0x7fffffff) -- Type aliasing
 //	/** @deprecated */
 //	private int AIR(float x) {return Float.floatToRawIntBits(x);}
 //
 //	//! Floating-point representation of an integer value.
-//	//#define FR(x)					((float&)(x))
+//	#define FR(x)					((GREAL&)(x)) -- Type aliasing
 //	/** @deprecated */
 //	private float FR(int x) {return Float.intBitsToFloat(x);}
 
@@ -148,43 +150,30 @@ public class GimMath {
 
 	///Swap numbers
 //	#define SWAP_NUMBERS(a,b){ \
-//	    (a) = (a)+(b); \
-//	    (b) = (a)-(b); \
-//	    (a) = (a)-(b); \
-//	}\
-//	private static final void SWAP_NUMBERS(final RefFloat a, final RefFloat b){ 
-//		a.d = a.d+b.d; 
-//		b.d = a.d-b.d; 
-//		a.d = a.d-b.d; 
+//	GREAL _swap_tmp = (a); \
+//			(a) = (b); \
+//			(b) = _swap_tmp; \
 //	}
 
-	//#define GIM_INV_SQRT(va,isva)\
-	protected static float GIM_INV_SQRT(final float va)
-	{
-		float isva;
-	    if((va)<=0.0000001f)
-	    {
-	        (isva) = G_REAL_INFINITY;
-	    }
-	    else
-	    {
-	    	return (float) (1./Math.sqrt(va));
-//	        float _x = (va) * 0.5f;
-//	        GUINT32 _y = 0x5f3759df - ( IR(va) >> 1);
-//	        (isva) = FR(_y);
-//	        (isva) = (isva) * ( 1.5f - ( _x * (isva) * (isva) ) );
-	    }
-	    return isva;
-	}
-
+	//	#define GIM_SQRT(va,sva)\
+	//	{\
+	//		(sva) = GIM_SQRT_FN(va);\
+	//	}
 	//#define GIM_SQRT(va,sva)\ // sva == result !
 	protected static float GIM_SQRT(final float va)
 	{
-//	    GIM_INV_SQRT(va,sva);
-//	    (sva) = 1.0f/(sva);
 		return (float) Math.sqrt(va);
 	}
 
+
+	//    #define GIM_INV_SQRT(va,isva)\
+	//	{\
+	//		(isva) = 1.0f / GIM_SQRT_FN(va);\
+	//	}
+	protected static float GIM_INV_SQRT(final float va)
+	{
+	    return 1.0f / (float) Math.sqrt(va);
+	}
 
 	//! Computes 1.0f / sqrtf(x). Comes from Quake3. See http://www.magic-software.com/3DGEDInvSqrt.html
 	static float gim_inv_sqrt(final float f)

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTriCollision.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTriCollision.java
@@ -384,7 +384,7 @@ public class GimTriCollision {
 //			final vec3f U0, final vec3f U1, final vec3f U2) {
 //	{                                           
 //	  float a,b,c,d0,d1,d2;                    
-//	  /* is T1 completly inside T2? */          
+//	  /* is T1 completely inside T2? */
 //	  /* check if V0 is inside tri(U0,U1,U2) */ 
 //	  a=U1[i1]-U0[i1];                          
 //	  b=-(U1[i0]-U0[i0]);                       

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimesh.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimesh.java
@@ -559,9 +559,9 @@ public class GimTrimesh implements GimConstants {
 	\param vertex_count
 	\param triindex_array
 	\param index_count
-	\param copy_vertices If 1, it copies the source vertices in another buffer. Else (0) it constructs a reference to the data.
-	\param copy_indices If 1, it copies the source vertices in another buffer. Else (0) it constructs a reference to the data.
-	\param transformed_reply If 1, then the m_transformed_vertices is a reply of the source vertices. Else it just be a reference to the original array. Use 1 if you will apply transformations to the trimesh. See \ref gim_trimesh_set_tranform().
+	\param copy_vertices If 1, it copies the source vertices to another buffer. Else (0) it constructs a reference to the data.
+	\param copy_indices If 1, it copies the source vertices to another buffer. Else (0) it constructs a reference to the data.
+	\param transformed_reply If 1, then the m_transformed_vertices is a reply of the source vertices. Else it just is a reference to the original array. Use 1 if you will apply transformations to the trimesh. See \ref gim_trimesh_set_tranform().
 	*/
 //	void gim_trimesh_create_from_data(GBUFFER_MANAGER_DATA buffer_managers[],
 //			GIM_TRIMESH * trimesh, vec3f * vertex_array, GUINT32 vertex_count,char copy_vertices, 

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimesh.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimesh.java
@@ -48,8 +48,8 @@ import org.ode4j.ode.internal.gimpact.GimTrimeshCapsuleCollision.GIM_CAPSULE_DAT
 	<ul>
 	<li> For creating trimeshes, you must initialize Buffer managers by calling \ref gimpact_init
 	<li> Then you must define the vertex and index sources by creating them with \ref BUFFER_ARRAYS routines, and then call  \ref gim_trimesh_create_from_arrays.
-	<li> An alternative way for creaing trimesh objects is calling  \ref gim_trimesh_create_from_data.
-	<li> For access to the trimesh data (vertices, triangle indices), you must call  \ref gim_trimesh_locks_work_data , and  \ref gim_trimesh_unlocks_work_data for finish the access.
+	<li> An alternative way for creating trimesh objects is calling  \ref gim_trimesh_create_from_data.
+	<li> For access to the trimesh data (vertices, triangle indices), you must call  \ref gim_trimesh_locks_work_data , and  \ref gim_trimesh_unlocks_work_data to finish the access.
 	<li> Each time when the trimesh data is modified, you must call  \ref gim_trimesh_update after.
 	<li> When a trimesh is no longer needed, you must call \ref gim_trimesh_destroy.
 	</ul>
@@ -81,7 +81,7 @@ import org.ode4j.ode.internal.gimpact.GimTrimeshCapsuleCollision.GIM_CAPSULE_DAT
 	<p>Note that parameter transformed_reply is 0, that means that m_transformed_vertex_buffer is a reference to m_source_vertex on the trimesh, and transformations are not avaliable. Use that configuration if you have to simulate a deformable trimesh like cloth or elastic bodies.</p>
 	<p>When the trimesh is no longer needed, destroy it safely with gim_trimesh_destroy()</p>
 	<p><strong>UPDATING TRIMESHES</strong></p>
-	<p>On simulation loops, is needed to update trimeshes every time for update vertices althought updating triangle boxes and planes cache. There is two ways for update trimeshes: </p>
+	<p>On simulation loops, is needed to update trimeshes every time to update vertices althought updating triangle boxes and planes cache. There is two ways for update trimeshes: </p>
 	<ul>
 	<li> Updating vertices directly. You need to access to the \ref GIM_TRIMESH.m_source_vertex_buffer member; a vertex buffer which has access to the source vertices.
 	<pre>
@@ -141,7 +141,7 @@ public class GimTrimesh implements GimConstants {
 	GimBufferArrayFloat m_source_vertex_buffer;//!< Buffer of vec3f coordinates
 
 	/** 
-	 * (GUINT) Indices of triangles,groups of three elements.
+	 * (GUINT) Indices of triangles, groups of three elements.
 	 * Array of GUINT. Triangle indices. Each triple contains indices of the vertices for each triangle.
 	 * @invariant must be aligned
 	 */
@@ -170,7 +170,7 @@ public class GimTrimesh implements GimConstants {
 
 	/**
 	 * Trimesh Trimesh Collisions
-	 * Before use this function you must update each trimesh:
+	 * Before use of this function you must update each trimesh:
 	 * <code>
 	 * gim_trimesh_update(TriMesh1);
 	 * gim_trimesh_update(TriMesh2);
@@ -186,7 +186,7 @@ public class GimTrimesh implements GimConstants {
 	 *     //Collide trimeshes
 	 *     gim_trimesh_trimesh_collision(TriMesh1,TriMesh2,&amp; trimeshcontacts);
 	 *     
-	 *     if(trimeshcontacts.m_size == 0) //do  nothing
+	 *     if(trimeshcontacts.m_size == 0) //do nothing
 	 *     {
 	 *         GIM_DYNARRAY_DESTROY(trimeshcontacts);//clean contact array
 	 *         return 0;
@@ -232,7 +232,7 @@ public class GimTrimesh implements GimConstants {
 
 	//! Trimesh Sphere Collisions
 	/*!
-	Before use this function you must update the trimesh:
+	Before use of this function you must update the trimesh:
 	\code
 	gim_trimesh_update(trimesh);
 	\endcode
@@ -294,9 +294,9 @@ public class GimTrimesh implements GimConstants {
 
 	//! Trimesh Capsule collision
 	/*!
-	Find the closest primitive collided by the ray.
+	Finds the closest primitive collided with the ray.
 
-	Before use this function you must update the trimesh:
+	Before use of this function you must update the trimesh:
 	\code
 	gim_trimesh_update(trimesh);
 	\endcode
@@ -364,7 +364,7 @@ public class GimTrimesh implements GimConstants {
 	//! Trimesh Plane Collisions
 	/*!
 
-	Before use this function you must update the trimesh:
+	Before use of this function you must update the trimesh:
 	\code
 	gim_trimesh_update(trimesh);
 	\endcode
@@ -411,7 +411,7 @@ public class GimTrimesh implements GimConstants {
 	}
 	\endcode
 
-	In each contact the 3 first coordinates refers to the contact point, the fourth refers to the distance depth and the normal is the normal of the plane.
+	In each contact the 3 first coordinates refer to the contact point, the fourth refers to the distance depth and the normal is the normal of the plane.
 
 	\param trimesh
 	\param plane vec4f plane
@@ -442,7 +442,7 @@ public class GimTrimesh implements GimConstants {
 
 	//! Trimesh Ray Collisions closest
 	/*!
-	Find the closest primitive collided by the ray
+	Finds the closest primitive collided by the ray
 	\param trimesh
 	\param origin
 	\param dir
@@ -503,7 +503,7 @@ public class GimTrimesh implements GimConstants {
 	\param trimesh
 	\param vertex_array
 	\param triindex_array
-	\param transformed_reply If 1, then the m_transformed_vertices is a reply of the source vertices. Else it just be a reference to the original array.
+	\param transformed_reply If 1, then the m_transformed_vertices is a reply of the source vertices. Else it just is a reference to the original array.
 	\post it copies the arrays by reference, and creates the auxiliary data (m_aabbset,m_planes_cache_buffer)
 	*/
 //	void gim_trimesh_create_from_arrays(GBUFFER_MANAGER_DATA buffer_managers[],
@@ -554,7 +554,7 @@ public class GimTrimesh implements GimConstants {
 
 	//! Create a trimesh from vertex array and an index array
 	/*!
-	\param trimesh An uninitialized GimTrimesh  structure
+	\param trimesh An uninitialized GimTrimesh structure
 	\param vertex_array A buffer to a vec3f array
 	\param vertex_count
 	\param triindex_array
@@ -640,7 +640,7 @@ public class GimTrimesh implements GimConstants {
 	\post dest_trimesh will be created
 	\param source_trimesh
 	\param dest_trimesh
-	\param copy_by_reference If 1, it attach a reference to the source vertices, else it copies the vertices
+	\param copy_by_reference If 1, it attaches a reference to the source vertices, else it copies the vertices
 	\param transformed_reply IF 1, then it forces the m_trasnformed_vertices to be  a reply of the source vertices
 	\param transformed_reply If 1, transformed vertices are reply of source vertives. 1 Is recommended
 	*/
@@ -730,9 +730,9 @@ public class GimTrimesh implements GimConstants {
 	    return (m_mask&GIM_TRIMESH_NEED_UPDATE) != 0;
 	}
 
-	//! Change the state of the trimesh for force it to update
+	//! Change the state of the trimesh to force it to update
 	/*!
-	Call it after made changes to the trimesh.
+	Call it after having made changes to the trimesh.
 	\post gim_trimesh_need_update(trimesh) will return 1
 	\sa gim_trimesh_needs_update,gim_trimesh_has_tranformed_reply
 	*/

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshCapsuleCollision.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshCapsuleCollision.java
@@ -98,7 +98,7 @@ public class GimTrimeshCapsuleCollision {
 
 	
 	/**
-	 * Utility function for find the closest point between a segment and a triangle.
+	 * Utility function to find the closest point between a segment and a triangle.
 	 * <p> Postcondition: 
 	 * The contacts array is not set to 0. It adds additional contacts.
 	 * 
@@ -242,8 +242,8 @@ public class GimTrimeshCapsuleCollision {
 
 
 	/**
-	 * Utility function for find the closest point between a capsule and a triangle
-	 * <p>Postcondition: The contacts array is not set to 0. It adds aditional contacts
+	 * Utility function to find the closest point between a capsule and a triangle
+	 * <p>Postcondition: The contacts array is not set to 0. It adds additional contacts
 	 * @param triangle
 	 * @param capsule
 	 * @param contacts Contains the closest points on the capsule, and the normal points to triangle
@@ -296,7 +296,6 @@ public class GimTrimeshCapsuleCollision {
 	 * Find the closest primitive collided by the ray.
 	 * @param trimesh
 	 * @param capsule
-	 * @param contact
 	 * @param contacts A GIM_CONTACT array. Must be initialized
 	 */
 	static void gim_trimesh_capsule_collision(GimTrimesh trimesh, GIM_CAPSULE_DATA capsule, GimDynArray<GimContact> contacts)

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshCapsuleCollision.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshCapsuleCollision.java
@@ -293,7 +293,7 @@ public class GimTrimeshCapsuleCollision {
 
 	/**
 	 * Trimesh Capsule collision.
-	 * Find the closest primitive collided by the ray.
+	 * Finds the closest primitive collided by the ray.
 	 * @param trimesh
 	 * @param capsule
 	 * @param contacts A GIM_CONTACT array. Must be initialized

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshTrimeshCol.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshTrimeshCol.java
@@ -189,7 +189,7 @@ class GimTrimeshTrimeshCol {
 
 
 
-	    //State variabnles
+	    //State variables
 		int mostdir=0;
 		int clipped2_count=0;
 
@@ -203,7 +203,7 @@ class GimTrimeshTrimeshCol {
 		     return false;//Reject
 		}
 
-		//find most deep interval face1
+		//find deepest interval face1
 		int deep2_count=0;
 
 		RefFloat maxdeep = new RefFloat();

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshTrimeshCol.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/GimTrimeshTrimeshCol.java
@@ -283,7 +283,7 @@ class GimTrimeshTrimeshCol {
 	 * Finds the contact points from a collision of two triangles.
 	 * <p>
 	 * Returns the contact points, the penetration depth and the separating normal of the collision
-	 * between two triangles. The normal is pointing toward triangle 1 from triangle 2
+	 * between two triangles. The normal is pointing towards triangle 1 from triangle 2
 	 */
 //	int gim_triangle_triangle_collision(
 //			GIM_TRIANGLE_DATA *tri1,

--- a/core/src/main/java/org/ode4j/ode/internal/gimpact/Gimpact.java
+++ b/core/src/main/java/org/ode4j/ode/internal/gimpact/Gimpact.java
@@ -40,7 +40,7 @@ public class Gimpact {
 
 
 	/** 
-	 * Call this for initialize GIMPACT system structures.
+	 * Call this to initialize GIMPACT system structures.
 	 */
 	public static void gimpact_init()
 	{
@@ -48,7 +48,7 @@ public class Gimpact {
 	}
 
 	/**
-	 * Call this for clean GIMPACT system structures.
+	 * Call this to clean GIMPACT system structures.
 	 */
 	public static void gimpact_terminate()
 	{

--- a/core/src/main/java/org/ode4j/ode/internal/joints/DxJointContact.java
+++ b/core/src/main/java/org/ode4j/ode/internal/joints/DxJointContact.java
@@ -222,7 +222,7 @@ public class DxJointContact extends DxJoint implements DContactJoint
 		}
 
 		// set LCP limits for normal
-		pairLoHiA[pairLoHiOfs + ROW_NORMAL * pairskip + GI2_LO] = 0;
+		pairLoHiA[pairLoHiOfs + ROW_NORMAL * pairskip + GI2_LO] = (surface_mode & dContactInelastic) == 0 ? 0.0 : dMin(contact.surface.inward_force_limit, 0.0);
 		pairLoHiA[pairLoHiOfs + ROW_NORMAL * pairskip + GI2_HI] = dInfinity;
 
 

--- a/core/src/main/java/org/ode4j/ode/internal/joints/DxJointGroup.java
+++ b/core/src/main/java/org/ode4j/ode/internal/joints/DxJointGroup.java
@@ -94,7 +94,7 @@ public class DxJointGroup extends DBase implements DJointGroup
 	
     public static DxJointGroup dJointGroupCreate (int max_size)
     {
-        // not any more ... dUASSERT (max_size > 0,"max size must be > 0");
+        // not anymore ... dUASSERT (max_size > 0,"max size must be > 0");
         DxJointGroup group = new DxJointGroup();
 //        group.num = 0;
         return group;

--- a/core/src/main/java/org/ode4j/ode/internal/joints/DxJointPR.java
+++ b/core/src/main/java/org/ode4j/ode/internal/joints/DxJointPR.java
@@ -114,7 +114,7 @@ public class DxJointPR extends DxJoint implements DPRJoint
 		//  |+---------+   -                +-----------+
 		//  |
 		// X.-----------------------------------------> Y
-		// N.B. X is comming out of the page
+		// N.B. X is coming out of the page
 		_anchor2 = new DVector3();
 
 		axisR1 = new DVector3(1, 0, 0);
@@ -549,7 +549,7 @@ public class DxJointPR extends DxJoint implements DPRJoint
 		if ( parameter.isGroup2())//and( 0xff00 ).eq( 0x100 ))
 		{
 			limotR.set( parameter.toSUB(), value);     // Take only lower part of the
-		}                                              // parameter alue
+		}                                              // parameter value
 		else
 		{
 			limotP.set( parameter.toSUB(), value );
@@ -597,10 +597,10 @@ public class DxJointPR extends DxJoint implements DPRJoint
 //	void dJointAddPRTorque( dJoint j, double torque )
 	void dJointAddPRTorque( double torque )
 	{
-		DVector3 axis = new DVector3();
-
 		if ( isFlagsReverse() )
 			torque = -torque;
+
+		DVector3 axis = new DVector3();
 
 		getAxis( axis, axisR1 );
 //		axis.v[0] *= torque;

--- a/core/src/main/java/org/ode4j/ode/internal/joints/DxJointPU.java
+++ b/core/src/main/java/org/ode4j/ode/internal/joints/DxJointPU.java
@@ -50,7 +50,7 @@ import org.ode4j.ode.internal.cpp4j.java.RefDouble;
  * anchor1: Vector from body1 to the anchor point
  *          This vector is calculated when the body are attached or
  *          when the anchor point is set. It is like the offset of the Slider
- *          joint. Since their is a prismatic between the anchor and the body1
+ *          joint. Since there is a prismatic between the anchor and the body1
  *          the distance might change as the simulation goes on.
  * anchor2: Vector from body2 to the anchor point.
  * <PRE>
@@ -571,13 +571,6 @@ public class DxJointPU extends DxJointUniversal implements DPUJoint
 	}
 
 
-	public void dJointSetPUAxisP( double x, double y, double z )
-	{
-		dJointSetPUAxis3( x, y, z );
-	}
-
-
-
 	public void dJointSetPUAxis3( double x, double y, double z )
 	{
 		setAxes( x, y, z, axisP1, null );
@@ -585,6 +578,41 @@ public class DxJointPU extends DxJointUniversal implements DPUJoint
 		computeInitialRelativeRotations();
 	}
 
+
+	void dJointSetPUAxisP(double x, double y, double z)
+	{
+		dJointSetPUAxis3(x, y, z);
+	}
+
+
+	public void dJointSetPUParam( PARAM_N parameter, double value )
+	{
+		switch ( parameter.toGROUP()) //.and( 0xff00 ))
+		{
+			case dParamGroup1:
+				limot1.set( parameter.toSUB(), value );
+				break;
+			case dParamGroup2:
+				limot2.set( parameter.toSUB(), value );//.and( 0xff), value );
+				break;
+			case dParamGroup3:
+				limotP.set( parameter.toSUB(), value );//.and( 0xff ), value );
+				break;
+			default:
+				throw new IllegalArgumentException(parameter.name());
+		}
+	}
+
+	void dJointAddPUTorques(double torque1, double torque2)
+	{
+		DVector3 axis = new DVector3();
+		buildFirstBodyTorqueVector(axis, torque1, torque2);
+
+		if (this.node[0].body != null)
+			this.node[0].body.addTorque(axis);
+		if (this.node[1].body != null)
+			this.node[1].body.addTorque(axis.scale(-1));
+	}
 
 	//void dJointGetPUAngles( dJoint j, double *angle1, double *angle2 )
 	void dJointGetPUAngles( RefDouble angle1, RefDouble angle2 )
@@ -649,25 +677,6 @@ public class DxJointPU extends DxJointUniversal implements DPUJoint
 			return rate;
 		}
 		return 0;
-	}
-
-
-	public void dJointSetPUParam( PARAM_N parameter, double value )
-	{
-		switch ( parameter.toGROUP()) //.and( 0xff00 ))
-		{
-		case dParamGroup1:
-			limot1.set( parameter.toSUB(), value );
-			break;
-		case dParamGroup2:
-			limot2.set( parameter.toSUB(), value );//.and( 0xff), value );
-			break;
-		case dParamGroup3:
-			limotP.set( parameter.toSUB(), value );//.and( 0xff ), value );
-			break;
-		default:
-			throw new IllegalArgumentException(parameter.name());
-		}
 	}
 
 	//	void dJointGetPUAnchor( dJoint j, dVector3 result )
@@ -817,7 +826,7 @@ public class DxJointPU extends DxJointUniversal implements DPUJoint
 	{ dJointGetPUAxis3 (result); }
 	@Override
 	public final void getAxisP (DVector3 result)
-	{ dJointGetPUAxis3 (result); }
+	{ dJointGetPUAxisP (result); }
 
 	/** TZ Take care to call getAngle1Internal() from dx-classes.*/
 	@Override
@@ -848,6 +857,9 @@ public class DxJointPU extends DxJointUniversal implements DPUJoint
 	public final double getParam (PARAM_N parameter)
 	{ return dJointGetPUParam (parameter); }
 
+	@Override
+	public final void addTorques (double torque1, double torque2)
+	{ dJointAddPUTorques (torque1, torque2); }
 
 	@Override
 	public void setAnchorOffset(double x, double y, double z, double dx,

--- a/core/src/main/java/org/ode4j/ode/internal/joints/DxJointUniversal.java
+++ b/core/src/main/java/org/ode4j/ode/internal/joints/DxJointUniversal.java
@@ -109,7 +109,7 @@ public class DxJointUniversal extends DxJoint implements DUniversalJoint {
             // constraints won't be perfectly satisfied, or even very well
             // satisfied.)
             //
-            // However, we'd need a version of getHingeAngleFromRElativeQuat()
+            // However, we'd need a version of getHingeAngleFromRelativeQuat()
             // that CAN handle when its relative quat is rotated along a direction
             // other than the given axis.  What I have here works,
             // although it's probably much slower than need be.
@@ -133,7 +133,7 @@ public class DxJointUniversal extends DxJoint implements DUniversalJoint {
             // dRFrom2Axes(R, ax2[0], ax2[1], ax2[2], ax1[0], ax1[1], ax1[2]);
             // You see that the R is constructed from the same 2 axis as for angle1
             // but the first and second axis are swapped.
-            // So we can take the first R and rapply a rotation to it.
+            // So we can take the first R and reapply a rotation to it.
             // The rotation is around the axis between the 2 axes (ax1 and ax2).
             // We do a rotation of 180deg.
 
@@ -203,7 +203,7 @@ public class DxJointUniversal extends DxJoint implements DUniversalJoint {
             // constraints won't be perfectly satisfied, or even very well
             // satisfied.)
             //
-            // However, we'd need a version of getHingeAngleFromRElativeQuat()
+            // However, we'd need a version of getHingeAngleFromRelativeQuat()
             // that CAN handle when its relative quat is rotated along a direction
             // other than the given axis.  What I have here works,
             // although it's probably much slower than need be.
@@ -242,7 +242,7 @@ public class DxJointUniversal extends DxJoint implements DUniversalJoint {
             // constraints won't be perfectly satisfied, or even very well
             // satisfied.)
             //
-            // However, we'd need a version of getHingeAngleFromRElativeQuat()
+            // However, we'd need a version of getHingeAngleFromRelativeQuat()
             // that CAN handle when its relative quat is rotated along a direction
             // other than the given axis.  What I have here works,
             // although it's probably much slower than need be.
@@ -400,6 +400,26 @@ public class DxJointUniversal extends DxJoint implements DUniversalJoint {
                 qrel2.set(qcross);
             }
         }
+    }
+
+
+    //    void
+    //    dxJointUniversal::buildFirstBodyTorqueVector(dVector3 torqueVector, dReal torque1, dReal torque2)
+    void buildFirstBodyTorqueVector(DVector3 torqueVector, double torque1, double torque2) {
+        if ((this.flags & dJOINT_REVERSE) != 0)
+        {
+            double temp = torque1;
+            torque1 = -torque2;
+            torque2 = -temp;
+        }
+
+        DVector3 axis1 = new DVector3(), axis2 = new DVector3();
+        getAxis(axis1, this._axis1);
+        getAxis2(axis2, this._axis2);
+        //        torqueVector[0] = axis1[0] * torque1 + axis2[0] * torque2;
+        //        torqueVector[1] = axis1[1] * torque1 + axis2[1] * torque2;
+        //        torqueVector[2] = axis1[2] * torque1 + axis2[2] * torque2;
+        torqueVector.eqSum(axis1, torque1, axis2, torque2);
     }
 
 
@@ -646,23 +666,19 @@ public class DxJointUniversal extends DxJoint implements DUniversalJoint {
 
 
     private void dJointAddUniversalTorques(double torque1, double torque2) {
-        DVector3 axis1 = new DVector3(), axis2 = new DVector3();
-
         if (isFlagsReverse()) {
             double temp = torque1;
             torque1 = -torque2;
             torque2 = -temp;
         }
 
-        getAxis(axis1, _axis1);
-        getAxis2(axis2, _axis2);
-        //		axis1.v[0] = axis1.v[0] * torque1 + axis2.v[0] * torque2;
-        //		axis1.v[1] = axis1.v[1] * torque1 + axis2.v[1] * torque2;
-        //		axis1.v[2] = axis1.v[2] * torque1 + axis2.v[2] * torque2;
-        axis1.eqSum(axis1, torque1, axis2, torque2);
+        DVector3 axis = new DVector3();
+        buildFirstBodyTorqueVector(axis, torque1, torque2);
 
-        if (node[0].body != null) node[0].body.dBodyAddTorque(axis1);
-        if (node[1].body != null) node[1].body.dBodyAddTorque(axis1.scale(-1));
+        if (node[0].body != null)
+            node[0].body.dBodyAddTorque(axis);
+        if (node[1].body != null)
+            node[1].body.dBodyAddTorque(axis.scale(-1));
     }
 
 

--- a/core/src/main/java/org/ode4j/ode/internal/joints/OdeJointsFactoryImpl.java
+++ b/core/src/main/java/org/ode4j/ode/internal/joints/OdeJointsFactoryImpl.java
@@ -219,7 +219,7 @@ public class OdeJointsFactoryImpl {
 
 	//dJointGroup dJointGroupCreate (int max_size)
 	//{
-	//    // not any more ... dUASSERT (max_size > 0,"max size must be > 0");
+	//    // not anymore ... dUASSERT (max_size > 0,"max size must be > 0");
 	//    dxJointGroup *group = new dxJointGroup;
 	//    group->num = 0;
 	//    return group;

--- a/core/src/main/java/org/ode4j/ode/internal/libccd/CCD.java
+++ b/core/src/main/java/org/ode4j/ode/internal/libccd/CCD.java
@@ -129,7 +129,7 @@ public class CCD {
 
 	/**
 	 * This function computes separation vector of two objects. Separation
-	 * vector is minimal translation of obj2 to get obj1 and obj2 speparated
+	 * vector is minimal translation of obj2 to get obj1 and obj2 separated
 	 * (without intersection).
 	 * Returns 0 if obj1 and obj2 intersect and sep is filled with translation
 	 * vector. If obj1 and obj2 don't intersect -1 is returned.
@@ -294,7 +294,7 @@ public class CCD {
 		// and add this point to simplex as last one
 		ccdSimplexAdd(simplex, last);
 
-		// set up direction vector to as (O - last) which is exactly -last
+		// set up direction vector as (O - last) which is exactly -last
 		ccdVec3Copy(dir, last.v);
 		ccdVec3Scale(dir, -CCD_ONE);
 
@@ -450,7 +450,7 @@ public class CCD {
 		}
 
 		// check if triangle is really triangle (has area > 0)
-		// if not simplex can't be expanded and thus no itersection is found
+		// if not simplex can't be expanded and thus no intersection is found
 		if (ccdVec3Eq(A.v, B.v) || ccdVec3Eq(A.v, C.v)){
 			return -1;
 		}
@@ -459,7 +459,7 @@ public class CCD {
 		ccdVec3Copy(AO, A.v);
 		ccdVec3Scale(AO, -CCD_ONE);
 
-		// compute AB and AC segments and ABC vector (perpendircular to triangle)
+		// compute AB and AC segments and ABC vector (perpendicular to triangle)
 		ccdVec3Sub2(AB, B.v, A.v);
 		ccdVec3Sub2(AC, C.v, A.v);
 		ccdVec3Cross(ABC, AB, AC);
@@ -820,7 +820,7 @@ public class CCD {
 
 		// This situation is a bit tricky. If only one segment comes from
 		// previous run of GJK - it means that either this segment is on
-		// minkowski edge (and thus we have touch contact) or it it isn't and
+		// minkowski edge (and thus we have touch contact) or it isn't and
 		// therefore segment is somewhere *inside* minkowski sum and it *must*
 		// be possible to fully enclose this segment with polyhedron formed by
 		// at least 8 triangle faces.
@@ -1041,7 +1041,7 @@ public class CCD {
 		}
 	}
 
-	/** Finds next support point (at stores it in out argument).
+	/** Finds next support point (and stores it in out argument).
 	 *  Returns 0 on success, -1 otherwise */
 	static int nextSupport(final Object obj1, final Object obj2, final ccd_t ccd,
 			final ccd_pt_el_t<?> el,

--- a/core/src/main/java/org/ode4j/ode/internal/libccd/CCDList.java
+++ b/core/src/main/java/org/ode4j/ode/internal/libccd/CCDList.java
@@ -106,7 +106,7 @@ public class CCDList {
 //	}
 //
 //	/**
-//	 * Iterates over list safe against remove of list entry
+//	 * Iterates over list safe against removal of list entry
 //	 */
 //	static final void ccdListForEachSafe(ccd_list_t list, ccd_list_t item, tmp) {
 //		    for (item = (list).next, tmp = (item).next; 

--- a/core/src/main/java/org/ode4j/ode/internal/libccd/CCDMPR.java
+++ b/core/src/main/java/org/ode4j/ode/internal/libccd/CCDMPR.java
@@ -60,7 +60,7 @@ public class CCDMPR {
 	 * Computes penetration of obj2 into obj1.
 	 * Depth of penetration, direction and position is returned, i.e. if obj2
 	 * is translated by computed depth in resulting direction obj1 and obj2
-	 * would have touching contact. Position is point in global coordinates
+	 * would have touching contact. Position is a point in global coordinates
 	 * where force should be take a place.
 	 *
 	 * Minkowski Portal Refinement algorithm is used (MPR, a.k.a. XenoCollide,

--- a/core/src/main/java/org/ode4j/ode/internal/libccd/CCDPolyTope.java
+++ b/core/src/main/java/org/ode4j/ode/internal/libccd/CCDPolyTope.java
@@ -218,7 +218,7 @@ public class CCDPolyTope {
 	    ccd_pt_edge_t e;
 	    int i;
 
-	    // remove face from edges' recerence lists
+	    // remove face from edges' reference lists
 	    for (i = 0; i < 3; i++){
 	        e = f.edge(i);
 	        if (e.faces0 == f){

--- a/core/src/main/java/org/ode4j/ode/internal/processmem/DxIslandsProcessingCallContext.java
+++ b/core/src/main/java/org/ode4j/ode/internal/processmem/DxIslandsProcessingCallContext.java
@@ -46,9 +46,13 @@ public class DxIslandsProcessingCallContext {
 		m_stepper = stepper;
 		//m_islandToProcessStorage = 0;
 		m_stepperAllowedThreads = 0;
+        m_lcpAllowedThreads = 0;
 	}
 
-	public void SetStepperAllowedThreads(int allowedThreadsLimit) { m_stepperAllowedThreads = allowedThreadsLimit; }
+	public void SetStepperAllowedThreads(int stepperAllowedThreadCount, int lcpAllowedThreadCount) {
+        m_stepperAllowedThreads = stepperAllowedThreadCount;
+        m_lcpAllowedThreads = lcpAllowedThreadCount;
+    }
 
     final DxWorld                   m_world;
     final DxWorldProcessIslandsInfo m_islandsInfo;
@@ -56,8 +60,8 @@ public class DxIslandsProcessingCallContext {
     final dstepper_fn_t             m_stepper;
     //volatile int                  m_islandToProcessStorage;
     final AtomicInteger             m_islandToProcessStorage = new AtomicInteger();
-    int                        m_stepperAllowedThreads;
-
+    int                             m_stepperAllowedThreads;
+    int                             m_lcpAllowedThreads;
     
     public void ThreadedProcessJobStart(final TaskGroup parent)
     {

--- a/core/src/main/java/org/ode4j/ode/internal/processmem/DxSingleIslandCallContext.java
+++ b/core/src/main/java/org/ode4j/ode/internal/processmem/DxSingleIslandCallContext.java
@@ -38,7 +38,8 @@ public class DxSingleIslandCallContext {
 		m_arenaInitialState = arenaInitialState; 
 		m_stepperCallContext = new DxStepperProcessingCallContext(islandsProcessingContext.m_world, 
 				islandsProcessingContext.m_stepSize, 
-				islandsProcessingContext.m_stepperAllowedThreads, 
+				islandsProcessingContext.m_stepperAllowedThreads,
+				islandsProcessingContext.m_lcpAllowedThreads,
 				stepperArena, 
 				islandBodiesStart, islandJointsStart);
 	}

--- a/core/src/main/java/org/ode4j/ode/internal/processmem/DxStepperProcessingCallContext.java
+++ b/core/src/main/java/org/ode4j/ode/internal/processmem/DxStepperProcessingCallContext.java
@@ -33,14 +33,15 @@ public final class DxStepperProcessingCallContext {
 
 	//typedef void (*dstepper_fn_t) (const dxStepperProcessingCallContext *callContext);
 	public interface dstepper_fn_t {
-		public void run(DxStepperProcessingCallContext callContext);
+		void run(DxStepperProcessingCallContext callContext);
 	}
-	//typedef unsigned (*dmaxcallcountestimate_fn_t) (unsigned activeThreadCount, unsigned allowedThreadCount);
+	//typedef unsigned (*dmaxcallcountestimate_fn_t) (unsigned activeThreadCount, unsigned steppingAllowedThreadCount,
+	// unsigned lcpAllowedThreadCount);
 	public interface dmaxcallcountestimate_fn_t {
-		public int run(int activeThreadCount, int allowedThreadCount);
+		int run(int activeThreadCount, int steppingAllowedThreadCount, int lcpAllowedThreadCount);
 	}
 	
-	DxStepperProcessingCallContext(DxWorld world, double stepSize, int stepperAllowedThreads, 
+	DxStepperProcessingCallContext(DxWorld world, double stepSize, int stepperAllowedThreads, int lcpAllowedThreads,
 			DxWorldProcessMemArena stepperArena, 
 			DxBody[] islandBodiesStart,
 			DxJoint[] islandJointsStart) {
@@ -54,6 +55,7 @@ public final class DxStepperProcessingCallContext {
 		m_islandBodiesCount = 0;
 		m_islandJointsCount = 0;
 		m_stepperAllowedThreads = stepperAllowedThreads;
+		m_lcpAllowedThreads = lcpAllowedThreads;
 	}
 
 	void AssignIslandSelection(DxBody[] islandBodiesStartA, int islandBodiesStartOfs,
@@ -81,6 +83,7 @@ public final class DxStepperProcessingCallContext {
 	private int                m_islandBodiesCount;
 	private int                m_islandJointsCount;
 	private int                m_stepperAllowedThreads;
+	private int                m_lcpAllowedThreads;
 	private TaskGroup          m_taskGroup;
 	
     public DxWorldProcessMemArena m_stepperArena() {
@@ -101,6 +104,10 @@ public final class DxStepperProcessingCallContext {
 
 	public int m_stepperAllowedThreads() {
 		return m_stepperAllowedThreads;
+	}
+
+	public int m_lcpAllowedThreads() {
+		return m_lcpAllowedThreads;
 	}
 
 	public DxBody[] m_islandBodiesStartA() {

--- a/core/src/main/java/org/ode4j/ode/internal/processmem/DxUtil.java
+++ b/core/src/main/java/org/ode4j/ode/internal/processmem/DxUtil.java
@@ -70,6 +70,8 @@ public class DxUtil {
      */
     public static final int EFFICIENT_ALIGNMENT = 16;
 
+    public static final int COMMON_CACHELINE_SIZE = 128;
+
     /* ********************************************************************************************************* */
     /* ************************* TZ: This has been move here from Common because it is mostly required here **** */
     /* ********************************************************************************************************* */

--- a/core/src/main/java/org/ode4j/ode/internal/processmem/DxWorldProcessContext.java
+++ b/core/src/main/java/org/ode4j/ode/internal/processmem/DxWorldProcessContext.java
@@ -406,7 +406,7 @@ public class DxWorldProcessContext {
 
             // TODO TZ: This has not been migrfated from ODE 0.16.2
             // throw new UnsupportedOperationException("This has not been ported yet from ODE");
-            int islandThreadsCount = world.GetThreadingIslandsMaxThreadsCount(null);
+            int islandThreadsCount = world.calculateIslandIterationMaxThreadCount(null);
             if (!context.ReallocateStepperMemArenas(world, islandThreadsCount, stepperReqWithCallContext,
                     memmgr, reserveInfo.m_fReserveFactor, reserveInfo.m_uiReserveMinimum))
             {

--- a/core/src/main/java/org/ode4j/ode/internal/trimesh/DxTriDataBase.java
+++ b/core/src/main/java/org/ode4j/ode/internal/trimesh/DxTriDataBase.java
@@ -68,7 +68,7 @@ public class DxTriDataBase extends DBase {
     // TriMesh code by Erwin de Vries.
     // Modified for FreeSOLID Compatibility by Rodrigo Hernandez
     // TriMesh caches separation by Oleh Derevenko
-    // TriMesh storage classes refactoring and face angle computation code by Oleh Derevenko (C) 2016-2017
+    // TriMesh storage classes refactoring and face angle computation code by Oleh Derevenko (C) 2016-2025
 
 
     //  #ifndef _ODE_COLLISION_TRIMESH_INTERNAL_H_
@@ -415,7 +415,7 @@ public class DxTriDataBase extends DBase {
                     }
 
                     if (useFlags != null) {
-                        // For the last element EdgeRecord::kAbsVertexUsed assignment can be skipped as noone is going to need it any more
+                        // For the last element EdgeRecord::kAbsVertexUsed assignment can be skipped as noone is going to need it anymore
                         final EdgeRecord currEdge0 = edges[currEdgeOfs];
                         useFlags[currEdge0.m_triIdx] |= ((edges[currEdge0.m_vertIdx1].m_absVertexFlags & EdgeRecord.AVF_VERTEX_USED) == 0 ? currEdge0.m_vert1Flags : 0) | ((edges[currEdge0.m_vertIdx2].m_absVertexFlags & EdgeRecord.AVF_VERTEX_USED) == 0 ? currEdge0.m_vert2Flags : 0) | currEdge0.m_edgeFlags;
                     }
@@ -500,7 +500,7 @@ public class DxTriDataBase extends DBase {
                 double normalSegmentDot = dCalcVectorDot3(triangleNormal, secondOppositeVertexSegment);
 
                 // This is a concave edge, leave it for the next pass
-                // OD: This is the "dot >= kConcaveThresh" check, but since the vectros were not normalized to save on roots and divisions,
+                // OD: This is the "dot >= kConcaveThresh" check, but since the vectors were not normalized to save on roots and divisions,
                 // the check against zero is performed first and then the dot product is squared and compared against the threshold multiplied by lengths' squares
                 // OD: Originally, there was dot > -kConcaveThresh check, but this does not seem to be a good idea
                 // as it can mark all edges on potentially large (nearly) flat surfaces concave.
@@ -807,7 +807,7 @@ public class DxTriDataBase extends DBase {
     //  collision_trimesh_internal.cpp
     // **************************************************
 
-    // TriMesh storage classes refactoring and face angle computation code by Oleh Derevenko (C) 2016-2017
+    // TriMesh storage classes refactoring and face angle computation code by Oleh Derevenko (C) 2016-2025
 
     //////////////////////////////////////////////////////////////////////////
 

--- a/core/src/main/java/org/ode4j/ode/threading/Atomics.java
+++ b/core/src/main/java/org/ode4j/ode/threading/Atomics.java
@@ -27,9 +27,29 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class Atomics {
 
+	public static int ThrsafeIncrement(AtomicInteger atomic)
+	{
+		return atomic.incrementAndGet();
+	}
+
+	public static int ThrsafeDecrement(AtomicInteger atomic)
+	{
+		return atomic.decrementAndGet();
+	}
+
+	public static void ThrsafeIncrementNoResult(AtomicInteger atomic)
+	{
+		atomic.incrementAndGet();
+	}
+
+	public static void ThrsafeDecrementNoResult(AtomicInteger atomic)
+	{
+		atomic.decrementAndGet();
+	}
+
 	public static boolean ThrsafeCompareExchange(AtomicInteger paoDestination, int aoComparand, int aoExchange)
 	{
-	    return paoDestination.compareAndSet(aoComparand, aoExchange);
+		return paoDestination.compareAndSet(aoComparand, aoExchange);
 	}
 
 	public static boolean ThrsafeCompareExchange(AtomicIntegerArray paoDestination, int arrayOffset, int aoComparand, int aoExchange)

--- a/core/src/test/java/org/ode4j/libccd/CCDTestSupport.java
+++ b/core/src/test/java/org/ode4j/libccd/CCDTestSupport.java
@@ -95,17 +95,17 @@ public class CCDTestSupport {
 		return name;
 	}
 
-//	/**
-//	 * Returns supporting vertex via v.
-//	 * Supporting vertex is fathest vertex from object in direction dir.
-//	 */
-//	void ccdSupport(const void *obj, const ccd_vec3_t *dir,
-//	                ccd_vec3_t *v);
-//
-//	/**
-//	 * Returns center of object.
-//	 */
-//	void ccdObjCenter(const void *obj, ccd_vec3_t *center);
+	//	/**
+	//	 * Returns supporting vertex via v.
+	//	 * Supporting vertex is farthest vertex from object in direction dir.
+	//	 */
+	//	void ccdSupport(const void *obj, const ccd_vec3_t *dir,
+	//	                ccd_vec3_t *v);
+	//
+	//	/**
+	//	 * Returns center of object.
+	//	 */
+	//	void ccdObjCenter(const void *obj, ccd_vec3_t *center);
 
 	/***
 	 * libccd

--- a/core/src/test/java/org/ode4j/libccd/TestVec3.java
+++ b/core/src/test/java/org/ode4j/libccd/TestVec3.java
@@ -47,7 +47,7 @@ public class TestVec3 {
 	    ccdVec3Set(a, 0., 0., 0.);
 	    ccdVec3Set(b, 1., 0., 0.);
 
-	    // extereme w == a
+	    // extreme w == a
 	    ccdVec3Set(P, -1., 0., 0.);
 	    dist = ccdVec3PointSegmentDist2(P, a, b, w);
 	    assertTrue(ccdEq(dist, 1.));
@@ -84,7 +84,7 @@ public class TestVec3 {
 	    assertTrue(ccdVec3Eq(w, a));
 
 
-	    // extereme w == b
+	    // extreme w == b
 	    ccdVec3Set(P, 2., 0., 0.);
 	    dist = ccdVec3PointSegmentDist2(P, a, b, w);
 	    assertTrue(ccdEq(dist, 1.));
@@ -148,7 +148,7 @@ public class TestVec3 {
 	    ccdVec3Set(a, -.5, 2., 1.);
 	    ccdVec3Set(b, 1., 1.5, 0.5);
 
-	    // extereme w == a
+	    // extreme w == a
 	    ccdVec3Set(P, -10., 0., 0.);
 	    dist = ccdVec3PointSegmentDist2(P, a, b, w);
 	    assertTrue(ccdEq(dist, 9.5 * 9.5 + 2. * 2. + 1.));
@@ -159,7 +159,7 @@ public class TestVec3 {
 	    assertTrue(ccdEq(dist, 9.5 * 9.5 + 7.2 * 7.2 + 2.4 * 2.4));
 	    assertTrue(ccdVec3Eq(w, a));
 
-	    // extereme w == b
+	    // extreme w == b
 	    ccdVec3Set(P, 10., 0., 0.);
 	    dist = ccdVec3PointSegmentDist2(P, a, b, w);
 	    assertTrue(ccdEq(dist, 9. * 9. + 1.5 * 1.5 + 0.5 * 0.5));

--- a/demo/src/main/java/org/ode4j/demo/DemoBasket.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBasket.java
@@ -266,7 +266,7 @@ public class DemoBasket extends dsFunctions {
 		space.add (sphgeom);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		// Causes segm violation? Why?
 		// (because dWorldDestroy() destroys body connected to geom; must call first!)

--- a/demo/src/main/java/org/ode4j/demo/DemoBasket.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBasket.java
@@ -137,7 +137,7 @@ public class DemoBasket extends dsFunctions {
 		dsSetViewpoint (xyz,hpr);
 	}
 	private static final float[] xyz = {-8,0,5};
-	private static final float[] hpr = {0.0f,-29.5000f,0.0000f};
+	private static final float[] hpr = {0.0f,-9.5000f,0.0000f};
 
 
 

--- a/demo/src/main/java/org/ode4j/demo/DemoBasket.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBasket.java
@@ -136,8 +136,8 @@ public class DemoBasket extends dsFunctions {
 
 		dsSetViewpoint (xyz,hpr);
 	}
-	private float[] xyz = {-8,0,5};
-	private float[] hpr = {0.0f,-29.5000f,0.0000f};
+	private static final float[] xyz = {-8,0,5};
+	private static final float[] hpr = {0.0f,-29.5000f,0.0000f};
 
 
 

--- a/demo/src/main/java/org/ode4j/demo/DemoBasketConvex.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBasketConvex.java
@@ -136,8 +136,8 @@ public class DemoBasketConvex extends dsFunctions {
 
 		dsSetViewpoint (xyz,hpr);
 	}
-	private float[] xyz = {-8,0,5};
-	private float[] hpr = {0.0f,-29.5000f,0.0000f};
+	private static final float[] xyz = {-8,0,5};
+	private static final float[] hpr = {0.0f,-29.5000f,0.0000f};
 
 
 

--- a/demo/src/main/java/org/ode4j/demo/DemoBasketConvex.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBasketConvex.java
@@ -137,7 +137,7 @@ public class DemoBasketConvex extends dsFunctions {
 		dsSetViewpoint (xyz,hpr);
 	}
 	private static final float[] xyz = {-8,0,5};
-	private static final float[] hpr = {0.0f,-29.5000f,0.0000f};
+	private static final float[] hpr = {0.0f,-9.5000f,0.0000f};
 
 
 

--- a/demo/src/main/java/org/ode4j/demo/DemoBasketConvex.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBasketConvex.java
@@ -271,7 +271,7 @@ public class DemoBasketConvex extends dsFunctions {
 		space.add (sphgeom);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		// Causes segm violation? Why?
 		// (because dWorldDestroy() destroys body connected to geom; must call first!)

--- a/demo/src/main/java/org/ode4j/demo/DemoBoxstack.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBoxstack.java
@@ -213,8 +213,8 @@ class DemoBoxstack extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {2.1640f,-1.3079f,1.7600f};
+	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 

--- a/demo/src/main/java/org/ode4j/demo/DemoBoxstack.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBoxstack.java
@@ -29,16 +29,8 @@ import static org.ode4j.demo.IcosahedronGeom.Sphere_planes;
 import static org.ode4j.demo.IcosahedronGeom.Sphere_pointcount;
 import static org.ode4j.demo.IcosahedronGeom.Sphere_points;
 import static org.ode4j.demo.IcosahedronGeom.Sphere_polygons;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawConvex;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DMisc.dRandReal;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
 import static org.ode4j.ode.OdeConstants.dContactBounce;
@@ -596,7 +588,7 @@ class DemoBoxstack extends dsFunctions {
 //	    world.setStepThreadingImplementation(threading.dThreadingImplementationGetFunctions(), threading);
 	    
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 //	    threading.shutdownProcessing();//dThreadingImplementationShutdownProcessing(threading);
 //	    pool.freeThreadPool();

--- a/demo/src/main/java/org/ode4j/demo/DemoBoxstack.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBoxstack.java
@@ -214,7 +214,7 @@ class DemoBoxstack extends dsFunctions {
 
 
 	private static final float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] hpr = {125.5000f,-7.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 

--- a/demo/src/main/java/org/ode4j/demo/DemoBuggy.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBuggy.java
@@ -126,8 +126,8 @@ class DemoBuggy extends dsFunctions {
 	}
 
 
-	private float[] xyz = {0.8317f,-0.9817f,0.8000f};
-	private float[] hpr = {121.0000f,-27.5000f,0.0000f};
+	private static final float[] xyz = {0.8317f,-0.9817f,0.8000f};
+	private static final float[] hpr = {121.0000f,-27.5000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoBuggy.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBuggy.java
@@ -126,8 +126,8 @@ class DemoBuggy extends dsFunctions {
 	}
 
 
-	private static final float[] xyz = {0.8317f,-0.9817f,0.8000f};
-	private static final float[] hpr = {121.0000f,-27.5000f,0.0000f};
+	private static final float[] xyz = {0.8317f,-1.9817f,0.8000f};
+	private static final float[] hpr = {90.0000f,-5.000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoBuggy.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBuggy.java
@@ -126,8 +126,8 @@ class DemoBuggy extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {0.8317f,-0.9817f,0.8000f};
-	private static float[] hpr = {121.0000f,-27.5000f,0.0000f};
+	private float[] xyz = {0.8317f,-0.9817f,0.8000f};
+	private float[] hpr = {121.0000f,-27.5000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()
@@ -305,7 +305,7 @@ class DemoBuggy extends dsFunctions {
 		ground_box.setRotation(R);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		box[0].destroy();
 		sphere[0].destroy();

--- a/demo/src/main/java/org/ode4j/demo/DemoBuoyancy.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBuoyancy.java
@@ -90,7 +90,7 @@ public class DemoBuoyancy extends dsFunctions {
 
 
     private static float[] xyz = {-3.5f, 0f, 6f};
-    private static float[] hpr = {0f, -20.0000f,0.0000f};
+    private static float[] hpr = {0f, -10.0000f,0.0000f};
 
     // start simulation - set viewpoint
 

--- a/demo/src/main/java/org/ode4j/demo/DemoBuoyancy.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBuoyancy.java
@@ -335,8 +335,8 @@ public class DemoBuoyancy extends dsFunctions {
     public void stop() {
     }
 
-    private final static double WATER_LEVEL = 5; 
-    private final static double WATER_DENSITY = 0.27; 
+    private static final double WATER_LEVEL = 5;
+    private static final double WATER_DENSITY = 0.27;
 
     public void handleBuoyancy() {
         List<DGeom> floatingGeoms = new ArrayList<>();

--- a/demo/src/main/java/org/ode4j/demo/DemoBuoyancy.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoBuoyancy.java
@@ -1,15 +1,7 @@
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawConvex;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DMisc.dRandReal;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
 import static org.ode4j.ode.OdeConstants.dContactBounce;
@@ -331,7 +323,7 @@ public class DemoBuoyancy extends dsFunctions {
         for (int i = 0; i < obj.length; i++) obj[i] = new MyObject();
         OdeHelper.createPlane( space, 0, 0, 1, 0 );
 
-        dsSimulationLoop (args,640,480,this);
+        dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
         contactgroup.destroy ();
         space.destroy ();
         world.destroy ();

--- a/demo/src/main/java/org/ode4j/demo/DemoCards.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCards.java
@@ -151,9 +151,13 @@ public class DemoCards extends dsFunctions {
 	}
 
 
+	private static final float[] xyz = {-10.0f,0.0f,1.0000f}; // TZ
+	private static final float[] hpr = {0.0000f,25.000f,0.0000f}; // TZ
+	// start simulation - set viewpoint
 	@Override
 	public void start()
 	{
+		dsSetViewpoint (xyz,hpr); // TZ
 		System.out.println("Controls:");
 		System.out.println("   SPACE - reposition cards");
 		System.out.println("   -     - one less level");

--- a/demo/src/main/java/org/ode4j/demo/DemoCards.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCards.java
@@ -24,9 +24,8 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
 import static org.ode4j.ode.OdeConstants.dContactApprox1;
 
@@ -242,8 +241,19 @@ public class DemoCards extends dsFunctions {
 
 		place_cards();
 
+		//	dThreadingImplementationID threading = dThreadingAllocateMultiThreadedImplementation();
+		//	dThreadingThreadPoolID pool = dThreadingAllocateThreadPool(4, 0, dAllocateFlagBasicData, NULL);
+		//	dThreadingThreadPoolServeMultiThreadedImplementation(pool, threading);
+		//	// dWorldSetStepIslandsProcessingMaxThreadCount(world, 1);
+		//	dWorldSetStepThreadingImplementation(world, dThreadingImplementationGetFunctions(threading), threading);
+
 		// run simulation
-		dsSimulationLoop (args, 640, 480, this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
+
+		//	dThreadingImplementationShutdownProcessing(threading);
+		//	dThreadingFreeThreadPool(pool);
+		//	dWorldSetStepThreadingImplementation(world, NULL, NULL);
+		//	dThreadingFreeImplementation(threading);
 
 		levels = 0;
 		place_cards();

--- a/demo/src/main/java/org/ode4j/demo/DemoChain1.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoChain1.java
@@ -99,8 +99,8 @@ class DemoChain1 extends dsFunctions {
 	}
 
 
-	private float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {2.1640f,-1.3079f,1.7600f};
+	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
 	/**
 	 *  start simulation - set viewpoint 
 	 */

--- a/demo/src/main/java/org/ode4j/demo/DemoChain1.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoChain1.java
@@ -99,8 +99,8 @@ class DemoChain1 extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private float[] xyz = {2.1640f,-1.3079f,1.7600f};
+	private float[] hpr = {125.5000f,-17.0000f,0.0000f};
 	/**
 	 *  start simulation - set viewpoint 
 	 */
@@ -174,7 +174,7 @@ class DemoChain1 extends dsFunctions {
 		}
 
 		/* run simulation */
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.destroy();
 		space.destroy();

--- a/demo/src/main/java/org/ode4j/demo/DemoChain2.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoChain2.java
@@ -97,8 +97,8 @@ class DemoChain2 extends dsFunctions {
 		}
 	};
 	
-	private static float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private float[] xyz = {2.1640f,-1.3079f,1.7600f};
+	private float[] hpr = {125.5000f,-17.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 
@@ -107,8 +107,8 @@ class DemoChain2 extends dsFunctions {
 	{
 		//TODO dAllocateODEDataForThread(dAllocateMaskAll);
 
-		//  static float xyz[3] = {2.1640f,-1.3079f,1.7600f};
-		//  static float hpr[3] = {125.5000f,-17.0000f,0.0000f};
+		//  float xyz[3] = {2.1640f,-1.3079f,1.7600f};
+		//  float hpr[3] = {125.5000f,-17.0000f,0.0000f};
 		dsSetViewpoint (xyz,hpr);
 	}
 
@@ -176,7 +176,7 @@ class DemoChain2 extends dsFunctions {
 		}
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		OdeHelper.closeODE();
 	}

--- a/demo/src/main/java/org/ode4j/demo/DemoChain2.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoChain2.java
@@ -97,8 +97,8 @@ class DemoChain2 extends dsFunctions {
 		}
 	};
 	
-	private float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {2.1640f,-1.3079f,1.7600f};
+	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 

--- a/demo/src/main/java/org/ode4j/demo/DemoCollision.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCollision.java
@@ -67,84 +67,88 @@ import org.ode4j.ode.internal.cpp4j.java.RefInt;
 class DemoCollision extends dsFunctions {
 
 
-	//****************************************************************************
-	// test infrastructure, including constants and macros
+    //****************************************************************************
+    // test infrastructure, including constants and macros
 
-	//#define TEST_REPS1 1000		// run each test this many times (first batch)
-	//#define TEST_REPS2 10000	// run each test this many times (second batch)
-	//const dReal tol = 1e-8;		// tolerance used for numerical checks
-	//#define MAX_TESTS 1000		// maximum number of test slots
-	//#define Z_OFFSET 2		// z offset for drawing (to get above ground)
-	private static final int TEST_REPS1 = 1000;		// run each test this many times (first batch)
-	private static final int TEST_REPS2 = 10000;	// run each test this many times (second batch)
-	private static final float tol = 1e-8f;		// tolerance used for numerical checks
-	private static final int MAX_TESTS = 1000;		// maximum number of test slots
-	private static final float Z_OFFSET = 2;		// z offset for drawing (to get above ground)
+    //#define TEST_REPS1 1000		// run each test this many times (first batch)
+    //#define TEST_REPS2 10000	// run each test this many times (second batch)
+    //const dReal tol = 1e-8;		// tolerance used for numerical checks
+    //#define MAX_TESTS 1000		// maximum number of test slots
+    //#define Z_OFFSET 2		// z offset for drawing (to get above ground)
+    private static final int TEST_REPS1 = 1000;        // run each test this many times (first batch)
+    private static final int TEST_REPS2 = 10000;    // run each test this many times (second batch)
+    private static final float tol = 1e-8f;        // tolerance used for numerical checks
+    private static final int MAX_TESTS = 1000;        // maximum number of test slots
+    private static final float Z_OFFSET = 2;        // z offset for drawing (to get above ground)
 
-	//using namespace ode;
+    //using namespace ode;
 
-	// test function. returns 1 if the test passed or 0 if it failed
-	//typedef int test_function_t();
+    // test function. returns 1 if the test passed or 0 if it failed
+    //typedef int test_function_t();
 
-	private class TestSlot {
-		int number;			// number of test
-		//const char *name;			// name of test
-		String name;			// name of test
-		int failcount;
-		//  test_function_t test_fn;
-		int last_failed_line;
-		public boolean test_fn() {
-			return DemoCollision.this.runtest(name);
-		}
-	}
+    private class TestSlot {
+        int number;            // number of test
+        //const char *name;			// name of test
+        String name;            // name of test
+        int failcount;
+        //  test_function_t test_fn;
+        int last_failed_line;
 
-	private boolean runtest(String name) {
-		try {
-			Method m = DemoCollision.class.getDeclaredMethod(name);
-			return (Boolean)m.invoke(this);
-		} catch (SecurityException | NoSuchMethodException | IllegalArgumentException | IllegalAccessException |
+        public boolean test_fn() {
+            return DemoCollision.this.runtest(name);
+        }
+    }
+
+    private boolean runtest(String name) {
+        try {
+            Method m = DemoCollision.class.getDeclaredMethod(name);
+            return (Boolean) m.invoke(this);
+        } catch (SecurityException | NoSuchMethodException | IllegalArgumentException | IllegalAccessException |
                  InvocationTargetException e) {
-			throw new RuntimeException(e);
-		}
+            throw new RuntimeException(e);
+        }
     }
 
 
-	private final TestSlot[] testslot=new TestSlot[MAX_TESTS];
+    private final TestSlot[] testslot = new TestSlot[MAX_TESTS];
 
 
-	// globals used by the test functions
-	private int graphical_test = 0;		// show graphical results of this test, 0=none
-	private int current_test;		// currently execiting test
-	private boolean draw_all_objects_called;
+    // globals used by the test functions
+    private int graphical_test = 0;        // show graphical results of this test, 0=none
+    private int current_test;        // currently execiting test
+    private boolean draw_all_objects_called;
 
 
-	//#define MAKE_TEST(number,function) \
-	//  if (testslot[number].name) dDebug (0,"test number already used"); \
-	//  if (number <= 0 || number >= MAX_TESTS) dDebug (0,"bad test number"); \
-	//  testslot[number].name = # function; \
-	//  testslot[number].test_fn = function;
-	private void MAKE_TEST(int number,String function) {
-		if (testslot[number].name != null) dDebug (0,"test number already used"); 
-		if (number <= 0 || number >= MAX_TESTS) dDebug (0,"bad test number"); 
-		//  testslot[number].name = # function; 
-		//  testslot[number].test_fn = function;
-		testslot[number].name = function; 
-	}
+    //#define MAKE_TEST(number,function) \
+    //  if (testslot[number].name) dDebug (0,"test number already used"); \
+    //  if (number <= 0 || number >= MAX_TESTS) dDebug (0,"bad test number"); \
+    //  testslot[number].name = # function; \
+    //  testslot[number].test_fn = function;
+    private void MAKE_TEST(int number, String function) {
+        if (testslot[number].name != null) dDebug(0, "test number already used");
+        if (number <= 0 || number >= MAX_TESTS) dDebug(0, "bad test number");
+        //  testslot[number].name = # function;
+        //  testslot[number].test_fn = function;
+        testslot[number].name = function;
+    }
 
-	//#define FAILED() { if (graphical_test==0) { \
-	//  testslot[current_test].last_failed_line=__LINE__; return 0; } }
-	private boolean testFAILED() { 
-		if (graphical_test==0) { 
-			testslot[current_test].last_failed_line=new RuntimeException().getStackTrace()[0].getLineNumber(); 
-			return true;
-		} else return false;
+    //#define FAILED() { if (graphical_test==0) { \
+    //  testslot[current_test].last_failed_line=__LINE__; return 0; } }
+    private boolean testFAILED() {
+        if (graphical_test == 0) {
+            testslot[current_test].last_failed_line = new RuntimeException().getStackTrace()[0].getLineNumber();
+            return true;
+        } else return false;
 
-	}
-	//#define PASSED() { return 1; }
-	private boolean retPASSED() { return true; }
+    }
 
-	//****************************************************************************
-	// globals
+    //#define PASSED() { return 1; }
+    private boolean retPASSED() {
+        return true;
+    }
+
+    //****************************************************************************
+    // globals
 
 	/* int dBoxBox (const dVector3 p1, const dMatrix3 R1,
 	     const dVector3 side1, const dVector3 p2,
@@ -152,816 +156,807 @@ class DemoCollision extends dsFunctions {
 	     dVector3 normal, dReal *depth, int *code,
 	     int maxc, dContactGeom *contact, int skip); */
 
-	//void dLineClosestApproach (final dVector3 pa, final dVector3 ua,
-	//			   final dVector3 pb, final dVector3 ub,
-	//			   double *alpha, double *beta);
-
-	//****************************************************************************
-	// draw all objects in a space, and draw all the collision contact points
-
-	//void nearCallback (void *data, dGeom o1, dGeom o2)
-	private void nearCallback (Object data, DGeom o1, DGeom o2)
-	{
-		int n;
-		final int N = 100;
-		//dContactGeom contact[N];
-		DContactGeomBuffer contacts = new DContactGeomBuffer(N);
-
-		if (o2 instanceof DRay) {
-			n = OdeHelper.collide (o2,o1,N,contacts);//,sizeof(dContactGeom));
-		}
-		else {
-			n = OdeHelper.collide (o1,o2,N,contacts);//,sizeof(dContactGeom));
-		}
-		if (n > 0) {
-			DMatrix3 RI = new DMatrix3();
-			RI.setIdentity();
-			DVector3 ss = new DVector3(0.01,0.01,0.01);
-			for (int i=0; i<n; i++) {
-				DContactGeom contact = contacts.get(i);
-				contact.pos.add2( Z_OFFSET );
-				dsDrawBox (contact.pos,RI,ss);
-				DVector3 n2 = new DVector3();
-				//for (j=0; j<3; j++) n[j] = contact[i].pos[j] + 0.1*contact[i].normal[j];
-				n2.eqSum(contact.pos, contact.normal, 0.1);
-				dsDrawLine (contact.pos,n2);
-			}
-		}
-	}
-
-	private DNearCallback nearCallback = new DNearCallback() {
-		@Override
-		public void call(Object data, DGeom o1, DGeom o2) {
-			nearCallback(data, o1, o2);
-		}
-	};
-
-	private void draw_all_objects (DSpace space)
-	{
-		int i;
-
-		draw_all_objects_called = true;
-		if (0==graphical_test) return;
-		int nGeoms = space.getNumGeoms();
-
-		// draw all contact points
-		dsSetColor (0,1,1);
-		space.collide(null,nearCallback);
-
-		// draw all rays
-		for (DGeom g : space.getGeoms()) {
-			if (g instanceof DRay) {
-				dsSetColor (1,1,1);
-				DVector3 origin = new DVector3(),dir=new DVector3();
-				((DRay)g).get (origin,dir);
-				origin.add2( Z_OFFSET );
-				double length = ((DRay)g).getLength ();
-				//for (j=0; j<3; j++) dir[j] = dir[j]*length + origin[j];
-				dir.eqSum(origin, dir, length);
-				dsDrawLine (origin,dir);
-				dsSetColor (0,0,1);
-				dsDrawSphere (origin,g.getRotation(),0.01);
-			}
-		}
-
-		// draw all other objects
-		for (DGeom g : space.getGeoms()) {
-			DVector3 pos = new DVector3();
-			if (!(g instanceof DPlane)) {//dGeomGetClass (g) != dPlaneClass) {
-				//memcpy (pos,dGeomGetPosition(g),sizeof(pos));
-				pos.set(g.getPosition());
-				pos.add2( Z_OFFSET );
-			}
-
-			switch (g.getClassID()) {
-
-			case dSphereClass: {
-				dsSetColorAlpha (1f,0f,0f,0.8f);
-				double radius = ((DSphere)g).getRadius ();
-				dsDrawSphere (pos,g.getRotation(),radius);
-				break;
-			}
-
-			case dBoxClass: {
-				dsSetColorAlpha (1f,1f,0f,0.8f);
-				DVector3C sides = ((DBox)g).getLengths ();
-				dsDrawBox (pos,g.getRotation(), sides);
-				break;
-			}
-
-			case dCapsuleClass: {
-				dsSetColorAlpha (0f,1f,0f,0.8f);
-				double radius = ((DCapsule)g).getRadius();
-				double length = ((DCapsule)g).getLength();
-				dsDrawCapsule (pos,g.getRotation(),length,radius);
-				break;
-			}
-
-			case dCylinderClass: {
-				dsSetColorAlpha (0,1,0,0.8);
-				double radius = ((DCylinder)g).getRadius();
-				double length = ((DCylinder)g).getLength();
-				dsDrawCylinder (pos,g.getRotation(),length,radius);
-				break;
-			}
-
-		    case dPlaneClass: {
-				DMatrix3 R = new DMatrix3();
-				DVector3 pos2 = new DVector3();
-				DVector3C n3 = ((DPlane)g).getNormal();
-				double depth = ((DPlane)g).getDepth();
-				OdeMath.dRFromZAxis (R,n3);
-				pos.set( n3 ).scale( depth );
-				pos.add2( Z_OFFSET );
-				DVector3 sides = new DVector3( 2, 2, 0.001 );
-				dsSetColor (1,0,1);
-				pos2.set( pos ).add( 0.1*depth, 0.1* depth, 0.1*depth);
-				dsDrawLine (pos,pos2);
-				dsSetColorAlpha (1f,0f,1f,0.8f);
-				dsDrawBox (pos,R,sides);
-				break;
-			}
-
-			}
-		}
-	}
-
-	//****************************************************************************
-	// point depth tests
-
-	private boolean test_sphere_point_depth()
-	{
-		int j;
-		DVector3 p=new DVector3(),q=new DVector3();
-		DMatrix3 R=new DMatrix3();
-		double r,d;
-
-		//dSimpleSpace space(0);
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
-		DSphere sphere = OdeHelper.createSphere (null,1);
-		space.add (sphere);
-
-		// ********** make a random sphere of radius r at position p
-
-		r = dRandReal()+0.1;
-		sphere.setRadius (r);
-		dMakeRandomVector (p,1.0);
-		sphere.setPosition (p);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		sphere.setRotation (R);
-
-		// ********** test center point has depth r
-
-		if (dFabs(sphere.getPointDepth (p) - r) > tol) if (testFAILED()) return false;
-
-		// ********** test point on surface has depth 0
-
-		for (j=0; j<3; j++) q.set(j,  dRandReal()-0.5 );
-		q.normalize();
-		q.eqSum( p, q, r);
-		if (dFabs(sphere.getPointDepth (q)) > tol) if (testFAILED()) return false;
-
-		// ********** test point at random depth
-
-		d = (dRandReal()*2-1) * r;
-		for (j=0; j<3; j++) q.set(j,  dRandReal()-0.5 );
-		q.normalize();
-		q.eqSum( p, q, (r-d) );
-		if (dFabs(sphere.getPointDepth (q)-d) > tol) if (testFAILED()) return false;
-
-		return retPASSED();
-	}
-
-
-	private boolean test_box_point_depth()
-	{
-		int i,j;
-		DVector3 s=new DVector3(),p=new DVector3(),q=new DVector3(),q2=new DVector3();	// s = box sides
-		DMatrix3 R=new DMatrix3();
-		double ss,d;		// ss = smallest side
-
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
-		DBox box = OdeHelper.createBox (null,1,1,1);
-		space.add (box);
-
-		// ********** make a random box
-
-		for (j=0; j<3; j++) s.set(j, dRandReal() + 0.1);
-		box.setLengths (s);
-		dMakeRandomVector (p,1.0);
-		box.setPosition (p);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		box.setRotation (R);
-
-		// ********** test center point has depth of smallest side
-
-		ss = 1e9;
-		for (j=0; j<3; j++) if (s.get(j) < ss) ss = s.get(j);
-		if (dFabs(box.getPointDepth (p) - 0.5*ss) > tol)
-			if (testFAILED()) return false;
-
-		// ********** test point on surface has depth 0
-
-		for (j=0; j<3; j++) q.set(j, (dRandReal()-0.5)*s.get(j) );
-		i = dRandInt (3);
-		if (dRandReal() > 0.5) q.set( i, 0.5*s.get(i) ); else q.set( i, -0.5*s.get(i) );
-		dMultiply0 (q2,box.getRotation(),q);
-		//for (j=0; j<3; j++) q2[j] += p[j];
-		q2.add(p);
-		if (dFabs(box.getPointDepth (q2)) > tol) if (testFAILED()) return false;
-
-		// ********** test points outside box have -ve depth
-
-		for (j=0; j<3; j++) {
-			q.set(j, 0.5*s.get(j) + dRandReal() + 0.01 );
-			if (dRandReal() > 0.5) q.scale (i, -1);
-		}
-		dMultiply0 (q2,box.getRotation(),q);
-		q2.add(p);
-		if (box.getPointDepth (q2) >= 0) if (testFAILED()) return false;
-
-		// ********** test points inside box have +ve depth
-
-		for (j=0; j<3; j++) q.set(j, s.get(j) * 0.99 * (dRandReal()-0.5) );
-		dMultiply0 (q2,box.getRotation(),q);
-		q2.add(p);
-		if (box.getPointDepth (q2) <= 0) if (testFAILED()) return false;
-
-		// ********** test random depth of point aligned along axis (up to ss deep)
-
-		i = dRandInt (3);
-		q.setZero();
-		d = (dRandReal()*(ss*0.5+1)-1);
-		q.set(i, s.get(i)*0.5 - d );
-		if (dRandReal() > 0.5) q.scale( i, -1 );
-		dMultiply0 (q2,box.getRotation(),q);
-		q2.add(p);
-		if (dFabs(box.getPointDepth (q2) - d) >= tol) if (testFAILED()) return false;
-
-		return retPASSED();
-	}
-
-
-	private boolean test_ccylinder_point_depth()
-	{
-		int j;
-		DVector3 p=new DVector3(),a=new DVector3();
-		DMatrix3 R=new DMatrix3();
-		double r,l,beta,x,y,d;
-
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
-
-		DCapsule ccyl = OdeHelper.createCapsule (null,1,1);
-		space.add (ccyl);
-
-		// ********** make a random ccyl
-
-		r = dRandReal()*0.5 + 0.01;
-		l = dRandReal()*1 + 0.01;
-		ccyl.setParams (r,l);
-		dMakeRandomVector (p,1.0);
-		ccyl.setPosition (p);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		ccyl.setRotation (R);
-
-		// ********** test point on axis has depth of 'radius'
-
-		beta = dRandReal()-0.5;
-		a.eqSum(p, R.viewCol(2), l*beta );
-		if (dFabs(ccyl.getPointDepth (a) - r) >= tol)
-			if (testFAILED()) return false;
-
-		// ********** test point on surface (excluding caps) has depth 0
-
-		beta = dRandReal()*2*M_PI;
-		x = r*Math.sin(beta);
-		y = r*Math.cos(beta);
-		beta = dRandReal()-0.5;
-		for (j=0; j<3; j++) a.set(j, p.get(j) + x*R.get(j,0) + y*R.get(j,1) + l*beta*R.get(j,2) );
-		if (dFabs(ccyl.getPointDepth (a)) >= tol) if (testFAILED()) return false;
-
-		// ********** test point on surface of caps has depth 0
-
-		for (j=0; j<3; j++) a.set(j, dRandReal()-0.5 );
-		a.normalize();
-		if (dCalcVectorDot3_14(a,R,2) > 0) {
-			for (j=0; j<3; j++) a.set(j, p.get(j) + a.get(j)*r + l*0.5*R.get(j,2) );
-		}
-		else {
-			for (j=0; j<3; j++) a.set(j, p.get(j) + a.get(j)*r - l*0.5*R.get(j,2) );
-		}
-		if (dFabs(ccyl.getPointDepth (a)) >= tol) if (testFAILED()) return false;
-
-		// ********** test point inside ccyl has positive depth
-
-		for (j=0; j<3; j++) a.set(j, dRandReal()-0.5 );
-		a.normalize();
-		beta = dRandReal()-0.5;
-		for (j=0; j<3; j++) a.set(j, p.get(j) + a.get(j)*r*0.99 + l*beta*R.get(j,2) );
-		if (ccyl.getPointDepth (a) < 0) if (testFAILED()) return false;
-
-		// ********** test point depth (1)
-
-		d = (dRandReal()*2-1) * r;
-		beta = dRandReal()*2*M_PI;
-		x = (r-d)*Math.sin(beta);
-		y = (r-d)*Math.cos(beta);
-		beta = dRandReal()-0.5;
-		for (j=0; j<3; j++) a.set(j, p.get(j) + x*R.get(j,0) + y*R.get(j,1) + l*beta*R.get(j,2) );
-		if (dFabs(ccyl.getPointDepth (a) - d) >= tol)
-			if (testFAILED()) return false;
-
-		// ********** test point depth (2)
-
-		d = (dRandReal()*2-1) * r;
-		for (j=0; j<3; j++) a.set(j, dRandReal()-0.5 );
-		a.normalize();
-		if (dCalcVectorDot3_14(a,R,2) > 0) {
-			for (j=0; j<3; j++) a.set(j, p.get(j) + a.get(j)*(r-d) + l*0.5*R.get(j,2) );
-		}
-		else {
-			for (j=0; j<3; j++) a.set(j, p.get(j) + a.get(j)*(r-d) - l*0.5*R.get(j,2) );
-		}
-		if (dFabs(ccyl.getPointDepth (a) - d) >= tol)
-			if (testFAILED()) return false;
-
-		return retPASSED();
-	}
-
-
-	private boolean test_plane_point_depth()
-	{
-		int j;
-		DVector3 n=new DVector3(),p=new DVector3(),q=new DVector3(),
-		a=new DVector3(),b=new DVector3();	// n = plane normal
-		double d;
-
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
-
-		DPlane plane = OdeHelper.createPlane (null,0,0,1,0);
-		space.add (plane);
-
-		// ********** make a random plane
-
-		for (j=0; j<3; j++) n.set(j,dRandReal() - 0.5);
-		n.normalize();
-		d = dRandReal() - 0.5;
-		plane.setParams (n,d);
-		dPlaneSpace (n,p,q);
-
-		// ********** test point on plane has depth 0
-
-		a.set0( dRandReal() - 0.5 );
-		a.set1( dRandReal() - 0.5 );
-		a.set2( 0 );
-		for (j=0; j<3; j++) b.set(j, a.get0()*p.get(j) + a.get1()*q.get(j) + (a.get2()+d)*n.get(j) );
-		if (dFabs(plane.getPointDepth (b)) >= tol) if (testFAILED()) return false;
-
-		// ********** test arbitrary depth point
-
-		a.set0( dRandReal() - 0.5 );
-		a.set1( dRandReal() - 0.5 );
-		a.set2( dRandReal() - 0.5 );
-		for (j=0; j<3; j++) b.set(j,  a.get0()*p.get(j) + a.get1()*q.get(j) + (a.get2()+d)*n.get(j) );
-		if (dFabs(plane.getPointDepth (b) + a.get2()) >= tol)
-			if (testFAILED()) return false;
-
-		// ********** test depth-1 point
-
-		a.set0( dRandReal() - 0.5 );
-		a.set1( dRandReal() - 0.5 );
-		a.set2( -1 );
-		for (j=0; j<3; j++) b.set(j,  a.get0()*p.get(j) + a.get1()*q.get(j) + (a.get2()+d)*n.get(j) );
-		if (dFabs(plane.getPointDepth (b) - 1) >= tol) if (testFAILED()) return false;
-
-		return retPASSED();
-	}
-
-	//****************************************************************************
-	// ray tests
-
-	private boolean test_ray_and_sphere()
-	{
-		DContactGeomBuffer contacts = new DContactGeomBuffer(1);
-		DVector3 p=new DVector3(),q=new DVector3(),q2=new DVector3(),
-		n=new DVector3(),v1=new DVector3();
-		DMatrix3 R=new DMatrix3();
-		double r,k;
-
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
-
-		DRay ray = OdeHelper.createRay (null,0);
-		DSphere sphere = OdeHelper.createSphere (null,1);
-		space.add (ray);
-		space.add (sphere);
-
-		// ********** make a random sphere of radius r at position p
-
-		r = dRandReal()+0.1;
-		sphere.setRadius (r);
-		dMakeRandomVector (p,1.0);
-		sphere.setPosition (p);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		sphere.setRotation (R);
-
-		// ********** test zero length ray just inside sphere
-
-		ray.setLength (0);
-		dMakeRandomVector (q,1.0);
-		q.normalize();
-		q.eqSum( p, q, 0.11*r );
-		ray.setPosition (q);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		ray.setRotation (R);
-		if (OdeHelper.collide (ray,sphere,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test zero length ray just outside that sphere
-
-		ray.setLength (0);
-		dMakeRandomVector (q,1.0);
-		q.normalize();
-		q.eqSum( p, q, 1.01*r );
-		ray.setPosition (q);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		ray.setRotation (R);
-		if (OdeHelper.collide (ray,sphere,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test finite length ray totally contained inside the sphere
-
-		dMakeRandomVector (q,1.0);
-		q.normalize();
-		k = dRandReal();
-		q.eqSum( p, q, k*r*0.99 );
-		dMakeRandomVector (q2,1.0);
-		q2.normalize();
-		k = dRandReal();
-		q2.eqSum( p, q2, k*r*0.99 );
-		n.eqDiff( q2, q );
-		n.normalize();
-		ray.set (q,n);
-		ray.setLength (q.distance(q2));
-		if (OdeHelper.collide (ray,sphere,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test finite length ray totally outside the sphere
-
-		dMakeRandomVector (q,1.0);
-		q.normalize();
-		do {
-			dMakeRandomVector (n,1.0);
-			n.normalize();
-		} while (n.dot(q) < 0);	// make sure normal goes away from sphere
-		q.eqSum( p, q, 1.01*r );
-		ray.set (q,n);
-		ray.setLength (100);
-		if (OdeHelper.collide (ray,sphere,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test ray from outside to just above surface
-
-		dMakeRandomVector (q,1.0);
-		q.normalize();
-		n.set( q ).scale( -1 );
-		q2.eqSum( p, q, 2*r );
-		ray.set (q2,n);
-		ray.setLength (0.99*r);
-		if (OdeHelper.collide (ray,sphere,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test ray from outside to just below surface
-
-		ray.setLength (1.01*r);
-		if (OdeHelper.collide (ray,sphere,1,contacts) != 1) if (testFAILED()) return false;
-		q2.eqSum( p, q, r );
-		if (contacts.get(0).pos.distance(q2) > tol) if (testFAILED()) return false;
-
-		// ********** test contact point distance for random rays
-
-		dMakeRandomVector (q,1.0);
-		q.normalize();
-		k = dRandReal()+0.5;
-		q.eqSum( p, q, k*r );
-		dMakeRandomVector (n,1.0);
-		n.normalize();
-		ray.set (q,n);
-		ray.setLength (100);
-		if (OdeHelper.collide (ray,sphere,1,contacts)!=0) {
-			DContactGeom contact = contacts.get(0);
-			k = contacts.get(0).pos.distance(sphere.getPosition());
-			if (dFabs(k - r) > tol) if (testFAILED()) return false;
-			// also check normal signs
-			if (n.dot(contact.normal) > 0) if (testFAILED()) return false;
-			// also check depth of contact point
-			if (dFabs (sphere.getPointDepth(contact.pos)) > tol)
-				if (testFAILED()) return false;
-
-			draw_all_objects (space);
-		}
-
-		// ********** test tangential grazing - miss
-
-		dMakeRandomVector (q,1.0);
-		q.normalize ();
-		dPlaneSpace (q,n,v1);
-		q.eqSum( p, q, 1.01*r );
-		q.sub( n );
-		ray.set (q,n);
-		ray.setLength (2);
-		if (OdeHelper.collide (ray,sphere,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test tangential grazing - hit
-
-		dMakeRandomVector (q,1.0);
-		q.normalize ();
-		dPlaneSpace (q,n,v1);
-		q.eqSum( p, q, 0.99*r );
-		q.sub( n );
-		ray.set (q,n);
-		ray.setLength (2);
-		if (OdeHelper.collide (ray,sphere,1,contacts) != 1) if (testFAILED()) return false;
-
-		return retPASSED();
-	}
-
-
-	private boolean test_ray_and_box()
-	{
-		int i,j;
-		//dContactGeom contact;
-		DContactGeomBuffer contacts = new DContactGeomBuffer(1);
-		DVector3 s=new DVector3(),p=new DVector3(),q=new DVector3(),n=new DVector3(),
-		q2=new DVector3(),q3=new DVector3(),q4=new DVector3();		// s = box sides
-		DMatrix3 R=new DMatrix3();
-		double k;
-
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
-
-		DRay ray = OdeHelper.createRay (null,0);
-		DBox box = OdeHelper.createBox (null,1,1,1);
-		space.add (ray);
-		space.add (box);
-
-		// ********** make a random box
-
-		for (j=0; j<3; j++) s.set(j,  dRandReal() + 0.1 );
-		box.setLengths (s);
-		dMakeRandomVector (p,1.0);
-		box.setPosition (p);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		box.setRotation (R);
-
-		// ********** test zero length ray just inside box
-
-		ray.setLength (0);
-		for (j=0; j<3; j++) q.set(j,  (dRandReal()-0.5)*s.get(j) );
-		i = dRandInt (3);
-		if (dRandReal() > 0.5) q.set(i, 0.99*0.5*s.get(i) ); else q.set(i, -0.99*0.5*s.get(i) );
-		dMultiply0 (q2,box.getRotation(),q);
-		q2.add(p);
-		ray.setPosition (q2);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		ray.setRotation (R);
-		if (OdeHelper.collide (ray,box,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test zero length ray just outside box
-
-		ray.setLength (0);
-		for (j=0; j<3; j++) q.set(j,  (dRandReal()-0.5)*s.get(j) );
-		i = dRandInt (3);
-		if (dRandReal() > 0.5) q.set(i, 1.01*0.5*s.get(i)); else q.set(i, -1.01*0.5*s.get(i));
-		dMultiply0 (q2,box.getRotation(),q);
-		q2.add( p );
-		ray.setPosition (q2);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		ray.setRotation (R);
-		if (OdeHelper.collide (ray,box,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test finite length ray totally contained inside the box
-
-		for (j=0; j<3; j++) q.set(j,  (dRandReal()-0.5)*0.99*s.get(j) );
-		dMultiply0 (q2,box.getRotation(),q);
-		q2.add( p );
-		for (j=0; j<3; j++) q3.set(j,  (dRandReal()-0.5)*0.99*s.get(j) );
-		dMultiply0 (q4,box.getRotation(),q3);
-		q4.add( p );
-		n.eqDiff( q4, q2 );
-		n.normalize();
-		ray.set (q2,n);
-		ray.setLength (q2.distance(q4));
-		if (OdeHelper.collide (ray,box,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test finite length ray totally outside the box
-
-		for (j=0; j<3; j++) q.set(j,  (dRandReal()-0.5)*s.get(j) );
-		i = dRandInt (3);
-		if (dRandReal() > 0.5) q.set(i, 1.01*0.5*s.get(i)); else q.set(i, -1.01*0.5*s.get(i));
-		dMultiply0 (q2,box.getRotation(),q);
-		q3.eqSum( q2, p );
-		q2.normalize();
-		ray.set (q3,q2);
-		ray.setLength (10);
-		if (OdeHelper.collide (ray,box,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test ray from outside to just above surface
-
-		for (j=0; j<3; j++) q.set(j,  (dRandReal()-0.5)*s.get(j) );
-		i = dRandInt (3);
-		if (dRandReal() > 0.5) q.set(i, 1.01*0.5*s.get(i)); else q.set(i, -1.01*0.5*s.get(i) );
-		dMultiply0 (q2,box.getRotation(),q);
-		q3.eqSum( p, q2, 2 );
-		k = q2.length();
-		q2.scale( -1 );
-		ray.set (q3,q2);
-		ray.setLength (k*0.99);
-		if (OdeHelper.collide (ray,box,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test ray from outside to just below surface
-
-		ray.setLength (k*1.01);
-		if (OdeHelper.collide (ray,box,1,contacts) != 1) if (testFAILED()) return false;
-
-		// ********** test contact point position for random rays
-
-		for (j=0; j<3; j++) q.set(j,  dRandReal()*s.get(j) );
-		dMultiply0 (q2,box.getRotation(),q);
-		q2.add( p );
-		for (j=0; j<3; j++) q3.set(j,  dRandReal()-0.5 );
-		q3.normalize();
-		ray.set (q2,q3);
-		ray.setLength (10);
-		if (OdeHelper.collide (ray,box,1,contacts)!=0) {
-			DContactGeom contact = contacts.get(0);
-			// check depth of contact point
-			if (dFabs (box.getPointDepth (contact.pos)) > tol)
-				if (testFAILED()) return false;
-			// check position of contact point
-			contact.pos.sub( p );
-			dMultiply1 (q,box.getRotation(),contact.pos);
-			if ( dFabs(dFabs (q.get0()) - 0.5*s.get0()) > tol &&
-					dFabs(dFabs (q.get1()) - 0.5*s.get1()) > tol &&
-					dFabs(dFabs (q.get2()) - 0.5*s.get2()) > tol) {
-				if (testFAILED()) return false;
-			}
-			// also check normal signs
-			if (q3.dot(contact.normal) > 0) if (testFAILED()) return false;
-
-			draw_all_objects (space);
-		}
-
-		return retPASSED();
-	}
-
-
-	private boolean test_ray_and_ccylinder()
-	{
-		int j;
-		DContactGeomBuffer contacts = new DContactGeomBuffer(1);
-		DVector3 p=new DVector3(),a=new DVector3(),b=new DVector3(),n=new DVector3();
-		DMatrix3 R=new DMatrix3();
-		double r,l,k,x,y;
-
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
-
-		DRay ray = OdeHelper.createRay (null,0);
-		DCapsule ccyl = OdeHelper.createCapsule (null,1,1);
-		space.add (ray);
-		space.add (ccyl);
-
-		// ********** make a random capped cylinder
-
-		r = dRandReal()*0.5 + 0.01;
-		l = dRandReal()*1 + 0.01;
-		ccyl.setParams (r,l);
-		dMakeRandomVector (p,1.0);
-		ccyl.setPosition (p);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		ccyl.setRotation (R);
-
-		// ********** test ray completely within ccyl
-
-		for (j=0; j<3; j++) a.set(j,  dRandReal()-0.5 );
-		a.normalize ();
-		k = (dRandReal()-0.5)*l;
-		for (j=0; j<3; j++) a.set(j,  p.get(j) + r*0.99*a.get(j) + k*0.99*R.get(j,2) );
-		for (j=0; j<3; j++) b.set(j,  dRandReal()-0.5 );
-		b.normalize ();
-		k = (dRandReal()-0.5)*l;
-		for (j=0; j<3; j++) b.set(j,  p.get(j) + r*0.99*b.get(j) + k*0.99*R.get(j,2) );
-		ray.setLength (a.distance(b));
-		b.sub( a );
-		b.normalize ();
-		ray.set (a, b);
-		if (OdeHelper.collide (ray,ccyl,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test ray outside ccyl that just misses (between caps)
-
-		k = dRandReal()*2*M_PI;
-		x = Math.sin(k);
-		y = Math.cos(k);
-		for (j=0; j<3; j++) a.set(j,  x*R.get(j,0) + y*R.get(j,1) );
-		k = (dRandReal()-0.5)*l;
-		for (j=0; j<3; j++) b.set(j,  -a.get(j)*r*2 + k*R.get(j,2) + p.get(j) );
-		ray.set (b, a);
-		ray.setLength (r*0.99);
-		if (OdeHelper.collide (ray,ccyl,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test ray outside ccyl that just hits (between caps)
-
-		ray.setLength (r*1.01);
-		if (OdeHelper.collide (ray,ccyl,1,contacts) != 1) if (testFAILED()) return false;
-		// check depth of contact point
-		if (dFabs (ccyl.getPointDepth (contacts.get(0).pos)) > tol)
-			if (testFAILED()) return false;
-
-		// ********** test ray outside ccyl that just misses (caps)
-
-		for (j=0; j<3; j++) a.set(j,  dRandReal()-0.5 );
-		a.normalize ();
-		if (dCalcVectorDot3_14(a,R,2) < 0) {
-			for (j=0; j<3; j++) b.set(j,  p.get(j) - a.get(j)*2*r + l*0.5*R.get(j,2) );
-		}
-		else {
-			for (j=0; j<3; j++) b.set(j,  p.get(j) - a.get(j)*2*r - l*0.5*R.get(j,2) );
-		}
-		ray.set (b,a);
-		ray.setLength (r*0.99);
-		if (OdeHelper.collide (ray,ccyl,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test ray outside ccyl that just hits (caps)
-
-		ray.setLength (r*1.01);
-		if (OdeHelper.collide (ray,ccyl,1,contacts) != 1) if (testFAILED()) return false;
-		// check depth of contact point
-		if (dFabs (ccyl.getPointDepth (contacts.get(0).pos)) > tol)
-			if (testFAILED()) return false;
-
-		// ********** test random rays
-
-		for (j=0; j<3; j++) a.set(j,  dRandReal()-0.5 );
-		for (j=0; j<3; j++) n.set(j,  dRandReal()-0.5 );
-		n.normalize ();
-		ray.set (a, n);
-		ray.setLength (10);
-
-		if (OdeHelper.collide (ray,ccyl,1,contacts)!=0) {
-			// check depth of contact point
-			if (dFabs (ccyl.getPointDepth (contacts.get(0).pos)) > tol)
-				if (testFAILED()) return false;
-
-			// check normal signs
-			if (n.dot(contacts.get(0).normal) > 0) if (testFAILED()) return false;
-
-			draw_all_objects (space);
-		}
-
-		return retPASSED();
-	}
-
-
-	/**
-	  Test rays within the cylinder
-	  -completely inside
-	  -exiting through side
-	  -exiting through cap
-	  -exiting through corner
-	  Test rays outside the cylinder
-	*/
-	private boolean test_ray_and_cylinder()
-	{
-	  DVector3 a = new DVector3(), b = new DVector3();
-
-	  DSimpleSpace space = OdeHelper.createSimpleSpace();
-	  DRay ray = OdeHelper.createRay(space,4);
-
-	  // The first thing that happens is the ray is
-	  // rotated into cylinder coordinates.  We'll trust that's
-	  // done right.  The major axis is in the z-dir.
-
-
-	  // Random tests
+    //void dLineClosestApproach (final dVector3 pa, final dVector3 ua,
+    //			   final dVector3 pb, final dVector3 ub,
+    //			   double *alpha, double *beta);
+
+    //****************************************************************************
+    // draw all objects in a space, and draw all the collision contact points
+
+    //void nearCallback (void *data, dGeom o1, dGeom o2)
+    private void nearCallback(Object data, DGeom o1, DGeom o2) {
+        int n;
+        final int N = 100;
+        //dContactGeom contact[N];
+        DContactGeomBuffer contacts = new DContactGeomBuffer(N);
+
+        if (o2 instanceof DRay) {
+            n = OdeHelper.collide(o2, o1, N, contacts);//,sizeof(dContactGeom));
+        } else {
+            n = OdeHelper.collide(o1, o2, N, contacts);//,sizeof(dContactGeom));
+        }
+        if (n > 0) {
+            DMatrix3 RI = new DMatrix3();
+            RI.setIdentity();
+            DVector3 ss = new DVector3(0.01, 0.01, 0.01);
+            for (int i = 0; i < n; i++) {
+                DContactGeom contact = contacts.get(i);
+                contact.pos.add2(Z_OFFSET);
+                dsDrawBox(contact.pos, RI, ss);
+                DVector3 n2 = new DVector3();
+                //for (j=0; j<3; j++) n[j] = contact[i].pos[j] + 0.1*contact[i].normal[j];
+                n2.eqSum(contact.pos, contact.normal, 0.1);
+                dsDrawLine(contact.pos, n2);
+            }
+        }
+    }
+
+    private DNearCallback nearCallback = new DNearCallback() {
+        @Override
+        public void call(Object data, DGeom o1, DGeom o2) {
+            nearCallback(data, o1, o2);
+        }
+    };
+
+    private void draw_all_objects(DSpace space) {
+        int i;
+
+        draw_all_objects_called = true;
+        if (0 == graphical_test) return;
+        int nGeoms = space.getNumGeoms();
+
+        // draw all contact points
+        dsSetColor(0, 1, 1);
+        space.collide(null, nearCallback);
+
+        // draw all rays
+        for (DGeom g : space.getGeoms()) {
+            if (g instanceof DRay) {
+                dsSetColor(1, 1, 1);
+                DVector3 origin = new DVector3(), dir = new DVector3();
+                ((DRay) g).get(origin, dir);
+                origin.add2(Z_OFFSET);
+                double length = ((DRay) g).getLength();
+                //for (j=0; j<3; j++) dir[j] = dir[j]*length + origin[j];
+                dir.eqSum(origin, dir, length);
+                dsDrawLine(origin, dir);
+                dsSetColor(0, 0, 1);
+                dsDrawSphere(origin, g.getRotation(), 0.01);
+            }
+        }
+
+        // draw all other objects
+        for (DGeom g : space.getGeoms()) {
+            DVector3 pos = new DVector3();
+            if (!(g instanceof DPlane)) {//dGeomGetClass (g) != dPlaneClass) {
+                //memcpy (pos,dGeomGetPosition(g),sizeof(pos));
+                pos.set(g.getPosition());
+                pos.add2(Z_OFFSET);
+            }
+
+            switch (g.getClassID()) {
+
+                case dSphereClass: {
+                    dsSetColorAlpha(1f, 0f, 0f, 0.8f);
+                    double radius = ((DSphere) g).getRadius();
+                    dsDrawSphere(pos, g.getRotation(), radius);
+                    break;
+                }
+
+                case dBoxClass: {
+                    dsSetColorAlpha(1f, 1f, 0f, 0.8f);
+                    DVector3C sides = ((DBox) g).getLengths();
+                    dsDrawBox(pos, g.getRotation(), sides);
+                    break;
+                }
+
+                case dCapsuleClass: {
+                    dsSetColorAlpha(0f, 1f, 0f, 0.8f);
+                    double radius = ((DCapsule) g).getRadius();
+                    double length = ((DCapsule) g).getLength();
+                    dsDrawCapsule(pos, g.getRotation(), length, radius);
+                    break;
+                }
+
+                case dCylinderClass: {
+                    dsSetColorAlpha(0, 1, 0, 0.8);
+                    double radius = ((DCylinder) g).getRadius();
+                    double length = ((DCylinder) g).getLength();
+                    dsDrawCylinder(pos, g.getRotation(), length, radius);
+                    break;
+                }
+
+                case dPlaneClass: {
+                    DMatrix3 R = new DMatrix3();
+                    DVector3 pos2 = new DVector3();
+                    DVector3C n3 = ((DPlane) g).getNormal();
+                    double depth = ((DPlane) g).getDepth();
+                    OdeMath.dRFromZAxis(R, n3);
+                    pos.set(n3).scale(depth);
+                    pos.add2(Z_OFFSET);
+                    DVector3 sides = new DVector3(2, 2, 0.001);
+                    dsSetColor(1, 0, 1);
+                    pos2.set(pos).add(0.1 * depth, 0.1 * depth, 0.1 * depth);
+                    dsDrawLine(pos, pos2);
+                    dsSetColorAlpha(1f, 0f, 1f, 0.8f);
+                    dsDrawBox(pos, R, sides);
+                    break;
+                }
+
+            }
+        }
+    }
+
+    //****************************************************************************
+    // point depth tests
+
+    private boolean test_sphere_point_depth() {
+        int j;
+        DVector3 p = new DVector3(), q = new DVector3();
+        DMatrix3 R = new DMatrix3();
+        double r, d;
+
+        //dSimpleSpace space(0);
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+        DSphere sphere = OdeHelper.createSphere(null, 1);
+        space.add(sphere);
+
+        // ********** make a random sphere of radius r at position p
+
+        r = dRandReal() + 0.1;
+        sphere.setRadius(r);
+        dMakeRandomVector(p, 1.0);
+        sphere.setPosition(p);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        sphere.setRotation(R);
+
+        // ********** test center point has depth r
+
+        if (dFabs(sphere.getPointDepth(p) - r) > tol) if (testFAILED()) return false;
+
+        // ********** test point on surface has depth 0
+
+        for (j = 0; j < 3; j++) q.set(j, dRandReal() - 0.5);
+        q.normalize();
+        q.eqSum(p, q, r);
+        if (dFabs(sphere.getPointDepth(q)) > tol) if (testFAILED()) return false;
+
+        // ********** test point at random depth
+
+        d = (dRandReal() * 2 - 1) * r;
+        for (j = 0; j < 3; j++) q.set(j, dRandReal() - 0.5);
+        q.normalize();
+        q.eqSum(p, q, (r - d));
+        if (dFabs(sphere.getPointDepth(q) - d) > tol) if (testFAILED()) return false;
+
+        return retPASSED();
+    }
+
+
+    private boolean test_box_point_depth() {
+        int i, j;
+        DVector3 s = new DVector3(), p = new DVector3(), q = new DVector3(), q2 = new DVector3();    // s = box sides
+        DMatrix3 R = new DMatrix3();
+        double ss, d;        // ss = smallest side
+
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+        DBox box = OdeHelper.createBox(null, 1, 1, 1);
+        space.add(box);
+
+        // ********** make a random box
+
+        for (j = 0; j < 3; j++) s.set(j, dRandReal() + 0.1);
+        box.setLengths(s);
+        dMakeRandomVector(p, 1.0);
+        box.setPosition(p);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        box.setRotation(R);
+
+        // ********** test center point has depth of smallest side
+
+        ss = 1e9;
+        for (j = 0; j < 3; j++) if (s.get(j) < ss) ss = s.get(j);
+        if (dFabs(box.getPointDepth(p) - 0.5 * ss) > tol)
+            if (testFAILED()) return false;
+
+        // ********** test point on surface has depth 0
+
+        for (j = 0; j < 3; j++) q.set(j, (dRandReal() - 0.5) * s.get(j));
+        i = dRandInt(3);
+        if (dRandReal() > 0.5) q.set(i, 0.5 * s.get(i));
+        else q.set(i, -0.5 * s.get(i));
+        dMultiply0(q2, box.getRotation(), q);
+        //for (j=0; j<3; j++) q2[j] += p[j];
+        q2.add(p);
+        if (dFabs(box.getPointDepth(q2)) > tol) if (testFAILED()) return false;
+
+        // ********** test points outside box have -ve depth
+
+        for (j = 0; j < 3; j++) {
+            q.set(j, 0.5 * s.get(j) + dRandReal() + 0.01);
+            if (dRandReal() > 0.5) q.scale(i, -1);
+        }
+        dMultiply0(q2, box.getRotation(), q);
+        q2.add(p);
+        if (box.getPointDepth(q2) >= 0) if (testFAILED()) return false;
+
+        // ********** test points inside box have +ve depth
+
+        for (j = 0; j < 3; j++) q.set(j, s.get(j) * 0.99 * (dRandReal() - 0.5));
+        dMultiply0(q2, box.getRotation(), q);
+        q2.add(p);
+        if (box.getPointDepth(q2) <= 0) if (testFAILED()) return false;
+
+        // ********** test random depth of point aligned along axis (up to ss deep)
+
+        i = dRandInt(3);
+        q.setZero();
+        d = (dRandReal() * (ss * 0.5 + 1) - 1);
+        q.set(i, s.get(i) * 0.5 - d);
+        if (dRandReal() > 0.5) q.scale(i, -1);
+        dMultiply0(q2, box.getRotation(), q);
+        q2.add(p);
+        if (dFabs(box.getPointDepth(q2) - d) >= tol) if (testFAILED()) return false;
+
+        return retPASSED();
+    }
+
+
+    private boolean test_ccylinder_point_depth() {
+        int j;
+        DVector3 p = new DVector3(), a = new DVector3();
+        DMatrix3 R = new DMatrix3();
+        double r, l, beta, x, y, d;
+
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+
+        DCapsule ccyl = OdeHelper.createCapsule(null, 1, 1);
+        space.add(ccyl);
+
+        // ********** make a random ccyl
+
+        r = dRandReal() * 0.5 + 0.01;
+        l = dRandReal() * 1 + 0.01;
+        ccyl.setParams(r, l);
+        dMakeRandomVector(p, 1.0);
+        ccyl.setPosition(p);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        ccyl.setRotation(R);
+
+        // ********** test point on axis has depth of 'radius'
+
+        beta = dRandReal() - 0.5;
+        a.eqSum(p, R.viewCol(2), l * beta);
+        if (dFabs(ccyl.getPointDepth(a) - r) >= tol)
+            if (testFAILED()) return false;
+
+        // ********** test point on surface (excluding caps) has depth 0
+
+        beta = dRandReal() * 2 * M_PI;
+        x = r * Math.sin(beta);
+        y = r * Math.cos(beta);
+        beta = dRandReal() - 0.5;
+        for (j = 0; j < 3; j++) a.set(j, p.get(j) + x * R.get(j, 0) + y * R.get(j, 1) + l * beta * R.get(j, 2));
+        if (dFabs(ccyl.getPointDepth(a)) >= tol) if (testFAILED()) return false;
+
+        // ********** test point on surface of caps has depth 0
+
+        for (j = 0; j < 3; j++) a.set(j, dRandReal() - 0.5);
+        a.normalize();
+        if (dCalcVectorDot3_14(a, R, 2) > 0) {
+            for (j = 0; j < 3; j++) a.set(j, p.get(j) + a.get(j) * r + l * 0.5 * R.get(j, 2));
+        } else {
+            for (j = 0; j < 3; j++) a.set(j, p.get(j) + a.get(j) * r - l * 0.5 * R.get(j, 2));
+        }
+        if (dFabs(ccyl.getPointDepth(a)) >= tol) if (testFAILED()) return false;
+
+        // ********** test point inside ccyl has positive depth
+
+        for (j = 0; j < 3; j++) a.set(j, dRandReal() - 0.5);
+        a.normalize();
+        beta = dRandReal() - 0.5;
+        for (j = 0; j < 3; j++) a.set(j, p.get(j) + a.get(j) * r * 0.99 + l * beta * R.get(j, 2));
+        if (ccyl.getPointDepth(a) < 0) if (testFAILED()) return false;
+
+        // ********** test point depth (1)
+
+        d = (dRandReal() * 2 - 1) * r;
+        beta = dRandReal() * 2 * M_PI;
+        x = (r - d) * Math.sin(beta);
+        y = (r - d) * Math.cos(beta);
+        beta = dRandReal() - 0.5;
+        for (j = 0; j < 3; j++) a.set(j, p.get(j) + x * R.get(j, 0) + y * R.get(j, 1) + l * beta * R.get(j, 2));
+        if (dFabs(ccyl.getPointDepth(a) - d) >= tol)
+            if (testFAILED()) return false;
+
+        // ********** test point depth (2)
+
+        d = (dRandReal() * 2 - 1) * r;
+        for (j = 0; j < 3; j++) a.set(j, dRandReal() - 0.5);
+        a.normalize();
+        if (dCalcVectorDot3_14(a, R, 2) > 0) {
+            for (j = 0; j < 3; j++) a.set(j, p.get(j) + a.get(j) * (r - d) + l * 0.5 * R.get(j, 2));
+        } else {
+            for (j = 0; j < 3; j++) a.set(j, p.get(j) + a.get(j) * (r - d) - l * 0.5 * R.get(j, 2));
+        }
+        if (dFabs(ccyl.getPointDepth(a) - d) >= tol)
+            if (testFAILED()) return false;
+
+        return retPASSED();
+    }
+
+
+    private boolean test_plane_point_depth() {
+        int j;
+        DVector3 n = new DVector3(), p = new DVector3(), q = new DVector3(),
+                a = new DVector3(), b = new DVector3();    // n = plane normal
+        double d;
+
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+
+        DPlane plane = OdeHelper.createPlane(null, 0, 0, 1, 0);
+        space.add(plane);
+
+        // ********** make a random plane
+
+        for (j = 0; j < 3; j++) n.set(j, dRandReal() - 0.5);
+        n.normalize();
+        d = dRandReal() - 0.5;
+        plane.setParams(n, d);
+        dPlaneSpace(n, p, q);
+
+        // ********** test point on plane has depth 0
+
+        a.set0(dRandReal() - 0.5);
+        a.set1(dRandReal() - 0.5);
+        a.set2(0);
+        for (j = 0; j < 3; j++) b.set(j, a.get0() * p.get(j) + a.get1() * q.get(j) + (a.get2() + d) * n.get(j));
+        if (dFabs(plane.getPointDepth(b)) >= tol) if (testFAILED()) return false;
+
+        // ********** test arbitrary depth point
+
+        a.set0(dRandReal() - 0.5);
+        a.set1(dRandReal() - 0.5);
+        a.set2(dRandReal() - 0.5);
+        for (j = 0; j < 3; j++) b.set(j, a.get0() * p.get(j) + a.get1() * q.get(j) + (a.get2() + d) * n.get(j));
+        if (dFabs(plane.getPointDepth(b) + a.get2()) >= tol)
+            if (testFAILED()) return false;
+
+        // ********** test depth-1 point
+
+        a.set0(dRandReal() - 0.5);
+        a.set1(dRandReal() - 0.5);
+        a.set2(-1);
+        for (j = 0; j < 3; j++) b.set(j, a.get0() * p.get(j) + a.get1() * q.get(j) + (a.get2() + d) * n.get(j));
+        if (dFabs(plane.getPointDepth(b) - 1) >= tol) if (testFAILED()) return false;
+
+        return retPASSED();
+    }
+
+    //****************************************************************************
+    // ray tests
+
+    private boolean test_ray_and_sphere() {
+        DContactGeomBuffer contacts = new DContactGeomBuffer(1);
+        DVector3 p = new DVector3(), q = new DVector3(), q2 = new DVector3(),
+                n = new DVector3(), v1 = new DVector3();
+        DMatrix3 R = new DMatrix3();
+        double r, k;
+
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+
+        DRay ray = OdeHelper.createRay(null, 0);
+        DSphere sphere = OdeHelper.createSphere(null, 1);
+        space.add(ray);
+        space.add(sphere);
+
+        // ********** make a random sphere of radius r at position p
+
+        r = dRandReal() + 0.1;
+        sphere.setRadius(r);
+        dMakeRandomVector(p, 1.0);
+        sphere.setPosition(p);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        sphere.setRotation(R);
+
+        // ********** test zero length ray just inside sphere
+
+        ray.setLength(0);
+        dMakeRandomVector(q, 1.0);
+        q.normalize();
+        q.eqSum(p, q, 0.11 * r);
+        ray.setPosition(q);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        ray.setRotation(R);
+        if (OdeHelper.collide(ray, sphere, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test zero length ray just outside that sphere
+
+        ray.setLength(0);
+        dMakeRandomVector(q, 1.0);
+        q.normalize();
+        q.eqSum(p, q, 1.01 * r);
+        ray.setPosition(q);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        ray.setRotation(R);
+        if (OdeHelper.collide(ray, sphere, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test finite length ray totally contained inside the sphere
+
+        dMakeRandomVector(q, 1.0);
+        q.normalize();
+        k = dRandReal();
+        q.eqSum(p, q, k * r * 0.99);
+        dMakeRandomVector(q2, 1.0);
+        q2.normalize();
+        k = dRandReal();
+        q2.eqSum(p, q2, k * r * 0.99);
+        n.eqDiff(q2, q);
+        n.normalize();
+        ray.set(q, n);
+        ray.setLength(q.distance(q2));
+        if (OdeHelper.collide(ray, sphere, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test finite length ray totally outside the sphere
+
+        dMakeRandomVector(q, 1.0);
+        q.normalize();
+        do {
+            dMakeRandomVector(n, 1.0);
+            n.normalize();
+        } while (n.dot(q) < 0);    // make sure normal goes away from sphere
+        q.eqSum(p, q, 1.01 * r);
+        ray.set(q, n);
+        ray.setLength(100);
+        if (OdeHelper.collide(ray, sphere, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test ray from outside to just above surface
+
+        dMakeRandomVector(q, 1.0);
+        q.normalize();
+        n.set(q).scale(-1);
+        q2.eqSum(p, q, 2 * r);
+        ray.set(q2, n);
+        ray.setLength(0.99 * r);
+        if (OdeHelper.collide(ray, sphere, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test ray from outside to just below surface
+
+        ray.setLength(1.01 * r);
+        if (OdeHelper.collide(ray, sphere, 1, contacts) != 1) if (testFAILED()) return false;
+        q2.eqSum(p, q, r);
+        if (contacts.get(0).pos.distance(q2) > tol) if (testFAILED()) return false;
+
+        // ********** test contact point distance for random rays
+
+        dMakeRandomVector(q, 1.0);
+        q.normalize();
+        k = dRandReal() + 0.5;
+        q.eqSum(p, q, k * r);
+        dMakeRandomVector(n, 1.0);
+        n.normalize();
+        ray.set(q, n);
+        ray.setLength(100);
+        if (OdeHelper.collide(ray, sphere, 1, contacts) != 0) {
+            DContactGeom contact = contacts.get(0);
+            k = contacts.get(0).pos.distance(sphere.getPosition());
+            if (dFabs(k - r) > tol) if (testFAILED()) return false;
+            // also check normal signs
+            if (n.dot(contact.normal) > 0) if (testFAILED()) return false;
+            // also check depth of contact point
+            if (dFabs(sphere.getPointDepth(contact.pos)) > tol)
+                if (testFAILED()) return false;
+
+            draw_all_objects(space);
+        }
+
+        // ********** test tangential grazing - miss
+
+        dMakeRandomVector(q, 1.0);
+        q.normalize();
+        dPlaneSpace(q, n, v1);
+        q.eqSum(p, q, 1.01 * r);
+        q.sub(n);
+        ray.set(q, n);
+        ray.setLength(2);
+        if (OdeHelper.collide(ray, sphere, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test tangential grazing - hit
+
+        dMakeRandomVector(q, 1.0);
+        q.normalize();
+        dPlaneSpace(q, n, v1);
+        q.eqSum(p, q, 0.99 * r);
+        q.sub(n);
+        ray.set(q, n);
+        ray.setLength(2);
+        if (OdeHelper.collide(ray, sphere, 1, contacts) != 1) if (testFAILED()) return false;
+
+        return retPASSED();
+    }
+
+
+    private boolean test_ray_and_box() {
+        int i, j;
+        //dContactGeom contact;
+        DContactGeomBuffer contacts = new DContactGeomBuffer(1);
+        DVector3 s = new DVector3(), p = new DVector3(), q = new DVector3(), n = new DVector3(),
+                q2 = new DVector3(), q3 = new DVector3(), q4 = new DVector3();        // s = box sides
+        DMatrix3 R = new DMatrix3();
+        double k;
+
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+
+        DRay ray = OdeHelper.createRay(null, 0);
+        DBox box = OdeHelper.createBox(null, 1, 1, 1);
+        space.add(ray);
+        space.add(box);
+
+        // ********** make a random box
+
+        for (j = 0; j < 3; j++) s.set(j, dRandReal() + 0.1);
+        box.setLengths(s);
+        dMakeRandomVector(p, 1.0);
+        box.setPosition(p);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        box.setRotation(R);
+
+        // ********** test zero length ray just inside box
+
+        ray.setLength(0);
+        for (j = 0; j < 3; j++) q.set(j, (dRandReal() - 0.5) * s.get(j));
+        i = dRandInt(3);
+        if (dRandReal() > 0.5) q.set(i, 0.99 * 0.5 * s.get(i));
+        else q.set(i, -0.99 * 0.5 * s.get(i));
+        dMultiply0(q2, box.getRotation(), q);
+        q2.add(p);
+        ray.setPosition(q2);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        ray.setRotation(R);
+        if (OdeHelper.collide(ray, box, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test zero length ray just outside box
+
+        ray.setLength(0);
+        for (j = 0; j < 3; j++) q.set(j, (dRandReal() - 0.5) * s.get(j));
+        i = dRandInt(3);
+        if (dRandReal() > 0.5) q.set(i, 1.01 * 0.5 * s.get(i));
+        else q.set(i, -1.01 * 0.5 * s.get(i));
+        dMultiply0(q2, box.getRotation(), q);
+        q2.add(p);
+        ray.setPosition(q2);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        ray.setRotation(R);
+        if (OdeHelper.collide(ray, box, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test finite length ray totally contained inside the box
+
+        for (j = 0; j < 3; j++) q.set(j, (dRandReal() - 0.5) * 0.99 * s.get(j));
+        dMultiply0(q2, box.getRotation(), q);
+        q2.add(p);
+        for (j = 0; j < 3; j++) q3.set(j, (dRandReal() - 0.5) * 0.99 * s.get(j));
+        dMultiply0(q4, box.getRotation(), q3);
+        q4.add(p);
+        n.eqDiff(q4, q2);
+        n.normalize();
+        ray.set(q2, n);
+        ray.setLength(q2.distance(q4));
+        if (OdeHelper.collide(ray, box, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test finite length ray totally outside the box
+
+        for (j = 0; j < 3; j++) q.set(j, (dRandReal() - 0.5) * s.get(j));
+        i = dRandInt(3);
+        if (dRandReal() > 0.5) q.set(i, 1.01 * 0.5 * s.get(i));
+        else q.set(i, -1.01 * 0.5 * s.get(i));
+        dMultiply0(q2, box.getRotation(), q);
+        q3.eqSum(q2, p);
+        q2.normalize();
+        ray.set(q3, q2);
+        ray.setLength(10);
+        if (OdeHelper.collide(ray, box, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test ray from outside to just above surface
+
+        for (j = 0; j < 3; j++) q.set(j, (dRandReal() - 0.5) * s.get(j));
+        i = dRandInt(3);
+        if (dRandReal() > 0.5) q.set(i, 1.01 * 0.5 * s.get(i));
+        else q.set(i, -1.01 * 0.5 * s.get(i));
+        dMultiply0(q2, box.getRotation(), q);
+        q3.eqSum(p, q2, 2);
+        k = q2.length();
+        q2.scale(-1);
+        ray.set(q3, q2);
+        ray.setLength(k * 0.99);
+        if (OdeHelper.collide(ray, box, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test ray from outside to just below surface
+
+        ray.setLength(k * 1.01);
+        if (OdeHelper.collide(ray, box, 1, contacts) != 1) if (testFAILED()) return false;
+
+        // ********** test contact point position for random rays
+
+        for (j = 0; j < 3; j++) q.set(j, dRandReal() * s.get(j));
+        dMultiply0(q2, box.getRotation(), q);
+        q2.add(p);
+        for (j = 0; j < 3; j++) q3.set(j, dRandReal() - 0.5);
+        q3.normalize();
+        ray.set(q2, q3);
+        ray.setLength(10);
+        if (OdeHelper.collide(ray, box, 1, contacts) != 0) {
+            DContactGeom contact = contacts.get(0);
+            // check depth of contact point
+            if (dFabs(box.getPointDepth(contact.pos)) > tol)
+                if (testFAILED()) return false;
+            // check position of contact point
+            contact.pos.sub(p);
+            dMultiply1(q, box.getRotation(), contact.pos);
+            if (dFabs(dFabs(q.get0()) - 0.5 * s.get0()) > tol &&
+                    dFabs(dFabs(q.get1()) - 0.5 * s.get1()) > tol &&
+                    dFabs(dFabs(q.get2()) - 0.5 * s.get2()) > tol) {
+                if (testFAILED()) return false;
+            }
+            // also check normal signs
+            if (q3.dot(contact.normal) > 0) if (testFAILED()) return false;
+
+            draw_all_objects(space);
+        }
+
+        return retPASSED();
+    }
+
+
+    private boolean test_ray_and_ccylinder() {
+        int j;
+        DContactGeomBuffer contacts = new DContactGeomBuffer(1);
+        DVector3 p = new DVector3(), a = new DVector3(), b = new DVector3(), n = new DVector3();
+        DMatrix3 R = new DMatrix3();
+        double r, l, k, x, y;
+
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+
+        DRay ray = OdeHelper.createRay(null, 0);
+        DCapsule ccyl = OdeHelper.createCapsule(null, 1, 1);
+        space.add(ray);
+        space.add(ccyl);
+
+        // ********** make a random capped cylinder
+
+        r = dRandReal() * 0.5 + 0.01;
+        l = dRandReal() * 1 + 0.01;
+        ccyl.setParams(r, l);
+        dMakeRandomVector(p, 1.0);
+        ccyl.setPosition(p);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        ccyl.setRotation(R);
+
+        // ********** test ray completely within ccyl
+
+        for (j = 0; j < 3; j++) a.set(j, dRandReal() - 0.5);
+        a.normalize();
+        k = (dRandReal() - 0.5) * l;
+        for (j = 0; j < 3; j++) a.set(j, p.get(j) + r * 0.99 * a.get(j) + k * 0.99 * R.get(j, 2));
+        for (j = 0; j < 3; j++) b.set(j, dRandReal() - 0.5);
+        b.normalize();
+        k = (dRandReal() - 0.5) * l;
+        for (j = 0; j < 3; j++) b.set(j, p.get(j) + r * 0.99 * b.get(j) + k * 0.99 * R.get(j, 2));
+        ray.setLength(a.distance(b));
+        b.sub(a);
+        b.normalize();
+        ray.set(a, b);
+        if (OdeHelper.collide(ray, ccyl, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test ray outside ccyl that just misses (between caps)
+
+        k = dRandReal() * 2 * M_PI;
+        x = Math.sin(k);
+        y = Math.cos(k);
+        for (j = 0; j < 3; j++) a.set(j, x * R.get(j, 0) + y * R.get(j, 1));
+        k = (dRandReal() - 0.5) * l;
+        for (j = 0; j < 3; j++) b.set(j, -a.get(j) * r * 2 + k * R.get(j, 2) + p.get(j));
+        ray.set(b, a);
+        ray.setLength(r * 0.99);
+        if (OdeHelper.collide(ray, ccyl, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test ray outside ccyl that just hits (between caps)
+
+        ray.setLength(r * 1.01);
+        if (OdeHelper.collide(ray, ccyl, 1, contacts) != 1) if (testFAILED()) return false;
+        // check depth of contact point
+        if (dFabs(ccyl.getPointDepth(contacts.get(0).pos)) > tol)
+            if (testFAILED()) return false;
+
+        // ********** test ray outside ccyl that just misses (caps)
+
+        for (j = 0; j < 3; j++) a.set(j, dRandReal() - 0.5);
+        a.normalize();
+        if (dCalcVectorDot3_14(a, R, 2) < 0) {
+            for (j = 0; j < 3; j++) b.set(j, p.get(j) - a.get(j) * 2 * r + l * 0.5 * R.get(j, 2));
+        } else {
+            for (j = 0; j < 3; j++) b.set(j, p.get(j) - a.get(j) * 2 * r - l * 0.5 * R.get(j, 2));
+        }
+        ray.set(b, a);
+        ray.setLength(r * 0.99);
+        if (OdeHelper.collide(ray, ccyl, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test ray outside ccyl that just hits (caps)
+
+        ray.setLength(r * 1.01);
+        if (OdeHelper.collide(ray, ccyl, 1, contacts) != 1) if (testFAILED()) return false;
+        // check depth of contact point
+        if (dFabs(ccyl.getPointDepth(contacts.get(0).pos)) > tol)
+            if (testFAILED()) return false;
+
+        // ********** test random rays
+
+        for (j = 0; j < 3; j++) a.set(j, dRandReal() - 0.5);
+        for (j = 0; j < 3; j++) n.set(j, dRandReal() - 0.5);
+        n.normalize();
+        ray.set(a, n);
+        ray.setLength(10);
+
+        if (OdeHelper.collide(ray, ccyl, 1, contacts) != 0) {
+            // check depth of contact point
+            if (dFabs(ccyl.getPointDepth(contacts.get(0).pos)) > tol)
+                if (testFAILED()) return false;
+
+            // check normal signs
+            if (n.dot(contacts.get(0).normal) > 0) if (testFAILED()) return false;
+
+            draw_all_objects(space);
+        }
+
+        return retPASSED();
+    }
+
+
+    /**
+     * Test rays within the cylinder
+     * -completely inside
+     * -exiting through side
+     * -exiting through cap
+     * -exiting through corner
+     * Test rays outside the cylinder
+     */
+    private boolean test_ray_and_cylinder() {
+        DVector3 a = new DVector3(), b = new DVector3();
+
+        DSimpleSpace space = OdeHelper.createSimpleSpace();
+        DRay ray = OdeHelper.createRay(space, 4);
+
+        // The first thing that happens is the ray is
+        // rotated into cylinder coordinates.  We'll trust that's
+        // done right.  The major axis is in the z-dir.
+
+
+        // Random tests
 	  /*b[0]=4*dRandReal()-2;
 	  b[1]=4*dRandReal()-2;
 	  b[2]=4*dRandReal()-2;
 	  a[0]=2*dRandReal()-1;
 	  a[1]=2*dRandReal()-1;
 	  a[2]=2*dRandReal()-1;*/
-	  
-	  // Inside out
-	  b.set0( dRandReal()-0.5 );
-	  b.set1( dRandReal()-0.5 );
-	  b.set2( dRandReal()-0.5 );
-	  a.set0( 2*dRandReal()-1 );
-	  a.set1( 2*dRandReal()-1 );
-	  a.set2( 2*dRandReal()-1 );
 
-	  // Outside in
+        // Inside out
+        b.set0(dRandReal() - 0.5);
+        b.set1(dRandReal() - 0.5);
+        b.set2(dRandReal() - 0.5);
+        a.set0(2 * dRandReal() - 1);
+        a.set1(2 * dRandReal() - 1);
+        a.set2(2 * dRandReal() - 1);
+
+        // Outside in
 	  /*b[0]=4*dRandReal()-2;
 	  b[1]=4*dRandReal()-2;
 	  b[2]=4*dRandReal()-2;
@@ -969,326 +964,331 @@ class DemoCollision extends dsFunctions {
 	  a[1]=-b[1];
 	  a[2]=-b[2];*/
 
-	  
-	  ray.set (b ,a);
-	  // This is just for visual inspection right now.
-	  //if (dCollide (ray,cyl,1,&contact,sizeof(dContactGeom)) != 1) FAILED();
 
-	  draw_all_objects (space);
+        ray.set(b, a);
+        // This is just for visual inspection right now.
+        //if (dCollide (ray,cyl,1,&contact,sizeof(dContactGeom)) != 1) FAILED();
 
-	  return retPASSED();
-	}
+        draw_all_objects(space);
 
-
-	private boolean test_ray_and_plane()
-	{
-		int j;
-		DContactGeomBuffer contacts = new DContactGeomBuffer(1);
-		DVector3 n=new DVector3(),p=new DVector3(),q=new DVector3(),a=new DVector3(),
-		b=new DVector3(),g=new DVector3(),h=new DVector3();		// n,d = plane parameters
-		DMatrix3 R=new DMatrix3();
-		double d;
-
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
-
-		DRay ray = OdeHelper.createRay (null,0);
-		DPlane plane = OdeHelper.createPlane (null,0,0,1,0);
-		space.add (ray);
-		space.add (plane);
-
-		// ********** make a random plane
-
-		for (j=0; j<3; j++) n.set(j,  dRandReal() - 0.5 );
-		n.normalize ();
-		d = dRandReal() - 0.5;
-		plane.setParams (n, d);
-		dPlaneSpace (n,p,q);
-
-		// ********** test finite length ray below plane
-
-		ray.setLength (0.09);
-		a.set0( dRandReal()-0.5 );
-		a.set1( dRandReal()-0.5 );
-		a.set2( -dRandReal()*0.5 - 0.1 );
-		for (j=0; j<3; j++) b.set(j,  a.get0()*p.get(j) + a.get1()*q.get(j) + (a.get2()+d)*n.get(j) );
-		ray.setPosition (b);
-		dRFromAxisAndAngle (R,dRandReal()*2-1,dRandReal()*2-1,
-				dRandReal()*2-1,dRandReal()*10-5);
-		ray.setRotation (R);
-		if (OdeHelper.collide (ray,plane,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test finite length ray above plane
-
-		a.set0( dRandReal()-0.5 );
-		a.set1( dRandReal()-0.5 );
-		a.set2( dRandReal()*0.5 + 0.01 );
-		for (j=0; j<3; j++) b.set(j,  a.get0()*p.get(j) + a.get1()*q.get(j) + (a.get2()+d)*n.get(j) );
-		g.set0( dRandReal()-0.5 );
-		g.set1( dRandReal()-0.5 );
-		g.set2( dRandReal() + 0.01 );
-		for (j=0; j<3; j++) h.set(j,  g.get0()*p.get(j) + g.get1()*q.get(j) + g.get2()*n.get(j) );
-		h.normalize ();
-		ray.set (b, h);
-		ray.setLength (10);
-		if (OdeHelper.collide (ray,plane,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test finite length ray that intersects plane
-
-		a.set0( dRandReal()-0.5 );
-		a.set1( dRandReal()-0.5 );
-		a.set2( dRandReal()-0.5 );
-		for (j=0; j<3; j++) b.set(j,  a.get0()*p.get(j) + a.get1()*q.get(j) + (a.get2()+d)*n.get(j) );
-		g.set0( dRandReal()-0.5 );
-		g.set1( dRandReal()-0.5 );
-		g.set2( dRandReal()-0.5 );
-		for (j=0; j<3; j++) h.set(j,  g.get0()*p.get(j) + g.get1()*q.get(j) + g.get2()*n.get(j) );
-		h.normalize ();
-		ray.set (b, h);
-		ray.setLength (10);
-		if (OdeHelper.collide (ray,plane,1,contacts)!=0) {
-			// test that contact is on plane surface
-			if (dFabs (contacts.get(0).pos.dot(n) - d) > tol) if (testFAILED()) return false;
-			// also check normal signs
-			if (h.dot(contacts.get(0).normal) > 0) if (testFAILED()) return false;
-			// also check contact point depth
-			if (dFabs (plane.getPointDepth (contacts.get(0).pos)) > tol)
-				if (testFAILED()) return false;
-
-			draw_all_objects (space);
-		}
-
-		// ********** test ray that just misses
-
-		b.set(n).scale( 1+d );
-		h.set(n).scale( -1 );
-		ray.set (b, h);
-		ray.setLength (0.99);
-		if (OdeHelper.collide (ray,plane,1,contacts) != 0) if (testFAILED()) return false;
-
-		// ********** test ray that just hits
-
-		ray.setLength (1.01);
-		if (OdeHelper.collide (ray,plane,1,contacts) != 1) if (testFAILED()) return false;
-
-		// ********** test polarity with typical ground plane
-		plane.setParams (0,0,1,0);
-		a.set(0.1, 0.1, 1);
-		b.set(0, 0, -1);
-		ray.set (a,b);
-		ray.setLength (2);
-		if (OdeHelper.collide (ray,plane,1,contacts) != 1) if (testFAILED()) return false;
-		if (Math.abs(contacts.get(0).depth - 1) > tol) if (testFAILED()) return false;
-		a.set2( -1 );
-		b.set2( 1 );
-		ray.set (a, b);
-		if (OdeHelper.collide (ray,plane,1,contacts) != 1) if (testFAILED()) return false;
-		if (Math.abs(contacts.get(0).depth - 1) > tol) if (testFAILED()) return false;
-
-		return retPASSED();
-	}
-
-	//****************************************************************************
-	// a really inefficient, but hopefully correct implementation of
-	// dBoxTouchesBox(), that does 144 edge-face tests.
-
-	// return 1 if edge v1 -> v2 hits the rectangle described by p1,p2,p3
-
-	private static boolean edgeIntersectsRect (DVector3 v1, DVector3 v2,
-			DVector3 p1, DVector3 p2, DVector3 p3)
-	{
-		DVector3 u1=new DVector3(),u2=new DVector3(),n=new DVector3(),tmp=new DVector3();
-
-		//for (k=0; k<3; k++) u1[k] = p3[k]-p1[k];
-		u1.eqDiff(p3, p1);
-		//for (k=0; k<3; k++) u2[k] = p2[k]-p1[k];
-		u2.eqDiff(p2, p1);
-
-		double d1 = dSqrt(u1.dot(u1));
-		double d2 = dSqrt(u2.dot(u2));
-		u1.normalize();
-		u2.normalize();
-
-		double error;
-		// #ifdef dSINGLE
-		// 	const dReal uEpsilon = 1e-5, pEpsilon = 1e-6, tmpEpsilon = 1.5e-4;
-		// #else
-		final double uEpsilon = 1e-6, pEpsilon = 1e-8, tmpEpsilon = 1e-6;
-		// #endif
-
-		error = dFabs(dCalcVectorDot3(u1, u2));
-		if (error > uEpsilon) dDebug(0, "bad u1/u2");
-
-		dCalcVectorCross3(n, u1, u2);
-
-		// for (k=0; k < 3; k++) tmp[k] = v2[k] - v1[k];
-		tmp.eqDiff(v2, v1);
-
-		double d = -dCalcVectorDot3(n, p1);
-
-		error = dFabs(dCalcVectorDot3(n, p1) + d);
-		if (error > pEpsilon) dDebug(0, "bad n wrt p1");
-
-		error = dFabs(dCalcVectorDot3(n, p2) + d);
-		if (error > pEpsilon) dDebug(0, "bad n wrt p2");
-
-		error = dFabs(dCalcVectorDot3(n, p3) + d);
-		if (error > pEpsilon) dDebug(0, "bad n wrt p3");
-
-		double alpha = -(d + dCalcVectorDot3(n, v1)) / dCalcVectorDot3(n, tmp);
-		// for (k=0; k < 3; k++) tmp[k] = v1[k] + alpha * (v2[k] - v1[k]);
-		tmp.eqDiff(v2, v1).scale(alpha).add(v1);
-
-		error = dFabs(dCalcVectorDot3(n, tmp) + d);
-		if (error > tmpEpsilon) dDebug(0, "bad tmp");
-
-		if (alpha < 0) return false;
-		if (alpha > 1) return false;
-
-		//for (k=0; k<3; k++) tmp[k] -= p1[k];
-		tmp.sub(p1);
-		double a1 = u1.dot(tmp);
-		double a2 = u2.dot(tmp);
-		if (a1<0 || a2<0 || a1>d1 || a2>d2) return false;
-
-		return true;
-	}
+        return retPASSED();
+    }
 
 
-	// return 1 if box 1 is completely inside box 2
+    private boolean test_ray_and_plane() {
+        int j;
+        DContactGeomBuffer contacts = new DContactGeomBuffer(1);
+        DVector3 n = new DVector3(), p = new DVector3(), q = new DVector3(), a = new DVector3(),
+                b = new DVector3(), g = new DVector3(), h = new DVector3();        // n,d = plane parameters
+        DMatrix3 R = new DMatrix3();
+        double d;
 
-	private static boolean box1inside2 (final DVector3 p1, final DMatrix3 R1,
-			final DVector3 side1, final DVector3 p2,
-			final DMatrix3 R2, final DVector3 side2)
-	{
-		for (int i=-1; i<=1; i+=2) {
-			for (int j=-1; j<=1; j+=2) {
-				for (int k=-1; k<=1; k+=2) {
-					DVector3 v=new DVector3(),vv=new DVector3();
-					v.set( side1 ).scale( i*0.5, j*0.5, k*0.5 );
-					dMultiply0_331 (vv,R1,v);
-					vv.add(p1).sub(p2);
-					for (int axis=0; axis < 3; axis++) {
-						double z = dCalcVectorDot3_14(vv,R2,axis);
-						if (z < (-side2.get(axis)*0.5) || z > (side2.get(axis)*0.5)) return false;
-					}
-				}
-			}
-		}
-		return true;
-	}
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+
+        DRay ray = OdeHelper.createRay(null, 0);
+        DPlane plane = OdeHelper.createPlane(null, 0, 0, 1, 0);
+        space.add(ray);
+        space.add(plane);
+
+        // ********** make a random plane
+
+        for (j = 0; j < 3; j++) n.set(j, dRandReal() - 0.5);
+        n.normalize();
+        d = dRandReal() - 0.5;
+        plane.setParams(n, d);
+        dPlaneSpace(n, p, q);
+
+        // ********** test finite length ray below plane
+
+        ray.setLength(0.09);
+        a.set0(dRandReal() - 0.5);
+        a.set1(dRandReal() - 0.5);
+        a.set2(-dRandReal() * 0.5 - 0.1);
+        for (j = 0; j < 3; j++) b.set(j, a.get0() * p.get(j) + a.get1() * q.get(j) + (a.get2() + d) * n.get(j));
+        ray.setPosition(b);
+        dRFromAxisAndAngle(R, dRandReal() * 2 - 1, dRandReal() * 2 - 1,
+                dRandReal() * 2 - 1, dRandReal() * 10 - 5);
+        ray.setRotation(R);
+        if (OdeHelper.collide(ray, plane, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test finite length ray above plane
+
+        a.set0(dRandReal() - 0.5);
+        a.set1(dRandReal() - 0.5);
+        a.set2(dRandReal() * 0.5 + 0.01);
+        for (j = 0; j < 3; j++) b.set(j, a.get0() * p.get(j) + a.get1() * q.get(j) + (a.get2() + d) * n.get(j));
+        g.set0(dRandReal() - 0.5);
+        g.set1(dRandReal() - 0.5);
+        g.set2(dRandReal() + 0.01);
+        for (j = 0; j < 3; j++) h.set(j, g.get0() * p.get(j) + g.get1() * q.get(j) + g.get2() * n.get(j));
+        h.normalize();
+        ray.set(b, h);
+        ray.setLength(10);
+        if (OdeHelper.collide(ray, plane, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test finite length ray that intersects plane
+
+        a.set0(dRandReal() - 0.5);
+        a.set1(dRandReal() - 0.5);
+        a.set2(dRandReal() - 0.5);
+        for (j = 0; j < 3; j++) b.set(j, a.get0() * p.get(j) + a.get1() * q.get(j) + (a.get2() + d) * n.get(j));
+        g.set0(dRandReal() - 0.5);
+        g.set1(dRandReal() - 0.5);
+        g.set2(dRandReal() - 0.5);
+        for (j = 0; j < 3; j++) h.set(j, g.get0() * p.get(j) + g.get1() * q.get(j) + g.get2() * n.get(j));
+        h.normalize();
+        ray.set(b, h);
+        ray.setLength(10);
+        if (OdeHelper.collide(ray, plane, 1, contacts) != 0) {
+            // test that contact is on plane surface
+            if (dFabs(contacts.get(0).pos.dot(n) - d) > tol) if (testFAILED()) return false;
+            // also check normal signs
+            if (h.dot(contacts.get(0).normal) > 0) if (testFAILED()) return false;
+            // also check contact point depth
+            if (dFabs(plane.getPointDepth(contacts.get(0).pos)) > tol)
+                if (testFAILED()) return false;
+
+            draw_all_objects(space);
+        }
+
+        // ********** test ray that just misses
+
+        b.set(n).scale(1 + d);
+        h.set(n).scale(-1);
+        ray.set(b, h);
+        ray.setLength(0.99);
+        if (OdeHelper.collide(ray, plane, 1, contacts) != 0) if (testFAILED()) return false;
+
+        // ********** test ray that just hits
+
+        ray.setLength(1.01);
+        if (OdeHelper.collide(ray, plane, 1, contacts) != 1) if (testFAILED()) return false;
+
+        // ********** test polarity with typical ground plane
+        plane.setParams(0, 0, 1, 0);
+        a.set(0.1, 0.1, 1);
+        b.set(0, 0, -1);
+        ray.set(a, b);
+        ray.setLength(2);
+        if (OdeHelper.collide(ray, plane, 1, contacts) != 1) if (testFAILED()) return false;
+        if (Math.abs(contacts.get(0).depth - 1) > tol) if (testFAILED()) return false;
+        a.set2(-1);
+        b.set2(1);
+        ray.set(a, b);
+        if (OdeHelper.collide(ray, plane, 1, contacts) != 1) if (testFAILED()) return false;
+        if (Math.abs(contacts.get(0).depth - 1) > tol) if (testFAILED()) return false;
+
+        return retPASSED();
+    }
+
+    //****************************************************************************
+    // a really inefficient, but hopefully correct implementation of
+    // dBoxTouchesBox(), that does 144 edge-face tests.
+
+    // return 1 if edge v1 -> v2 hits the rectangle described by p1,p2,p3
+
+    private static boolean edgeIntersectsRect(DVector3 v1, DVector3 v2,
+                                              DVector3 p1, DVector3 p2, DVector3 p3) {
+        DVector3 u1 = new DVector3(), u2 = new DVector3(), n = new DVector3(), tmp = new DVector3();
+
+        //for (k=0; k<3; k++) u1[k] = p3[k]-p1[k];
+        u1.eqDiff(p3, p1);
+        //for (k=0; k<3; k++) u2[k] = p2[k]-p1[k];
+        u2.eqDiff(p2, p1);
+
+        double d1 = dSqrt(u1.dot(u1));
+        double d2 = dSqrt(u2.dot(u2));
+        u1.normalize();
+        u2.normalize();
+
+        double error;
+        // #ifdef dSINGLE
+        // 	const dReal uEpsilon = 1e-5, pEpsilon = 1e-6, tmpEpsilon = 1.5e-4;
+        // #else
+        final double uEpsilon = 1e-6, pEpsilon = 1e-8, tmpEpsilon = 1e-6;
+        // #endif
+
+        error = dFabs(dCalcVectorDot3(u1, u2));
+        if (error > uEpsilon) dDebug(0, "bad u1/u2");
+
+        dCalcVectorCross3(n, u1, u2);
+
+        // for (k=0; k < 3; k++) tmp[k] = v2[k] - v1[k];
+        tmp.eqDiff(v2, v1);
+
+        double d = -dCalcVectorDot3(n, p1);
+
+        error = dFabs(dCalcVectorDot3(n, p1) + d);
+        if (error > pEpsilon) dDebug(0, "bad n wrt p1");
+
+        error = dFabs(dCalcVectorDot3(n, p2) + d);
+        if (error > pEpsilon) dDebug(0, "bad n wrt p2");
+
+        error = dFabs(dCalcVectorDot3(n, p3) + d);
+        if (error > pEpsilon) dDebug(0, "bad n wrt p3");
+
+        double alpha = -(d + dCalcVectorDot3(n, v1)) / dCalcVectorDot3(n, tmp);
+        // for (k=0; k < 3; k++) tmp[k] = v1[k] + alpha * (v2[k] - v1[k]);
+        tmp.eqDiff(v2, v1).scale(alpha).add(v1);
+
+        error = dFabs(dCalcVectorDot3(n, tmp) + d);
+        if (error > tmpEpsilon) dDebug(0, "bad tmp");
+
+        if (alpha < 0) return false;
+        if (alpha > 1) return false;
+
+        //for (k=0; k<3; k++) tmp[k] -= p1[k];
+        tmp.sub(p1);
+        double a1 = u1.dot(tmp);
+        double a2 = u2.dot(tmp);
+        if (a1 < 0 || a2 < 0 || a1 > d1 || a2 > d2) return false;
+
+        return true;
+    }
 
 
-	// test if any edge from box 1 hits a face from box 2
+    // return 1 if box 1 is completely inside box 2
 
-	private static boolean testBoxesTouch2 (final DVector3 p1, final DMatrix3 R1,
-			final DVector3 side1, final DVector3 p2,
-			final DMatrix3 R2, final DVector3 side2)
-	{
-		int j,k,j1,j2;
+    private static boolean box1inside2(final DVector3 p1, final DMatrix3 R1,
+                                       final DVector3 side1, final DVector3 p2,
+                                       final DMatrix3 R2, final DVector3 side2) {
+        for (int i = -1; i <= 1; i += 2) {
+            for (int j = -1; j <= 1; j += 2) {
+                for (int k = -1; k <= 1; k += 2) {
+                    DVector3 v = new DVector3(), vv = new DVector3();
+                    v.set(side1).scale(i * 0.5, j * 0.5, k * 0.5);
+                    dMultiply0_331(vv, R1, v);
+                    vv.add(p1).sub(p2);
+                    for (int axis = 0; axis < 3; axis++) {
+                        double z = dCalcVectorDot3_14(vv, R2, axis);
+                        if (z < (-side2.get(axis) * 0.5) || z > (side2.get(axis) * 0.5)) return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
 
-		// for 6 faces from box 2
-		for (int fd=0; fd<3; fd++) {		// direction for face
 
-			for (int fo=0; fo<2; fo++) {	// offset of face
-				// get four points on the face. first get 2 indexes that are not fd
-				int k1=0,k2=0;
-				if (fd==0) { k1 = 1; k2 = 2; }
-				if (fd==1) { k1 = 0; k2 = 2; }
-				if (fd==2) { k1 = 0; k2 = 1; }
-				DVector3[] fp = DVector3.newArray(4);
-				DVector3 tmp=new DVector3();
-				k=0;
-				for (j1=-1; j1<=1; j1+=2) {
-					for (j2=-1; j2<=1; j2+=2) {
-						fp[k].set( k1, j1 );
-						fp[k].set( k2, j2 );
-						fp[k].set( fd, fo*2-1 );
-						k++;
-					}
-				}
-				for (j=0; j<4; j++) {
-					fp[j].scale(side2).scale(0.5);
-					dMultiply0_331 (tmp,R2,fp[j]);
-					fp[j].eqSum( tmp, p2 );
-				}
+    // test if any edge from box 1 hits a face from box 2
 
-				// for 8 vertices
-				double[] v1=new double[3];
-				for (v1[0]=-1; v1[0] <= 1; v1[0] += 2) {
-					for (v1[1]=-1; v1[1] <= 1; v1[1] += 2) {
-						for (v1[2]=-1; v1[2] <= 1; v1[2] += 2) {
-							// for all possible +ve leading edges from those vertices
-							for (int ei=0; ei < 3; ei ++) {
-								if (v1[ei] < 0) {
-									// get vertex1 -> vertex2 = an edge from box 1
-									DVector3 vv1=new DVector3(),vv2=new DVector3();
-									vv1.set( v1[0], v1[1], v1[2] ).scale( 0.5 ).scale( side1 );
-									for (k=0; k<3; k++) vv2.set(k, (v1[k] + (k==ei?1:0)*2)*0.5*side1.get(k) );
-									DVector3 vertex1=new DVector3(),vertex2=new DVector3();
-									dMultiply0_331 (vertex1,R1,vv1);
-									dMultiply0_331 (vertex2,R1,vv2);
-									//for (k=0; k<3; k++) vertex1[k] += p1[k];
-									vertex1.add(p1);
-									//for (k=0; k<3; k++) vertex2[k] += p1[k];
-									vertex2.add(p1);
+    private static boolean testBoxesTouch2(final DVector3 p1, final DMatrix3 R1,
+                                           final DVector3 side1, final DVector3 p2,
+                                           final DMatrix3 R2, final DVector3 side2) {
+        int j, k, j1, j2;
 
-									// see if vertex1 -> vertex2 interesects face
-									if (edgeIntersectsRect (vertex1,vertex2,fp[0],fp[1],fp[2]))
-										return true;
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+        // for 6 faces from box 2
+        for (int fd = 0; fd < 3; fd++) {        // direction for face
 
-		if (box1inside2 (p1,R1,side1,p2,R2,side2)) return true;
-		if (box1inside2 (p2,R2,side2,p1,R1,side1)) return true;
+            for (int fo = 0; fo < 2; fo++) {    // offset of face
+                // get four points on the face. first get 2 indexes that are not fd
+                int k1 = 0, k2 = 0;
+                if (fd == 0) {
+                    k1 = 1;
+                    k2 = 2;
+                }
+                if (fd == 1) {
+                    k1 = 0;
+                    k2 = 2;
+                }
+                if (fd == 2) {
+                    k1 = 0;
+                    k2 = 1;
+                }
+                DVector3[] fp = DVector3.newArray(4);
+                DVector3 tmp = new DVector3();
+                k = 0;
+                for (j1 = -1; j1 <= 1; j1 += 2) {
+                    for (j2 = -1; j2 <= 1; j2 += 2) {
+                        fp[k].set(k1, j1);
+                        fp[k].set(k2, j2);
+                        fp[k].set(fd, fo * 2 - 1);
+                        k++;
+                    }
+                }
+                for (j = 0; j < 4; j++) {
+                    fp[j].scale(side2).scale(0.5);
+                    dMultiply0_331(tmp, R2, fp[j]);
+                    fp[j].eqSum(tmp, p2);
+                }
 
-		return false;
-	}
+                // for 8 vertices
+                double[] v1 = new double[3];
+                for (v1[0] = -1; v1[0] <= 1; v1[0] += 2) {
+                    for (v1[1] = -1; v1[1] <= 1; v1[1] += 2) {
+                        for (v1[2] = -1; v1[2] <= 1; v1[2] += 2) {
+                            // for all possible +ve leading edges from those vertices
+                            for (int ei = 0; ei < 3; ei++) {
+                                if (v1[ei] < 0) {
+                                    // get vertex1 -> vertex2 = an edge from box 1
+                                    DVector3 vv1 = new DVector3(), vv2 = new DVector3();
+                                    vv1.set(v1[0], v1[1], v1[2]).scale(0.5).scale(side1);
+                                    for (k = 0; k < 3; k++)
+                                        vv2.set(k, (v1[k] + (k == ei ? 1 : 0) * 2) * 0.5 * side1.get(k));
+                                    DVector3 vertex1 = new DVector3(), vertex2 = new DVector3();
+                                    dMultiply0_331(vertex1, R1, vv1);
+                                    dMultiply0_331(vertex2, R1, vv2);
+                                    //for (k=0; k<3; k++) vertex1[k] += p1[k];
+                                    vertex1.add(p1);
+                                    //for (k=0; k<3; k++) vertex2[k] += p1[k];
+                                    vertex2.add(p1);
 
-	//****************************************************************************
-	// dBoxTouchesBox() test
+                                    // see if vertex1 -> vertex2 interesects face
+                                    if (edgeIntersectsRect(vertex1, vertex2, fp[0], fp[1], fp[2]))
+                                        return true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-	private boolean test_dBoxTouchesBox()
-	{
-		int k;
-		boolean bt1,bt2;
-		DVector3 p1=new DVector3(),p2=new DVector3(),side1=new DVector3(),side2=new DVector3();
-		DMatrix3 R1=new DMatrix3(),R2=new DMatrix3();
+        if (box1inside2(p1, R1, side1, p2, R2, side2)) return true;
+        if (box1inside2(p2, R2, side2, p1, R1, side1)) return true;
 
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+        return false;
+    }
 
-		DBox box1 = OdeHelper.createBox (null,1,1,1);
-		space.add (box1);
-		DBox box2 = OdeHelper.createBox (null,1,1,1);
-		space.add (box2);
+    //****************************************************************************
+    // dBoxTouchesBox() test
 
-		dMakeRandomVector (p1,0.5);
-		dMakeRandomVector (p2,0.5);
-		for (k=0; k<3; k++) side1.set(k, dRandReal() + 0.01 );
-		for (k=0; k<3; k++) side2.set(k, dRandReal() + 0.01 );
-		dRFromAxisAndAngle (R1,dRandReal()*2.0-1.0,dRandReal()*2.0-1.0,
-				dRandReal()*2.0-1.0,dRandReal()*10.0-5.0);
-		dRFromAxisAndAngle (R2,dRandReal()*2.0-1.0,dRandReal()*2.0-1.0,
-				dRandReal()*2.0-1.0,dRandReal()*10.0-5.0);
+    private boolean test_dBoxTouchesBox() {
+        int k;
+        boolean bt1, bt2;
+        DVector3 p1 = new DVector3(), p2 = new DVector3(), side1 = new DVector3(), side2 = new DVector3();
+        DMatrix3 R1 = new DMatrix3(), R2 = new DMatrix3();
 
-		box1.setLengths (side1);
-		box2.setLengths (side2);
-		box1.setPosition (p1);
-		box1.setRotation (R1);
-		box2.setPosition (p2);
-		box2.setRotation (R2);
-		draw_all_objects (space);
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
 
-		boolean t1 = testBoxesTouch2 (p1,R1,side1,p2,R2,side2);
-		boolean t2 = testBoxesTouch2 (p2,R2,side2,p1,R1,side1);
-		bt1 = t1 || t2;
-		bt2 = DxCollisionUtil.dBoxTouchesBox (p1,R1,side1,p2,R2,side2);
+        DBox box1 = OdeHelper.createBox(null, 1, 1, 1);
+        space.add(box1);
+        DBox box2 = OdeHelper.createBox(null, 1, 1, 1);
+        space.add(box2);
 
-		if (bt1 != bt2) if (testFAILED()) return false;
+        dMakeRandomVector(p1, 0.5);
+        dMakeRandomVector(p2, 0.5);
+        for (k = 0; k < 3; k++) side1.set(k, dRandReal() + 0.01);
+        for (k = 0; k < 3; k++) side2.set(k, dRandReal() + 0.01);
+        dRFromAxisAndAngle(R1, dRandReal() * 2.0 - 1.0, dRandReal() * 2.0 - 1.0,
+                dRandReal() * 2.0 - 1.0, dRandReal() * 10.0 - 5.0);
+        dRFromAxisAndAngle(R2, dRandReal() * 2.0 - 1.0, dRandReal() * 2.0 - 1.0,
+                dRandReal() * 2.0 - 1.0, dRandReal() * 10.0 - 5.0);
+
+        box1.setLengths(side1);
+        box2.setLengths(side2);
+        box1.setPosition(p1);
+        box1.setRotation(R1);
+        box2.setPosition(p2);
+        box2.setRotation(R2);
+        draw_all_objects(space);
+
+        boolean t1 = testBoxesTouch2(p1, R1, side1, p2, R2, side2);
+        boolean t2 = testBoxesTouch2(p2, R2, side2, p1, R1, side1);
+        bt1 = t1 || t2;
+        bt2 = DxCollisionUtil.dBoxTouchesBox(p1, R1, side1, p2, R2, side2);
+
+        if (bt1 != bt2) if (testFAILED()) return false;
 
 		/*
     // some more debugging info if necessary
@@ -1300,250 +1300,244 @@ class DemoCollision extends dsFunctions {
 			     "says yes\n");
 		 */
 
-		return retPASSED();
-	}
+        return retPASSED();
+    }
 
-	//****************************************************************************
-	// test box-box collision
+    //****************************************************************************
+    // test box-box collision
 
-	private boolean test_dBoxBox()
-	{
-		int k,bt;
-		DVector3 p1=new DVector3(),p2=new DVector3(),side1=new DVector3(),side2=new DVector3(),
-		normal=new DVector3(),normal2=new DVector3();
-		DMatrix3 R1=new DMatrix3(),R2=new DMatrix3();
-		RefDouble depth=new RefDouble(),depth2=new RefDouble();
-		RefInt code = new RefInt();
-		//dContactGeom contact[48];
-		DContactGeomBuffer contacts = new DContactGeomBuffer(48);
+    private boolean test_dBoxBox() {
+        int k, bt;
+        DVector3 p1 = new DVector3(), p2 = new DVector3(), side1 = new DVector3(), side2 = new DVector3(),
+                normal = new DVector3(), normal2 = new DVector3();
+        DMatrix3 R1 = new DMatrix3(), R2 = new DMatrix3();
+        RefDouble depth = new RefDouble(), depth2 = new RefDouble();
+        RefInt code = new RefInt();
+        //dContactGeom contact[48];
+        DContactGeomBuffer contacts = new DContactGeomBuffer(48);
 
-		DSimpleSpace space = OdeHelper.createSimpleSpace(null);
+        DSimpleSpace space = OdeHelper.createSimpleSpace(null);
 
-		DBox box1 = OdeHelper.createBox (null,1,1,1);
-		space.add(box1);
-		DBox box2 = OdeHelper.createBox (null,1,1,1);
-		space.add(box2);
+        DBox box1 = OdeHelper.createBox(null, 1, 1, 1);
+        space.add(box1);
+        DBox box2 = OdeHelper.createBox(null, 1, 1, 1);
+        space.add(box2);
 
-		dMakeRandomVector (p1,0.5);
-		dMakeRandomVector (p2,0.5);
-		for (k=0; k<3; k++) side1.set(k, dRandReal() + 0.01 );
-		for (k=0; k<3; k++) side2.set(k, dRandReal() + 0.01 );
+        dMakeRandomVector(p1, 0.5);
+        dMakeRandomVector(p2, 0.5);
+        for (k = 0; k < 3; k++) side1.set(k, dRandReal() + 0.01);
+        for (k = 0; k < 3; k++) side2.set(k, dRandReal() + 0.01);
 
-		dRFromAxisAndAngle (R1,dRandReal()*2.0-1.0,dRandReal()*2.0-1.0,
-				dRandReal()*2.0-1.0,dRandReal()*10.0-5.0);
-		dRFromAxisAndAngle (R2,dRandReal()*2.0-1.0,dRandReal()*2.0-1.0,
-				dRandReal()*2.0-1.0,dRandReal()*10.0-5.0);
+        dRFromAxisAndAngle(R1, dRandReal() * 2.0 - 1.0, dRandReal() * 2.0 - 1.0,
+                dRandReal() * 2.0 - 1.0, dRandReal() * 10.0 - 5.0);
+        dRFromAxisAndAngle(R2, dRandReal() * 2.0 - 1.0, dRandReal() * 2.0 - 1.0,
+                dRandReal() * 2.0 - 1.0, dRandReal() * 10.0 - 5.0);
 
-		// dRSetIdentity (R1);	// we can also try this
-		// dRSetIdentity (R2);
+        // dRSetIdentity (R1);	// we can also try this
+        // dRSetIdentity (R2);
 
-		box1.setLengths (side1);
-		box2.setLengths (side2);
-		box1.setPosition (p1);
-		box1.setRotation (R1);
-		box2.setPosition (p2);
-		box2.setRotation (R2);
+        box1.setLengths(side1);
+        box2.setLengths(side2);
+        box1.setPosition(p1);
+        box1.setRotation(R1);
+        box2.setPosition(p2);
+        box2.setRotation(R2);
 
-		code.set(0); //= 0;
-		depth.set(0);// = 0;
-		bt = DxBox.dBoxBox (p1,R1,side1,p2,R2,side2,normal,depth,code,8,contacts, 1);
-		//sizeof(dContactGeom));
-		if (bt==1) {
-			p2.eqSum( p2, normal, 0.96 * depth.get() );
-			bt = DxBox.dBoxBox (p1,R1,side1,p2,R2,side2,normal2,depth2,code,8,contacts, 1);
-			//sizeof(dContactGeom));
+        code.set(0); //= 0;
+        depth.set(0);// = 0;
+        bt = DxBox.dBoxBox(p1, R1, side1, p2, R2, side2, normal, depth, code, 8, contacts, 1);
+        //sizeof(dContactGeom));
+        if (bt == 1) {
+            p2.eqSum(p2, normal, 0.96 * depth.get());
+            bt = DxBox.dBoxBox(p1, R1, side1, p2, R2, side2, normal2, depth2, code, 8, contacts, 1);
+            //sizeof(dContactGeom));
 
 			/*
     dGeomSetPosition (box2,p2[0],p2[1],p2[2]);
     draw_all_objects (space);
 			 */
 
-			if (bt != 1) {
-				if (testFAILED()) return false;
-				box2.setPosition (p2);
-				draw_all_objects (space);
-			}
+            if (bt != 1) {
+                if (testFAILED()) return false;
+                box2.setPosition(p2);
+                draw_all_objects(space);
+            }
 
-			p2.eqSum( p2, normal, 0.08 * depth.get() );
-			bt = DxBox.dBoxBox (p1,R1,side1,p2,R2,side2,normal2,depth2,code,8,contacts, 1);
-			//sizeof(dContactGeom));
-			if (bt != 0) if (testFAILED()) return false;
+            p2.eqSum(p2, normal, 0.08 * depth.get());
+            bt = DxBox.dBoxBox(p1, R1, side1, p2, R2, side2, normal2, depth2, code, 8, contacts, 1);
+            //sizeof(dContactGeom));
+            if (bt != 0) if (testFAILED()) return false;
 
-			// dGeomSetPosition (box2,p2[0],p2[1],p2[2]);
-			// draw_all_objects (space);
-		}
+            // dGeomSetPosition (box2,p2[0],p2[1],p2[2]);
+            // draw_all_objects (space);
+        }
 
-		// printf ("code=%2d  depth=%.4f  ",code,depth);
+        // printf ("code=%2d  depth=%.4f  ",code,depth);
 
-		return retPASSED();
-	}
+        return retPASSED();
+    }
 
-	//****************************************************************************
-	// graphics
+    //****************************************************************************
+    // graphics
 
-	private boolean space_pressed = false;
-
-
-	private static final float[] xyz = {2.4807f,-1.8023f,2.7600f};
-	private static final float[] hpr = {141.5000f,-18.5000f,0.0000f};
-	// start simulation - set viewpoint
-
-	@Override
-	public void start()
-	{
-		dsSetViewpoint (xyz,hpr);
-	}
+    private boolean space_pressed = false;
 
 
-	// called when a key pressed
+    private static final float[] xyz = {2.4807f, -1.8023f, 2.7600f};
+    private static final float[] hpr = {141.5000f, -18.5000f, 0.0000f};
+    // start simulation - set viewpoint
 
-	@Override
-	public void command (char cmd)
-	{
-		if (cmd == ' ') space_pressed = true;
-	}
+    @Override
+    public void start() {
+        dsSetViewpoint(xyz, hpr);
+    }
 
 
-	// simulation loop
+    // called when a key pressed
 
-	public void simLoop (boolean pause)
-	{
-		do {
-			draw_all_objects_called = false;
-			long seed = dRandGetSeed();
-			testslot[graphical_test].test_fn();
-			if (draw_all_objects_called) {
-				if (space_pressed) {
-				    space_pressed = false; 
-				} else {
-				    dRandSetSeed (seed);
-				}
-			}
-		}
-		while (!draw_all_objects_called);
-	}
+    @Override
+    public void command(char cmd) {
+        if (cmd == ' ') space_pressed = true;
+    }
 
-	//****************************************************************************
-	// do all the tests
 
-	private void do_tests (String[] args)
-	{
-		int i,j;
+    // simulation loop
 
-		// process command line arguments
-		if (args.length >= 2) {
-			graphical_test = Integer.parseInt(args[1]);
-		}
+    public void simLoop(boolean pause) {
+        do {
+            draw_all_objects_called = false;
+            long seed = dRandGetSeed();
+            testslot[graphical_test].test_fn();
+            if (draw_all_objects_called) {
+                if (space_pressed) {
+                    space_pressed = false;
+                } else {
+                    dRandSetSeed(seed);
+                }
+            }
+        }
+        while (!draw_all_objects_called);
+    }
 
-		if (graphical_test!=0) {
-			// do one test gaphically and interactively
+    //****************************************************************************
+    // do all the tests
 
-			if (graphical_test < 1 || graphical_test >= MAX_TESTS ||
-					testslot[graphical_test].name==null) {
-				dError (0,"invalid test number");
-			}
+    private void do_tests(String[] args) {
+        int i, j;
 
-			System.out.println ("performing test: " + testslot[graphical_test].name);
+        // process command line arguments
+        if (args.length >= 2) {
+            graphical_test = Integer.parseInt(args[1]);
+        }
 
-			dsSetSphereQuality (3);
-			dsSetCapsuleQuality (8);
-			dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
-		}
-		else {
-			// do all tests noninteractively
-			dsInitializeConsole(args);
+        if (graphical_test != 0) {
+            // do one test gaphically and interactively
 
-			for (i=0; i<MAX_TESTS; i++) testslot[i].number = i;
+            if (graphical_test < 1 || graphical_test >= MAX_TESTS ||
+                    testslot[graphical_test].name == null) {
+                dError(0, "invalid test number");
+            }
 
-			// first put the active tests into a separate array
-			int n=0;
-			for (i=0; i<MAX_TESTS; i++) if (testslot[i].name!=null) n++;
-			//TestSlot **ts = (TestSlot**) malloc (n * sizeof(TestSlot*));
-			TestSlot[] ts = new TestSlot[n];
-			j = 0;
-			for (i=0; i<MAX_TESTS; i++) if (testslot[i].name!=null) ts[j++] = testslot[i];//+i;
-			if (j != n) dDebug (0,"internal");
+            System.out.println("performing test: " + testslot[graphical_test].name);
 
-			// do two test batches. the first test batch has far fewer reps and will
-			// catch problems quickly. if all tests in the first batch passes, the
-			// second batch is run.
+            dsSetSphereQuality(3);
+            dsSetCapsuleQuality(8);
+            dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
+        } else {
+            // do all tests noninteractively
+            dsInitializeConsole(args);
 
-			for (i=0; i<n; i++) ts[i].failcount = 0;
-			int total_reps=0;
-			for (int batch=0; batch<2; batch++) {
-				int reps = (batch==0) ? TEST_REPS1 : TEST_REPS2;
-				total_reps += reps;
-				System.out.println ("testing batch " + (batch+1) + " (" + reps + " reps)...");
+            for (i = 0; i < MAX_TESTS; i++) testslot[i].number = i;
 
-				// run tests
-				for (j=0; j<reps; j++) {
-					for (i=0; i<n; i++) {
-						current_test = ts[i].number;
-						if (ts[i].test_fn() != true) ts[i].failcount++;
-					}
-				}
+            // first put the active tests into a separate array
+            int n = 0;
+            for (i = 0; i < MAX_TESTS; i++) if (testslot[i].name != null) n++;
+            //TestSlot **ts = (TestSlot**) malloc (n * sizeof(TestSlot*));
+            TestSlot[] ts = new TestSlot[n];
+            j = 0;
+            for (i = 0; i < MAX_TESTS; i++) if (testslot[i].name != null) ts[j++] = testslot[i];//+i;
+            if (j != n) dDebug(0, "internal");
 
-				// check for failures
-				int total_fail_count=0;
-				for (i=0; i<n; i++) total_fail_count += ts[i].failcount;
-				if (total_fail_count!=0) break;
-			}
+            // do two test batches. the first test batch has far fewer reps and will
+            // catch problems quickly. if all tests in the first batch passes, the
+            // second batch is run.
 
-			// print results
-			for (i=0; i<n; i++) {
-				System.out.print (ts[i].number + ": " + ts[i].name); //"%3d: %-30s: "
-				if (ts[i].failcount!=0) {
-					System.out.println ("FAILED (" +//(%.2f%%) at line %d\n",
-							((double)ts[i].failcount)/((double)total_reps)*100.0 + 
-							") at line " + ts[i].last_failed_line);
-				} else {
-					System.out.println ("\t ok");
-				}
-			}
-		}
+            for (i = 0; i < n; i++) ts[i].failcount = 0;
+            int total_reps = 0;
+            for (int batch = 0; batch < 2; batch++) {
+                int reps = (batch == 0) ? TEST_REPS1 : TEST_REPS2;
+                total_reps += reps;
+                System.out.println("testing batch " + (batch + 1) + " (" + reps + " reps)...");
 
-		dsFinalizeConsole();
-	}
+                // run tests
+                for (j = 0; j < reps; j++) {
+                    for (i = 0; i < n; i++) {
+                        current_test = ts[i].number;
+                        if (ts[i].test_fn() != true) ts[i].failcount++;
+                    }
+                }
 
-	//****************************************************************************
+                // check for failures
+                int total_fail_count = 0;
+                for (i = 0; i < n; i++) total_fail_count += ts[i].failcount;
+                if (total_fail_count != 0) break;
+            }
 
-	public static void main(String[] args) {
-		new DemoCollision().setup(args);
-	}
+            // print results
+            for (i = 0; i < n; i++) {
+                System.out.print(ts[i].number + ": " + ts[i].name); //"%3d: %-30s: "
+                if (ts[i].failcount != 0) {
+                    System.out.println("FAILED (" +//(%.2f%%) at line %d\n",
+                            ((double) ts[i].failcount) / ((double) total_reps) * 100.0 +
+                            ") at line " + ts[i].last_failed_line);
+                } else {
+                    System.out.println("\t ok");
+                }
+            }
+        }
 
-	private void setup(String[] args) {
-		// setup all tests
+        dsFinalizeConsole();
+    }
 
-		//memset (testslot,0,sizeof(testslot));
-		for (int i = 0; i < MAX_TESTS; i++) testslot[i] = new TestSlot();
+    //****************************************************************************
 
-		OdeHelper.initODE2(0);
+    public static void main(String[] args) {
+        new DemoCollision().setup(args);
+    }
 
-		MAKE_TEST(1,"test_sphere_point_depth");
-		MAKE_TEST(2,"test_box_point_depth");
-		MAKE_TEST(3,"test_ccylinder_point_depth");
-		MAKE_TEST(4,"test_plane_point_depth");
+    private void setup(String[] args) {
+        // setup all tests
 
-		MAKE_TEST(10,"test_ray_and_sphere");
-		MAKE_TEST(11,"test_ray_and_box");
-		MAKE_TEST(12,"test_ray_and_ccylinder");
-		MAKE_TEST(13,"test_ray_and_plane");
-		MAKE_TEST(14,"test_ray_and_cylinder");
+        //memset (testslot,0,sizeof(testslot));
+        for (int i = 0; i < MAX_TESTS; i++) testslot[i] = new TestSlot();
 
-		MAKE_TEST(100,"test_dBoxTouchesBox");
-		MAKE_TEST(101,"test_dBoxBox");
+        OdeHelper.initODE2(0);
 
-		do_tests (args);
-		OdeHelper.closeODE();
-	}
+        MAKE_TEST(1, "test_sphere_point_depth");
+        MAKE_TEST(2, "test_box_point_depth");
+        MAKE_TEST(3, "test_ccylinder_point_depth");
+        MAKE_TEST(4, "test_plane_point_depth");
 
-	@Override
-	public void step(boolean pause) {
-		simLoop(pause);
-	}
+        MAKE_TEST(10, "test_ray_and_sphere");
+        MAKE_TEST(11, "test_ray_and_box");
+        MAKE_TEST(12, "test_ray_and_ccylinder");
+        MAKE_TEST(13, "test_ray_and_plane");
+        MAKE_TEST(14, "test_ray_and_cylinder");
 
-	@Override
-	public void stop() {
-		// Nothing
-	}
+        MAKE_TEST(100, "test_dBoxTouchesBox");
+        MAKE_TEST(101, "test_dBoxBox");
+
+        do_tests(args);
+        OdeHelper.closeODE();
+    }
+
+    @Override
+    public void step(boolean pause) {
+        simLoop(pause);
+    }
+
+    @Override
+    public void stop() {
+        // Nothing
+    }
 }

--- a/demo/src/main/java/org/ode4j/demo/DemoCollision.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCollision.java
@@ -102,25 +102,18 @@ class DemoCollision extends dsFunctions {
 		try {
 			Method m = DemoCollision.class.getDeclaredMethod(name);
 			return (Boolean)m.invoke(this);
-		} catch (SecurityException e) {
-			throw new RuntimeException(e);
-		} catch (NoSuchMethodException e) {
-			throw new RuntimeException(e);
-		} catch (IllegalArgumentException e) {
-			throw new RuntimeException(e);
-		} catch (IllegalAccessException e) {
-			throw new RuntimeException(e);
-		} catch (InvocationTargetException e) {
+		} catch (SecurityException | NoSuchMethodException | IllegalArgumentException | IllegalAccessException |
+                 InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}
-	}
+    }
 
 
 	private final TestSlot[] testslot=new TestSlot[MAX_TESTS];
 
 
 	// globals used by the test functions
-	private int graphical_test=0;		// show graphical results of this test, 0=none
+	private int graphical_test = 0;		// show graphical results of this test, 0=none
 	private int current_test;		// currently execiting test
 	private boolean draw_all_objects_called;
 
@@ -622,8 +615,7 @@ class DemoCollision extends dsFunctions {
 		do {
 			dMakeRandomVector (n,1.0);
 			n.normalize();
-		}
-		while (n.dot(q) < 0);	// make sure normal goes away from sphere
+		} while (n.dot(q) < 0);	// make sure normal goes away from sphere
 		q.eqSum( p, q, 1.01*r );
 		ray.set (q,n);
 		ray.setLength (100);
@@ -1455,10 +1447,11 @@ class DemoCollision extends dsFunctions {
 
 			dsSetSphereQuality (3);
 			dsSetCapsuleQuality (8);
-			dsSimulationLoop (args,1280,900,this);
+			dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 		}
 		else {
 			// do all tests noninteractively
+			dsInitializeConsole(args);
 
 			for (i=0; i<MAX_TESTS; i++) testslot[i].number = i;
 
@@ -1508,6 +1501,8 @@ class DemoCollision extends dsFunctions {
 				}
 			}
 		}
+
+		dsFinalizeConsole();
 	}
 
 	//****************************************************************************

--- a/demo/src/main/java/org/ode4j/demo/DemoConvex.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoConvex.java
@@ -111,7 +111,7 @@ public class DemoConvex extends DrawStuff.dsFunctions {
 		-8, 0, 5
 	};
 	private static final float[] hpr = { // [ 3] ={
-		0.0f, -29.5000f, 0.0000f
+		0.0f, -19.5000f, 0.0000f
 	};
 
 

--- a/demo/src/main/java/org/ode4j/demo/DemoConvex.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoConvex.java
@@ -24,7 +24,6 @@ package org.ode4j.demo;
 import org.ode4j.drawstuff.DrawStuff;
 import org.ode4j.math.DMatrix3C;
 import org.ode4j.math.DQuaternion;
-import org.ode4j.math.DVector3;
 import org.ode4j.math.DVector3C;
 import org.ode4j.ode.*;
 
@@ -293,9 +292,7 @@ public class DemoConvex extends DrawStuff.dsFunctions {
 		}
 
 		// run simulation
-		final int w = 1280;
-		final int h = 720;
-		dsSimulationLoop(args, w, h, this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.empty ();
 		contactgroup.destroy ();

--- a/demo/src/main/java/org/ode4j/demo/DemoCrash.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCrash.java
@@ -177,7 +177,7 @@ class DemoCrash extends dsFunctions {
 
 
 	private static final float[] xyz = {3.8548f,9.0843f,7.5900f};
-	private static final float[] hpr = {-145.5f,-22.5f,0.25f};
+	private static final float[] hpr = {-145.5f,-3.5f,0.25f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoCrash.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCrash.java
@@ -675,7 +675,7 @@ class DemoCrash extends dsFunctions {
 		setupSimulation();
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		shutdownSimulation();
 		OdeHelper.closeODE();

--- a/demo/src/main/java/org/ode4j/demo/DemoCyl.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCyl.java
@@ -127,8 +127,8 @@ class DemoCyl extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {-8,-9,3};
-	private static float[] hpr = {45.0000f,-27.5000f,0.0000f};
+	private static final float[] xyz = {-8,-9,3};
+	private static final float[] hpr = {45.0000f,-27.5000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override
@@ -287,7 +287,7 @@ class DemoCyl extends dsFunctions {
 		reset_state();
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.empty();
 		contactgroup.destroy();

--- a/demo/src/main/java/org/ode4j/demo/DemoCyl.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCyl.java
@@ -128,7 +128,7 @@ class DemoCyl extends dsFunctions {
 
 
 	private static final float[] xyz = {-8,-9,3};
-	private static final float[] hpr = {45.0000f,-27.5000f,0.0000f};
+	private static final float[] hpr = {45.0000f,-3.5000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override

--- a/demo/src/main/java/org/ode4j/demo/DemoCylVsSphere.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCylVsSphere.java
@@ -132,7 +132,7 @@ class DemoCylVsSphere extends dsFunctions {
 
 
 	private static final float[] xyz = {-8,-9,3};
-	private static final float[] hpr = {45.0000f,-27.5000f,0.0000f};
+	private static final float[] hpr = {45.0000f,-2.5000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoCylVsSphere.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoCylVsSphere.java
@@ -131,8 +131,8 @@ class DemoCylVsSphere extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {-8,-9,3};
-	private static float[] hpr = {45.0000f,-27.5000f,0.0000f};
+	private static final float[] xyz = {-8,-9,3};
+	private static final float[] hpr = {45.0000f,-27.5000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()
@@ -228,7 +228,7 @@ class DemoCylVsSphere extends dsFunctions {
 		space.add (sphgeom);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.empty();
 		contactgroup.destroy();

--- a/demo/src/main/java/org/ode4j/demo/DemoDBall.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoDBall.java
@@ -21,15 +21,6 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawLine;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
-
 import org.ode4j.drawstuff.DrawStuff.DS_TEXTURE_NUMBER;
 import org.ode4j.drawstuff.DrawStuff.dsFunctions;
 import org.ode4j.math.DMatrix3C;
@@ -45,6 +36,9 @@ import org.ode4j.ode.DSphere;
 import org.ode4j.ode.DWorld;
 import org.ode4j.ode.OdeHelper;
 
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
+
 public class DemoDBall extends dsFunctions {
 
 	private DWorld world;
@@ -53,8 +47,8 @@ public class DemoDBall extends dsFunctions {
 	private DBody body2;
 	private DDoubleBallJoint joint1, joint2;
 
-	private static double[] xyz = {3.8966, -2.0614, 4.0300};
-	private static double[] hpr = {153.5, -16.5, 0};
+	private static final double[] xyz = {3.8966, -2.0614, 4.0300};
+	private static final double[] hpr = {153.5, -16.5, 0};
 
 	@Override
 	public void start()
@@ -191,7 +185,7 @@ public class DemoDBall extends dsFunctions {
 		OdeHelper.initODE();
 
 		// run demo
-		dsSimulationLoop (args, 800, 600, this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		OdeHelper.closeODE();
 	}

--- a/demo/src/main/java/org/ode4j/demo/DemoDBall.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoDBall.java
@@ -47,8 +47,8 @@ public class DemoDBall extends dsFunctions {
 	private DBody body2;
 	private DDoubleBallJoint joint1, joint2;
 
-	private static final double[] xyz = {3.8966, -2.0614, 4.0300};
-	private static final double[] hpr = {153.5, -16.5, 0};
+	private static final double[] xyz = {5.8966, -4.0614, 4.0300};
+	private static final double[] hpr = {153.5, 1, 0};
 
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoDHinge.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoDHinge.java
@@ -21,13 +21,6 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawLine;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
-
 import org.ode4j.drawstuff.DrawStuff.DS_TEXTURE_NUMBER;
 import org.ode4j.drawstuff.DrawStuff.dsFunctions;
 import org.ode4j.math.DMatrix3C;
@@ -42,6 +35,9 @@ import org.ode4j.ode.DSpace;
 import org.ode4j.ode.DWorld;
 import org.ode4j.ode.OdeHelper;
 
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
+
 public class DemoDHinge extends dsFunctions {
 
 	private DWorld world;
@@ -52,8 +48,8 @@ public class DemoDHinge extends dsFunctions {
 	private DDoubleHingeJoint joint2;
 	private boolean applyForce = false;
 
-	private static double[] xyz = {3.8966, -2.0614, 4.0300};
-	private static double[] hpr = {153.5, -16.5, 0};
+	private static final double[] xyz = {3.8966, -2.0614, 4.0300};
+	private static final double[] hpr = {153.5, -16.5, 0};
 
 	@Override
 	public void start() {
@@ -200,7 +196,7 @@ public class DemoDHinge extends dsFunctions {
 		OdeHelper.initODE();
 
 		// run demo
-		dsSimulationLoop (args, 800, 600, this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		OdeHelper.closeODE();
 	}

--- a/demo/src/main/java/org/ode4j/demo/DemoDHinge.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoDHinge.java
@@ -48,8 +48,8 @@ public class DemoDHinge extends dsFunctions {
 	private DDoubleHingeJoint joint2;
 	private boolean applyForce = false;
 
-	private static final double[] xyz = {3.8966, -2.0614, 4.0300};
-	private static final double[] hpr = {153.5, -16.5, 0};
+	private static final double[] xyz = {5.8966, -4.0614, 4.0300};
+	private static final double[] hpr = {153.5, 0, 0};
 
 	@Override
 	public void start() {

--- a/demo/src/main/java/org/ode4j/demo/DemoFeedback.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoFeedback.java
@@ -119,8 +119,8 @@ class DemoFeedback extends dsFunctions {
 	}
 
 
-	private static final float[] xyz = { -6, 8, 6};
-	private static final float[] hpr = { -65.0f, -27.0f, 0.0f};
+	private static final float[] xyz = { -10, 14, 6};
+	private static final float[] hpr = { -65.0f, 10.0f, 0.0f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoFeedback.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoFeedback.java
@@ -159,7 +159,7 @@ class DemoFeedback extends dsFunctions {
 
 	private static void inspectJoints()
 	{
-		final double forcelimit = 4000.0;
+		final double forcelimit = 5000.0;
 		int i;
 		for (i=0; i<SEGMCNT-1; i++)
 		{
@@ -302,7 +302,7 @@ class DemoFeedback extends dsFunctions {
 			colours[i]=0.0;
 
 		// run simulation
-		dsSimulationLoop (args,1280,720,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.empty();
 		contactgroup.destroy();

--- a/demo/src/main/java/org/ode4j/demo/DemoFriction.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoFriction.java
@@ -124,8 +124,8 @@ class DemoFriction extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {1.7772f,-0.7924f,2.7600f};
-	private static float[] hpr = {90.0000f,-54.0000f,0.0000f};
+	private static final float[] xyz = {1.7772f,-0.7924f,2.7600f};
+	private static final float[] hpr = {90.0000f,-54.0000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()
@@ -196,7 +196,7 @@ class DemoFriction extends dsFunctions {
 		}
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.destroy();
 		space.destroy();

--- a/demo/src/main/java/org/ode4j/demo/DemoFriction.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoFriction.java
@@ -124,8 +124,8 @@ class DemoFriction extends dsFunctions {
 	}
 
 
-	private static final float[] xyz = {1.7772f,-0.7924f,2.7600f};
-	private static final float[] hpr = {90.0000f,-54.0000f,0.0000f};
+	private static final float[] xyz = {1.7772f,-1.7924f,2.7600f};
+	private static final float[] hpr = {90.0000f,-24.0000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoGyro2.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoGyro2.java
@@ -64,8 +64,8 @@ public class DemoGyro2 extends dsFunctions {
 	private DBody impGyroBody;
 
 
-	private static final double[] xyz = {0,-4.0f,3.0f};
-	private static final double[] hpr = {90.0000,-15.0000,0.0000};
+	private static final double[] xyz = {0,-6.0f,3.0f};
+	private static final double[] hpr = {90.0000,0.0000,0.0000};
 
 	// start simulation - set viewpoint
 

--- a/demo/src/main/java/org/ode4j/demo/DemoGyro2.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoGyro2.java
@@ -24,12 +24,6 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
-
 import org.ode4j.drawstuff.DrawStuff.DS_TEXTURE_NUMBER;
 import org.ode4j.drawstuff.DrawStuff.dsFunctions;
 import org.ode4j.math.DMatrix3;
@@ -42,6 +36,9 @@ import org.ode4j.ode.DMassC;
 import org.ode4j.ode.DWorld;
 import org.ode4j.ode.OdeHelper;
 import org.ode4j.ode.OdeMath;
+
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 
 
 /**
@@ -67,8 +64,8 @@ public class DemoGyro2 extends dsFunctions {
 	private DBody impGyroBody;
 
 
-	private static double[] xyz = {0,-4.0f,3.0f};
-	private static double[] hpr = {90.0000,-15.0000,0.0000};
+	private static final double[] xyz = {0,-4.0f,3.0f};
+	private static final double[] hpr = {90.0000,-15.0000,0.0000};
 
 	// start simulation - set viewpoint
 
@@ -205,7 +202,7 @@ public class DemoGyro2 extends dsFunctions {
 		reset();
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		clear();
 		OdeHelper.closeODE();

--- a/demo/src/main/java/org/ode4j/demo/DemoGyroscopic.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoGyroscopic.java
@@ -96,8 +96,8 @@ public class DemoGyroscopic extends dsFunctions {
 	}
 
 
-	private static final float[] xyz = {4.777f, -2.084f, 2.18f};
-	private static final float[] hpr = {153.0f, -14.5f, 0.0f};
+	private static final float[] xyz = {6.777f, -4.084f, 2.18f};
+	private static final float[] hpr = {153.0f, 0f, 0.0f};
 	// start simulation - set viewpoint
 
 	@Override

--- a/demo/src/main/java/org/ode4j/demo/DemoGyroscopic.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoGyroscopic.java
@@ -96,8 +96,8 @@ public class DemoGyroscopic extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {4.777f, -2.084f, 2.18f};
-	private static float[] hpr = {153.0f, -14.5f, 0.0f};
+	private static final float[] xyz = {4.777f, -2.084f, 2.18f};
+	private static final float[] hpr = {153.0f, -14.5f, 0.0f};
 	// start simulation - set viewpoint
 
 	@Override
@@ -235,7 +235,7 @@ public class DemoGyroscopic extends dsFunctions {
 		reset();
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		g1.DESTRUCTOR();//delete g1;
 		g2.DESTRUCTOR();//delete g2;

--- a/demo/src/main/java/org/ode4j/demo/DemoHeightfield.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoHeightfield.java
@@ -230,8 +230,8 @@ class DemoHeightfield extends dsFunctions {
 		}
 	}
 
-	private static final float[] xyz = {3.1640f,-4.3079f,1.7600f};
-	private static final float[] hpr = {135.5000f,-7.0000f,0.0000f};
+	private static final float[] xyz = {4.1640f,-5.3079f,1.7600f};
+	private static final float[] hpr = {135.5000f,10.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override

--- a/demo/src/main/java/org/ode4j/demo/DemoHeightfield.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoHeightfield.java
@@ -27,17 +27,8 @@ package org.ode4j.demo;
 import static org.ode4j.demo.BunnyGeom.IndexCount;
 import static org.ode4j.demo.BunnyGeom.Indices;
 import static org.ode4j.demo.BunnyGeom.Vertices;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawConvex;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawTriangle;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DMisc.dRandReal;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
 import static org.ode4j.ode.OdeConstants.dContactBounce;
@@ -239,8 +230,8 @@ class DemoHeightfield extends dsFunctions {
 		}
 	}
 
-	private static float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {3.1640f,-4.3079f,1.7600f};
+	private static final float[] hpr = {135.5000f,-7.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override
@@ -675,7 +666,7 @@ class DemoHeightfield extends dsFunctions {
 //	    world.setStepThreadingImplementation(threading.dThreadingImplementationGetFunctions(), threading);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 //	    threading.shutdownProcessing();//dThreadingImplementationShutdownProcessing(threading);
 //	    pool.freeThreadPool();

--- a/demo/src/main/java/org/ode4j/demo/DemoHinge.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoHinge.java
@@ -66,7 +66,7 @@ public class DemoHinge extends dsFunctions {
 
 	// start simulation - set viewpoint
 	private static final float[] xyz = {1.0382f,-1.0811f,1.4700f};
-	private static final float[] hpr = {135.0000f,-19.5000f,0.0000f};
+	private static final float[] hpr = {135.0000f,0.000f,0.0000f};
 
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoHinge.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoHinge.java
@@ -65,8 +65,8 @@ public class DemoHinge extends dsFunctions {
 
 
 	// start simulation - set viewpoint
-	private static float[] xyz = {1.0382f,-1.0811f,1.4700f};
-	private static float[] hpr = {135.0000f,-19.5000f,0.0000f};
+	private static final float[] xyz = {1.0382f,-1.0811f,1.4700f};
+	private static final float[] hpr = {135.0000f,-19.5000f,0.0000f};
 
 	@Override
 	public void start()
@@ -172,9 +172,7 @@ public class DemoHinge extends dsFunctions {
 		hinge.setAxis (1,-1,1.41421356);
 
 		// run simulation
-		//	  dsSimulationLoop (argc,argv,352,288,&fn);
-//		dsSimulationLoop (args,352,288,fn);
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		world.destroy ();
 		OdeHelper.closeODE();

--- a/demo/src/main/java/org/ode4j/demo/DemoI.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoI.java
@@ -70,8 +70,8 @@ class DemoI extends dsFunctions {
 	private static int iteration;
 
 
-	private static float[] xyz = {1.5572f,-1.8886f,1.5700f};
-	private static float[] hpr = {118.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {1.5572f,-1.8886f,1.5700f};
+	private static final float[] hpr = {118.5000f,-17.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override
@@ -243,7 +243,7 @@ class DemoI extends dsFunctions {
 		reset_test();
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		world.destroy ();
 		OdeHelper.closeODE();

--- a/demo/src/main/java/org/ode4j/demo/DemoI.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoI.java
@@ -71,7 +71,7 @@ class DemoI extends dsFunctions {
 
 
 	private static final float[] xyz = {1.5572f,-1.8886f,1.5700f};
-	private static final float[] hpr = {118.5000f,-17.0000f,0.0000f};
+	private static final float[] hpr = {118.5000f,0.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override

--- a/demo/src/main/java/org/ode4j/demo/DemoJointConstrainedBall.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJointConstrainedBall.java
@@ -21,19 +21,15 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
-
 import org.ode4j.drawstuff.DrawStuff.DS_TEXTURE_NUMBER;
 import org.ode4j.drawstuff.DrawStuff.dsFunctions;
 import org.ode4j.math.DMatrix3C;
 import org.ode4j.math.DVector3;
 import org.ode4j.math.DVector3C;
 import org.ode4j.ode.*;
+
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 
 public class DemoJointConstrainedBall extends dsFunctions {
 
@@ -169,7 +165,7 @@ public class DemoJointConstrainedBall extends dsFunctions {
 		OdeHelper.initODE();
 
 		// run demo
-		dsSimulationLoop (args, 800, 600, this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		OdeHelper.closeODE();
 	}

--- a/demo/src/main/java/org/ode4j/demo/DemoJointConstrainedBall.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJointConstrainedBall.java
@@ -42,7 +42,7 @@ public class DemoJointConstrainedBall extends dsFunctions {
 	private DConstrainedBallJoint joint2;
 
 	private static final double[] xyz = {3.8966, -2.0614, 4.0300};
-	private static final double[] hpr = {153.5, -16.5, 0};
+	private static final double[] hpr = {153.5, -1.5, 0};
 
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoJointPR.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJointPR.java
@@ -84,8 +84,8 @@ class DemoJointPR extends dsFunctions {
 
 
 	//camera view
-	private static final float[] xyz = {2.0f,-3.5f,2.0000f};
-	private static final float[] hpr = {90.000f,-25.5000f,0.0000f};
+	private static final float[] xyz = {2.0f,-5.5f,2.0000f};
+	private static final float[] hpr = {90.000f,-5.5000f,0.0000f};
 	//world,space,body & geom
 	private static DWorld world;
 	private static DSpace space;

--- a/demo/src/main/java/org/ode4j/demo/DemoJointPR.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJointPR.java
@@ -84,8 +84,8 @@ class DemoJointPR extends dsFunctions {
 
 
 	//camera view
-	private static float[] xyz = {2.0f,-3.5f,2.0000f};
-	private static float[] hpr = {90.000f,-25.5000f,0.0000f};
+	private static final float[] xyz = {2.0f,-3.5f,2.0000f};
+	private static final float[] hpr = {90.000f,-25.5000f,0.0000f};
 	//world,space,body & geom
 	private static DWorld world;
 	private static DSpace space;
@@ -433,7 +433,7 @@ class DemoJointPR extends dsFunctions {
 		box1_space.add(box1);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 		contactgroup.destroy ();
 		space.destroy ();
 		world.destroy ();

--- a/demo/src/main/java/org/ode4j/demo/DemoJointPU.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJointPU.java
@@ -24,14 +24,8 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsElapsedTime;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
-import static org.ode4j.drawstuff.DrawStuff.dsStop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DRotation.dQFromAxisAndAngle;
 import static org.ode4j.ode.DRotation.dQMultiply1;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
@@ -178,8 +172,8 @@ public class DemoJointPU extends dsFunctions {
 
 
 	//camera view
-	private static float[] xyz = {6.0f,0.0f,6.0000f};
-	private static float[] hpr = {-180.000f,-25.5000f,0.0000f};
+	private static final float[] xyz = {6.0f,0.0f,6.0000f};
+	private static final float[] hpr = {-180.000f,-25.5000f,0.0000f};
 
 
 	//world,space,body & geom
@@ -743,7 +737,7 @@ public class DemoJointPU extends dsFunctions {
 
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		//delete joint;
 		//joint.DESTRUCTOR();  //TZ, not necessary, is deleted from dWorldDestroy()

--- a/demo/src/main/java/org/ode4j/demo/DemoJointPU.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJointPU.java
@@ -172,8 +172,8 @@ public class DemoJointPU extends dsFunctions {
 
 
 	//camera view
-	private static final float[] xyz = {6.0f,0.0f,6.0000f};
-	private static final float[] hpr = {-180.000f,-25.5000f,0.0000f};
+	private static final float[] xyz = {8.0f,0.0f,6.0000f};
+	private static final float[] hpr = {-180.000f,-5.5000f,0.0000f};
 
 
 	//world,space,body & geom

--- a/demo/src/main/java/org/ode4j/demo/DemoJoints.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJoints.java
@@ -987,8 +987,8 @@ public class DemoJoints extends dsFunctions {
 	// simulation stuff common to all the tests
 
 	// start simulation - set viewpoint
-	private static float[] xyz = {1.0382f,-1.0811f,1.4700f};
-	private static float[] hpr = {135.0000f,-19.5000f,0.0000f};
+	private static final float[] xyz = {1.0382f,-1.0811f,1.4700f};
+	private static final float[] hpr = {135.0000f,-19.5000f,0.0000f};
 	@Override
 	public void start()
 	{
@@ -1077,7 +1077,7 @@ public class DemoJoints extends dsFunctions {
 
 		// run simulation
 		if (cmd_graphics) {
-			dsSimulationLoop (args,640,480,this);
+			dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 		}
 		else {
 			for (int i=0; i < max_iterations; i++) step (false);

--- a/demo/src/main/java/org/ode4j/demo/DemoJoints.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoJoints.java
@@ -988,7 +988,7 @@ public class DemoJoints extends dsFunctions {
 
 	// start simulation - set viewpoint
 	private static final float[] xyz = {1.0382f,-1.0811f,1.4700f};
-	private static final float[] hpr = {135.0000f,-19.5000f,0.0000f};
+	private static final float[] hpr = {135.0000f,-5.5000f,0.0000f};
 	@Override
 	public void start()
 	{

--- a/demo/src/main/java/org/ode4j/demo/DemoKinematic.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoKinematic.java
@@ -270,8 +270,12 @@ public class DemoKinematic extends dsFunctions {
 	    OdeHelper.closeODE();
 	}
 
+	private static final float[] xyz = {8.0f,0.0f,4.0000f};
+	private static final float[] hpr = {-180.000f,-5.5000f,0.0000f};
+
 	@Override
-	public void start() {
+	public void start()	{
+		dsSetViewpoint (xyz,hpr);
 		// Nothing
 	}
 

--- a/demo/src/main/java/org/ode4j/demo/DemoKinematic.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoKinematic.java
@@ -264,8 +264,8 @@ public class DemoKinematic extends dsFunctions {
 	    hinge.attach(kbody, matraca);
 	    hinge.setAnchor(kx, ky, kz+1);
 	    hinge.setAxis(0, 0, 1);
-	    
-	    dsSimulationLoop (args, 640, 480, this);
+
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 	    
 	    OdeHelper.closeODE();
 	}

--- a/demo/src/main/java/org/ode4j/demo/DemoLayeredTrimeshHeightfield.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoLayeredTrimeshHeightfield.java
@@ -27,17 +27,8 @@ package org.ode4j.demo;
 import static org.ode4j.demo.BunnyGeom.IndexCount;
 import static org.ode4j.demo.BunnyGeom.Indices;
 import static org.ode4j.demo.BunnyGeom.Vertices;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawConvex;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawTriangle;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DMisc.dRandReal;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
 import static org.ode4j.ode.OdeConstants.dContactBounce;
@@ -243,8 +234,8 @@ class DemoLayeredTrimeshHeightfield extends dsFunctions {
 		}
 	}
 
-	private static float[] xyz = {1.1640f,-7.0079f,4.2600f};
-	private static float[] hpr = {95.5000f,-12.0000f,0.0000f};
+	private static final float[] xyz = {1.1640f,-7.0079f,4.2600f};
+	private static final float[] hpr = {95.5000f,-12.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override
@@ -690,7 +681,7 @@ class DemoLayeredTrimeshHeightfield extends dsFunctions {
 //	    world.setStepThreadingImplementation(threading.dThreadingImplementationGetFunctions(), threading);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 //	    threading.shutdownProcessing();//dThreadingImplementationShutdownProcessing(threading);
 //	    pool.freeThreadPool();

--- a/demo/src/main/java/org/ode4j/demo/DemoLayeredTrimeshHeightfield.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoLayeredTrimeshHeightfield.java
@@ -234,8 +234,8 @@ class DemoLayeredTrimeshHeightfield extends dsFunctions {
 		}
 	}
 
-	private static final float[] xyz = {1.1640f,-7.0079f,4.2600f};
-	private static final float[] hpr = {95.5000f,-12.0000f,0.0000f};
+	private static final float[] xyz = {1.1640f,-9.0079f,4.2600f};
+	private static final float[] hpr = {95.5000f,5.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override

--- a/demo/src/main/java/org/ode4j/demo/DemoMotion.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMotion.java
@@ -24,15 +24,8 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DMisc.dRandReal;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
 import static org.ode4j.ode.OdeConstants.dContactBounce;
@@ -245,8 +238,8 @@ public class DemoMotion extends dsFunctions {
 
 	// start simulation - set viewpoint
 
-	private static float[] xyz = {2.1106f,-1.3007f,2.f};
-	private static float[] hpr = {150.f,-13.5000f,0.0000f};
+	private static final float[] xyz = {2.1106f,-1.3007f,2.f};
+	private static final float[] hpr = {150.f,-13.5000f,0.0000f};
 
 	@Override
 	public void start()
@@ -528,7 +521,7 @@ public class DemoMotion extends dsFunctions {
 		platform.setCollideBits(~1l);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.destroy ();
 		space.destroy ();

--- a/demo/src/main/java/org/ode4j/demo/DemoMotor.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMotor.java
@@ -69,8 +69,8 @@ public class DemoMotor extends dsFunctions {
 
 	// start simulation - set viewpoint
 
-	private static final float[] xyz = {1.0382f,-1.0811f,1.4700f};
-	private static final float[] hpr = {135.0000f,-19.5000f,0.0000f};
+	private static final float[] xyz = {2.0382f,-2.0811f,1.4700f};
+	private static final float[] hpr = {135.0000f,19.5000f,0.0000f};
 	@Override
 	public void start()
 	{

--- a/demo/src/main/java/org/ode4j/demo/DemoMotor.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMotor.java
@@ -69,8 +69,8 @@ public class DemoMotor extends dsFunctions {
 
 	// start simulation - set viewpoint
 
-	private static float[] xyz = {1.0382f,-1.0811f,1.4700f};
-	private static float[] hpr = {135.0000f,-19.5000f,0.0000f};
+	private static final float[] xyz = {1.0382f,-1.0811f,1.4700f};
+	private static final float[] hpr = {135.0000f,-19.5000f,0.0000f};
 	@Override
 	public void start()
 	{
@@ -222,7 +222,7 @@ public class DemoMotor extends dsFunctions {
 		}
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.destroy();
 		space.destroy ();

--- a/demo/src/main/java/org/ode4j/demo/DemoMovingConvex.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMovingConvex.java
@@ -138,8 +138,8 @@ public class DemoMovingConvex extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {2.1640f,-3.3079f,1.7600f};
+	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 
@@ -421,7 +421,7 @@ public class DemoMovingConvex extends dsFunctions {
 		for (int i = 0; i < NUM; i++) obj[i] = new MyObject();
 
 		// run simulation
-		dsSimulationLoop( args,352,288,this );
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.destroy();
 		space.destroy();

--- a/demo/src/main/java/org/ode4j/demo/DemoMovingConvex.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMovingConvex.java
@@ -139,7 +139,7 @@ public class DemoMovingConvex extends dsFunctions {
 
 
 	private static final float[] xyz = {2.1640f,-3.3079f,1.7600f};
-	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] hpr = {125.5000f,-1.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 

--- a/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
@@ -134,7 +134,7 @@ public class DemoMovingTrimesh extends dsFunctions {
 
 
     // start simulation - set viewpoint
-	private static final float[] xyz = {2.1640f,-1.3079f,1.7600f};
+	private static final float[] xyz = {2.1640f,-2.3079f,1.7600f};
 	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
 
 	@Override
@@ -555,7 +555,7 @@ public class DemoMovingTrimesh extends dsFunctions {
 //	    world.setStepThreadingImplementation(threading.dThreadingImplementationGetFunctions(), threading);
 
 		// run simulation
-		dsSimulationLoop (args,600,600,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 //	    threading.shutdownProcessing();//dThreadingImplementationShutdownProcessing(threading);
 //	    pool.freeThreadPool();

--- a/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoMovingTrimesh.java
@@ -135,7 +135,7 @@ public class DemoMovingTrimesh extends dsFunctions {
 
     // start simulation - set viewpoint
 	private static final float[] xyz = {2.1640f,-2.3079f,1.7600f};
-	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] hpr = {125.5000f,-1.0000f,0.0000f};
 
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoOde.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoOde.java
@@ -1400,8 +1400,6 @@ void testReorthonormalize()
 	//****************************************************************************
 	// unit test
 
-	//#include <setjmp.h>
-
 	// static jmp_buf jump_buffer;
 
 	//	static void myDebug (int num, const char *msg, va_list ap)
@@ -1520,7 +1518,7 @@ void testReorthonormalize()
 		testCrossProduct();
 		testSetZero();
 		testNormalize3();
-		//testReorthonormalize();     ... not any more
+		//testReorthonormalize();     ... not anymore
 		testPlaneSpace();
 		testMatrixMultiply();
 		testSmallMatrixMultiply();

--- a/demo/src/main/java/org/ode4j/demo/DemoPiston.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoPiston.java
@@ -27,15 +27,8 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsElapsedTime;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
 import static org.ode4j.ode.OdeConstants.dContactApprox1;
 import static org.ode4j.ode.OdeConstants.dContactSlip1;
@@ -135,8 +128,8 @@ class DemoPiston extends dsFunctions {
 	//private static final double Mass2 = 8;
 
 	//camera view
-	private static float[] xyz = {2.0f,-3.5f,2.0000f};
-	private static float[] hpr = {90.000f,-25.5000f,0.0000f};
+	private static final float[] xyz = {2.0f,-5.5f,2.0000f};
+	private static final float[] hpr = {90.000f,-15.5000f,0.0000f};
 
 
 	//world,space,body & geom
@@ -726,7 +719,7 @@ class DemoPiston extends dsFunctions {
 
 
 		// run simulation
-		dsSimulationLoop (args,400,300,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		//delete joint;
 		contactgroup.destroy ();

--- a/demo/src/main/java/org/ode4j/demo/DemoPiston.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoPiston.java
@@ -129,7 +129,7 @@ class DemoPiston extends dsFunctions {
 
 	//camera view
 	private static final float[] xyz = {2.0f,-5.5f,2.0000f};
-	private static final float[] hpr = {90.000f,-15.5000f,0.0000f};
+	private static final float[] hpr = {90.000f,-1.5000f,0.0000f};
 
 
 	//world,space,body & geom

--- a/demo/src/main/java/org/ode4j/demo/DemoPlane2d.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoPlane2d.java
@@ -94,8 +94,8 @@ class DemoPlane2d extends dsFunctions {
 //	private static DJointGroup coll_contacts;
 
 
-	private static float[]    xyz = { 0.5f*STAGE_SIZE, 0.5f*STAGE_SIZE, 0.65f*STAGE_SIZE};
-	private static float[]    hpr = { 90.0f, -90.0f, 0 };
+	private static final float[]    xyz = { 0.5f*STAGE_SIZE, 0.5f*STAGE_SIZE, 0.85f*STAGE_SIZE};
+	private static final float[]    hpr = { 90.0f, -90.0f, 0 };
 
 	private static void cb_start ()	{
 		dsSetViewpoint (xyz, hpr);
@@ -336,7 +336,7 @@ class DemoPlane2d extends dsFunctions {
 
 		g_globals_ptr.coll_contacts = OdeHelper.createJointGroup();
 
-		dsSimulationLoop (args, 352,288,drawstuff_functions);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, drawstuff_functions);
 
 		OdeHelper.closeODE();
 	}

--- a/demo/src/main/java/org/ode4j/demo/DemoPlane2d.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoPlane2d.java
@@ -94,8 +94,8 @@ class DemoPlane2d extends dsFunctions {
 //	private static DJointGroup coll_contacts;
 
 
-	private static final float[]    xyz = { 0.5f*STAGE_SIZE, 0.5f*STAGE_SIZE, 0.85f*STAGE_SIZE};
-	private static final float[]    hpr = { 90.0f, -90.0f, 0 };
+	private static final float[]    xyz = { 0.5f*STAGE_SIZE, 0.5f*STAGE_SIZE, 1.85f*STAGE_SIZE};
+	private static final float[]    hpr = { 90.0f, -70.0f, 0 };
 
 	private static void cb_start ()	{
 		dsSetViewpoint (xyz, hpr);

--- a/demo/src/main/java/org/ode4j/demo/DemoRFriction.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoRFriction.java
@@ -24,12 +24,8 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.OdeConstants.dContactApprox1;
 import static org.ode4j.ode.OdeConstants.dContactRolling;
 
@@ -122,8 +118,8 @@ public class DemoRFriction extends dsFunctions {
 
 
 	// start simulation - set viewpoint
-	private static double[] xyz = {0,-3.0f,3.0f};
-	private static double[] hpr = {90.0000,-15.0000,0.0000};
+	private static final double[] xyz = {0,-3.0f,3.0f};
+	private static final double[] hpr = {90.0000,-15.0000,0.0000};
 
 	@Override
 	public void start() {
@@ -274,7 +270,7 @@ public class DemoRFriction extends dsFunctions {
 		reset();
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		clear();
 		OdeHelper.closeODE();

--- a/demo/src/main/java/org/ode4j/demo/DemoRFriction.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoRFriction.java
@@ -118,8 +118,8 @@ public class DemoRFriction extends dsFunctions {
 
 
 	// start simulation - set viewpoint
-	private static final double[] xyz = {0,-3.0f,3.0f};
-	private static final double[] hpr = {90.0000,-15.0000,0.0000};
+	private static final double[] xyz = {0,-7.0f,5.0f};
+	private static final double[] hpr = {90.0000,0.0000,0.0000};
 
 	@Override
 	public void start() {

--- a/demo/src/main/java/org/ode4j/demo/DemoSlider.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoSlider.java
@@ -56,8 +56,8 @@ class DemoSlider extends dsFunctions {
 
 
 	// start simulation - set viewpoint
-	private static float[] xyz= {1.0382f,-1.0811f,1.4700f};
-	private static float[] hpr= {135.0000f,-19.5000f,0.0000f};
+	private static final float[] xyz= {1.0382f,-1.0811f,1.4700f};
+	private static final float[] hpr= {135.0000f,-19.5000f,0.0000f};
 	
 	@Override
 	public void start()	{
@@ -168,7 +168,7 @@ class DemoSlider extends dsFunctions {
 		slider.setAxis (1,1,1);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		world.destroy ();
 		OdeHelper.closeODE();

--- a/demo/src/main/java/org/ode4j/demo/DemoSlider.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoSlider.java
@@ -57,7 +57,7 @@ class DemoSlider extends dsFunctions {
 
 	// start simulation - set viewpoint
 	private static final float[] xyz= {1.0382f,-1.0811f,1.4700f};
-	private static final float[] hpr= {135.0000f,-19.5000f,0.0000f};
+	private static final float[] hpr= {135.0000f,0.0000f,0.0000f};
 	
 	@Override
 	public void start()	{

--- a/demo/src/main/java/org/ode4j/demo/DemoSpace.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoSpace.java
@@ -129,8 +129,8 @@ class DemoSpace extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {2.1640f,-1.3079f,1.7600f};
+	private static final float[] hpr = {135.5000f,-17.0000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()
@@ -209,7 +209,7 @@ class DemoSpace extends dsFunctions {
 		init_test();
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		space.destroy ();
 		OdeHelper.closeODE();

--- a/demo/src/main/java/org/ode4j/demo/DemoSpace.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoSpace.java
@@ -129,8 +129,8 @@ class DemoSpace extends dsFunctions {
 	}
 
 
-	private static final float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static final float[] hpr = {135.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {3.1640f,-2.3079f,1.7600f};
+	private static final float[] hpr = {135.5000f,7.0000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoSpaceStress.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoSpaceStress.java
@@ -132,8 +132,8 @@ public class DemoSpaceStress extends dsFunctions {
 	}
 
 
-	private static final float[] xyz = {2.1640f,-1.3079f,3.7600f};
-	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {4.1640f,-3.3079f,3.7600f};
+	private static final float[] hpr = {135.5000f,0.0000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()	{

--- a/demo/src/main/java/org/ode4j/demo/DemoSpaceStress.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoSpaceStress.java
@@ -24,16 +24,8 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetSphereQuality;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DMisc.dRandReal;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
 import static org.ode4j.ode.OdeConstants.dContactBounce;
@@ -140,8 +132,8 @@ public class DemoSpaceStress extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {2.1640f,-1.3079f,3.7600f};
-	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {2.1640f,-1.3079f,3.7600f};
+	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()	{
@@ -456,7 +448,7 @@ public class DemoSpaceStress extends dsFunctions {
 		}
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		contactgroup.destroy();
 		space.destroy();

--- a/demo/src/main/java/org/ode4j/demo/DemoStep.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoStep.java
@@ -126,8 +126,8 @@ class DemoStep extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {2.6117f,-1.4433f,2.3700f};
-	private static float[] hpr = {151.5000f,-30.5000f,0.0000f};
+	private static final float[] xyz = {2.6117f,-1.4433f,2.3700f};
+	private static final float[] hpr = {151.5000f,-25.5000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()
@@ -178,7 +178,7 @@ class DemoStep extends dsFunctions {
 		createTest();
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		world.destroy();
 		OdeHelper.closeODE();

--- a/demo/src/main/java/org/ode4j/demo/DemoStep.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoStep.java
@@ -126,8 +126,8 @@ class DemoStep extends dsFunctions {
 	}
 
 
-	private static final float[] xyz = {2.6117f,-1.4433f,2.3700f};
-	private static final float[] hpr = {151.5000f,-25.5000f,0.0000f};
+	private static final float[] xyz = {3.6117f,-2.4433f,2.3700f};
+	private static final float[] hpr = {143.5000f,0.0000f,0.0000f};
 	// start simulation - set viewpoint
 	@Override
 	public void start()

--- a/demo/src/main/java/org/ode4j/demo/DemoTracks.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTracks.java
@@ -289,8 +289,8 @@ public class DemoTracks extends dsFunctions {
 
         dsSetSphereQuality(3);
     }
-    private static float[] xyz = {-5.9414f,-0.4804f,2.9800f};
-    private static float[] hpr = {32.5000f,-10.0000f,0.0000f};
+    private static final float[] xyz = {-7.9414f,-2.4804f,2.9800f};
+    private static final float[] hpr = {32.5000f,-10.0000f,0.0000f};
 
 
     private DNearCallback nearCallback = new DNearCallback() {
@@ -542,7 +542,7 @@ public class DemoTracks extends dsFunctions {
         OdeHelper.initODE2(0);
 
         // run demo
-        dsSimulationLoop (args, 800, 600, this);
+        dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
         OdeHelper.closeODE();
     }

--- a/demo/src/main/java/org/ode4j/demo/DemoTracks.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTracks.java
@@ -290,7 +290,7 @@ public class DemoTracks extends dsFunctions {
         dsSetSphereQuality(3);
     }
     private static final float[] xyz = {-7.9414f,-2.4804f,2.9800f};
-    private static final float[] hpr = {32.5000f,-10.0000f,0.0000f};
+    private static final float[] hpr = {32.5000f,0.0000f,0.0000f};
 
 
     private DNearCallback nearCallback = new DNearCallback() {

--- a/demo/src/main/java/org/ode4j/demo/DemoTransmission.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTransmission.java
@@ -24,14 +24,6 @@
  *************************************************************************/
 package org.ode4j.demo;
 
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawLine;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
-
 import org.ode4j.drawstuff.DrawStuff.DS_TEXTURE_NUMBER;
 import org.ode4j.drawstuff.DrawStuff.dsFunctions;
 import org.ode4j.math.DMatrix3;
@@ -51,6 +43,9 @@ import org.ode4j.ode.DTransmissionJoint;
 import org.ode4j.ode.DWorld;
 import org.ode4j.ode.OdeHelper;
 import org.ode4j.ode.OdeMath;
+
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 
 
 /**
@@ -163,8 +158,8 @@ public class DemoTransmission extends dsFunctions {
 		body2.setAngularVel(0, 0, 0);
 	}
 
-	private static double[] xyz = {1.15,-2.78,4.1};
-	private static double[] hpr = {105,-45.5,0};
+	private static final double[] xyz = {1.15,-2.78,4.1};
+	private static final double[] hpr = {105,-45.5,0};
 
 	@Override
 	public void start() {
@@ -420,7 +415,7 @@ public class DemoTransmission extends dsFunctions {
 		OdeHelper.initODE2(0);
 
 		// run simulation
-		dsSimulationLoop (args,800,600,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 		OdeHelper.closeODE();
 	}

--- a/demo/src/main/java/org/ode4j/demo/DemoTransmission.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTransmission.java
@@ -159,7 +159,7 @@ public class DemoTransmission extends dsFunctions {
 	}
 
 	private static final double[] xyz = {1.15,-2.78,4.1};
-	private static final double[] hpr = {105,-45.5,0};
+	private static final double[] hpr = {105,-30.5,0};
 
 	@Override
 	public void start() {

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimesh.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimesh.java
@@ -151,8 +151,8 @@ class DemoTrimesh extends dsFunctions {
 	}
 
 
-	private static final float[] xyz = {2.1640f,-4.3079f,1.7600f};
-	private static final float[] hpr = {115.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {4.1640f,-10.000f,6.00f};
+	private static final float[] hpr = {115.5000f,-5.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimesh.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimesh.java
@@ -151,8 +151,8 @@ class DemoTrimesh extends dsFunctions {
 	}
 
 
-	private static float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {2.1640f,-4.3079f,1.7600f};
+	private static final float[] hpr = {115.5000f,-17.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 
@@ -507,7 +507,7 @@ class DemoTrimesh extends dsFunctions {
 //	    world.setStepThreadingImplementation(threading.dThreadingImplementationGetFunctions(), threading);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 //	    threading.shutdownProcessing();//dThreadingImplementationShutdownProcessing(threading);
 //	    pool.freeThreadPool();

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimeshCollision.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimeshCollision.java
@@ -133,7 +133,7 @@ public class DemoTrimeshCollision extends dsFunctions {
     public void start() {
         // dAllocateODEDataForThread(dAllocateMaskAll);
         float[] xyz = {-8, 0, 5};
-        float[] hpr = {0.0f, -29.5000f, 0.0000f};
+        float[] hpr = {0.0f, -15.000f, 0.0000f};
         dsSetViewpoint(xyz, hpr);
         System.err.println("Press SPACE to reset the simulation1.");
     }

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimeshCollision.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimeshCollision.java
@@ -1,0 +1,377 @@
+/*************************************************************************
+ *                                                                       *
+ * Open Dynamics Engine, Copyright (C) 2001,2002 Russell L. Smith.       *
+ * All rights reserved.  Email: russ@q12.org   Web: www.q12.org          *
+ *                                                                       *
+ * This library is free software; you can redistribute it and/or         *
+ * modify it under the terms of EITHER:                                  *
+ *   (1) The GNU Lesser General Public License as published by the Free  *
+ *       Software Foundation; either version 2.1 of the License, or (at  *
+ *       your option) any later version. The text of the GNU Lesser      *
+ *       General Public License is included with this library in the     *
+ *       file LICENSE.TXT.                                               *
+ *   (2) The BSD-style license that is included with this library in     *
+ *       the file LICENSE-BSD.TXT.                                       *
+ *                                                                       *
+ * This library is distributed in the hope that it will be useful,       *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the files    *
+ * LICENSE.TXT and LICENSE-BSD.TXT for more details.                     *
+ *                                                                       *
+ *************************************************************************/
+package org.ode4j.demo;
+
+import org.ode4j.math.DMatrix3;
+import org.ode4j.math.DMatrix3C;
+import org.ode4j.math.DVector3;
+import org.ode4j.math.DVector3C;
+import org.ode4j.ode.*;
+import org.ode4j.ode.internal.DxMass;
+import org.ode4j.ode.internal.cpp4j.java.RefInt;
+
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.ode.OdeMath.*;
+
+// TriMesh collision demo.
+// Serves as a test for the collision of trimesh geometries.
+// By Davy (Dawei) Chen.
+public class DemoTrimeshCollision extends dsFunctions {
+
+    private static DWorld world;
+    private static DHashSpace space;
+    private static DJointGroup contactgroup;
+
+    // 2D Convex hulls to create the TriMesh geometries
+    private static final double[] HULL1 = {-1.000000, -35.000000, 1.000000, -34.000000, 5.000000, -31.000000, 16.000000, -20.000000, 16.000000, -11.000000, 5.000000, 0.000000, -1.000000, 3.000000, -7.000000, 4.000000, -13.000000, 3.000000, -16.000000, 2.000000, -20.000000, 0.000000, -24.000000, -4.000000, -26.000000, -8.000000, -27.000000, -12.000000, -27.000000, -15.000000, -27.000000, -19.000000, -26.000000, -23.000000, -24.000000, -27.000000, -20.000000, -31.000000, -16.000000, -34.000000};
+    private static final double[] HULL2 = {23.000000, 28.000000, 28.000000, 29.000000, 30.000000, 30.000000, 34.000000, 33.000000, 35.000000, 34.000000, 38.000000, 39.000000, 39.000000, 42.000000, 40.000000, 48.000000, 39.000000, 53.000000, 38.000000, 56.000000, 35.000000, 61.000000, 34.000000, 62.000000, 30.000000, 65.000000, 28.000000, 66.000000, 25.000000, 67.000000, 20.000000, 68.000000, 19.000000, 68.000000, 14.000000, 67.000000, 11.000000, 66.000000, 9.000000, 65.000000, 5.000000, 62.000000, 4.000000, 61.000000, 1.000000, 56.000000, 0.000000, 53.000000, 0.000000, 48.000000, 0.000000, 42.000000, 1.000000, 39.000000, 4.000000, 34.000000, 5.000000, 33.000000, 9.000000, 30.000000, 11.000000, 29.000000};
+    private static final double[] HULL3 = {-1.000000, -35.000000, 1.000000, -34.000000, 5.000000, -31.000000, 8.000000, -28.000000, 11.000000, -22.000000, 12.000000, -19.000000, 12.000000, -12.000000, 11.000000, -9.000000, 8.000000, -3.000000, 5.000000, 0.000000, -1.000000, 3.000000, -7.000000, 4.000000, -13.000000, 3.000000, -16.000000, 2.000000, -20.000000, 0.000000, -23.000000, -3.000000, -25.000000, -6.000000, -26.000000, -8.000000, -27.000000, -11.000000, -27.000000, -15.000000, -27.000000, -20.000000, -26.000000, -23.000000, -25.000000, -25.000000, -23.000000, -28.000000, -20.000000, -31.000000, -16.000000, -34.000000};
+    private static final double[] HULL4 = {-2.000000, -35.000000, 6.000000, -31.000000, 9.000000, -27.000000, 10.000000, -25.000000, 11.000000, -22.000000, 11.000000, -9.000000, 10.000000, -6.000000, 9.000000, -4.000000, 6.000000, 0.000000, -2.000000, 3.000000, -7.000000, 4.000000, -19.000000, 3.000000, -20.000000, 2.000000, -25.000000, -6.000000, -26.000000, -8.000000, -27.000000, -11.000000, -27.000000, -15.000000, -27.000000, -20.000000, -26.000000, -23.000000, -25.000000, -25.000000, -20.000000, -34.000000};
+    private static final double[] HULL5 = {-2.000000, -35.000000, 4.000000, -32.000000, 9.000000, -27.000000, 11.000000, -23.000000, 12.000000, -20.000000, 12.000000, -11.000000, 11.000000, -8.000000, 9.000000, -4.000000, 5.000000, 0.000000, -2.000000, 3.000000, -7.000000, 4.000000, -12.000000, 3.000000, -15.000000, 2.000000, -20.000000, 0.000000, -23.000000, -3.000000, -25.000000, -6.000000, -26.000000, -8.000000, -27.000000, -11.000000, -27.000000, -15.000000, -27.000000, -20.000000, -26.000000, -23.000000, -25.000000, -25.000000, -23.000000, -28.000000, -19.000000, -32.000000, -15.000000, -34.000000};
+    private static final double[] HULL6 = {-1.000000, -35.000000, 25.000000, -29.000000, 26.000000, -28.000000, 30.000000, -18.000000, 30.000000, -14.000000, 26.000000, -6.000000, 25.000000, -5.000000, -1.000000, 3.000000, -7.000000, 4.000000, -13.000000, 3.000000, -20.000000, 0.000000, -23.000000, -3.000000, -25.000000, -6.000000, -26.000000, -8.000000, -27.000000, -12.000000, -27.000000, -15.000000, -27.000000, -19.000000, -26.000000, -23.000000, -25.000000, -25.000000, -23.000000, -28.000000, -20.000000, -31.000000, -17.000000, -33.000000};
+
+    // Center points of the 2D Convex hulls
+    private final double[] CENTER1 = {-5.500000, -15.500000};
+    private final double[] CENTER2 = {20.000000, 48.000000};
+    private final double[] CENTER3 = {-7.500000, -15.500000};
+    private final double[] CENTER4 = {-8.000000, -15.500000};
+    private final double[] CENTER5 = {-7.500000, -15.500000};
+    private final double[] CENTER6 = {1.500000, -15.500000};
+
+    // Where to position the TriMeshes on the Ground plane
+    // In (X, Y) coordinates pairs
+    private final float[][] BODY_POSITIONS = { //[][2] = {
+            {-60.0f, -30.0f},
+            {0.0f, -30.0f},
+            {60.0f, -30.0f},
+            {-60.0f, 30.0f},
+            {0.0f, 30.0f},
+            {60.0f, 30.0f}
+    };
+
+    private static final double[][] HULLS = {HULL1, HULL2, HULL3, HULL4, HULL5, HULL6};
+    private final int[] HULL_SIZES = {
+            HULL1.length / 2, HULL2.length / 2, HULL3.length / 2, HULL4.length / 2, HULL5.length / 2, HULL6.length / 2
+    };
+    private final double[][] CENTERS = {CENTER1, CENTER2, CENTER3, CENTER4, CENTER5, CENTER6};
+    private static final int HULLS_COUNT = HULLS.length;
+
+    private final float TRIMESH_HEIGHT = 2.0f;
+
+    private static final float[][] odeVerts = new float[HULLS_COUNT][]; // *odeVerts[HULLS_COUNT];
+    private static final int[][] odeInds = new int[HULLS_COUNT][];// *odeInds[HULLS_COUNT];
+    private static final int[] odeIndsCount = new int[HULLS_COUNT];
+
+    private static final DTriMeshData[] triMeshDataId = new DTriMeshData[HULLS_COUNT];
+    private static final DGeom[] triMeshId = new DGeom[HULLS_COUNT];
+    private static final DBody[] bodyId = new DBody[HULLS_COUNT];
+
+
+    private final DGeom.DNearCallback nearCallback = new DGeom.DNearCallback() {
+        @Override
+        public void call(Object data, DGeom o1, DGeom o2) {
+            nearCallback(data, o1, o2);
+        }
+    };
+
+    // this is called by dSpaceCollide when two objects in space are
+    // potentially colliding.
+
+    private void nearCallback(Object data, DGeom o1, DGeom o2) {
+        if (o1.isSpace() || o2.isSpace()) {
+            // colliding a space with something
+            OdeHelper.spaceCollide2(o1, o2, data, nearCallback);
+            // Note we do not want to test intersections within a space,
+            // only between spaces.
+            return;
+        }
+
+        final int N = 32;
+        DContactBuffer contacts = new DContactBuffer(N);   // up to MAX_CONTACTS contacts per box-box
+        int n = OdeHelper.collide(o1, o2, N, contacts.getGeomBuffer());
+        if (n > 0) {
+            for (int i = 0; i < n; i++) {
+                DContact contact = contacts.get(i);
+                contact.surface.slip1 = 0.7;
+                contact.surface.slip2 = 0.7;
+                contact.surface.mode = dContactSoftERP | dContactSoftCFM | dContactApprox1 | dContactSlip1 | dContactSlip2;
+                // Friction effect, if set to dInfinity, objects would be unmovable
+                contact.surface.mu = 0.0f;
+                contact.surface.soft_erp = 0.50;
+                contact.surface.soft_cfm = 0.03;
+                DJoint c = OdeHelper.createContactJoint(world, contactgroup, contact);
+                c.attach
+                        (
+                                contact.geom.g1.getBody(),
+                                contact.geom.g2.getBody()
+                        );
+            }
+        }
+    }
+
+    // start simulation - set viewpoint
+    @Override
+    public void start() {
+        // dAllocateODEDataForThread(dAllocateMaskAll);
+        float[] xyz = {-8, 0, 5};
+        float[] hpr = {0.0f, -29.5000f, 0.0000f};
+        dsSetViewpoint(xyz, hpr);
+        System.err.println("Press SPACE to reset the simulation1.");
+    }
+
+    void reset() {
+        for (int i = 0; i < HULLS_COUNT; i++) {
+            bodyId[i].setPosition(
+                    BODY_POSITIONS[i][0] * 0.05,
+                    BODY_POSITIONS[i][1] * 0.05,
+                    0.0f);
+
+            DMatrix3 R = new DMatrix3();
+            dRFromAxisAndAngle(R,
+                    1.0f,
+                    1.0f,
+                    1.0f,
+                    0.0f);
+            bodyId[i].setRotation(R);
+
+            // Enable the body as it might have been auto-disabled
+            bodyId[i].enable();
+        }
+    }
+
+    // called when a key pressed
+    @Override
+    public void command(char cmd) {
+        switch (cmd) {
+            case ' ':
+                reset();
+                break;
+            default:
+                break;
+        }
+    }
+
+    @Override
+    public void step(boolean pause) {
+        double simstep = 1 / 240.0;
+        double dt = dsElapsedTime();
+
+        int nrofsteps = (int) Math.ceil(dt / simstep);
+        nrofsteps = nrofsteps > 8 ? 8 : nrofsteps;
+
+        for (int i = 0; i < nrofsteps && !pause; i++) {
+            // Add force to TriMesh bodies, and make them gather towards world center
+            for (int j = 0; j < HULLS_COUNT; j++) {
+                DVector3C pos = bodyId[j].getPosition();
+                // Calculate force tensity according to distance from world center
+                double length = pos.length(); //dCalcVectorLengthSquare3(pos);
+                DVector3 pos1 = new DVector3();
+                dCopyVector3(pos1, pos);
+                dNegateVector3(pos1);
+                dNormalize3(pos1);
+                pos1.scale(5.0f * length);
+
+                bodyId[j].addForce(pos1);
+            }
+
+            space.collide(null, nearCallback);
+            world.quickStep(simstep);
+            contactgroup.empty();
+        }
+
+        dsSetColor(1, 1, 1);
+        for (int i = 0; i < HULLS_COUNT; i++) {
+            DVector3C Pos = bodyId[i].getPosition();
+            DMatrix3C Rot = bodyId[i].getRotation();
+
+            // Draw TriMeshes
+            if (odeVerts != null) // TODO?
+            {
+                for (int j = 0; j < odeIndsCount[i] / 3; j++) {
+                    DVector3C v0 = new DVector3(
+                            odeVerts[i][odeInds[i][j * 3 + 0] * 3],
+                            odeVerts[i][odeInds[i][j * 3 + 0] * 3 + 1],
+                            odeVerts[i][odeInds[i][j * 3 + 0] * 3 + 2]
+                    );
+                    DVector3C v1 = new DVector3(
+                            odeVerts[i][odeInds[i][j * 3 + 1] * 3],
+                            odeVerts[i][odeInds[i][j * 3 + 1] * 3 + 1],
+                            odeVerts[i][odeInds[i][j * 3 + 1] * 3 + 2]
+                    );
+                    DVector3C v2 = new DVector3(
+                            odeVerts[i][odeInds[i][j * 3 + 2] * 3],
+                            odeVerts[i][odeInds[i][j * 3 + 2] * 3 + 1],
+                            odeVerts[i][odeInds[i][j * 3 + 2] * 3 + 2]
+                    );
+                    dsDrawTriangle(Pos, Rot, v0, v1, v2, true);
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        new DemoTrimeshCollision().demo(args);
+    }
+
+    private void demo(String[] args) {
+        DMass m = new DxMass();
+
+        // setup pointers to drawstuff callback functions
+//    dsFunctions fn;
+//    fn.version = DS_VERSION;
+//    fn.start = &start;
+//    fn.step = &simLoop;
+//    fn.command = &command;
+//    fn.stop = 0;
+//    fn.path_to_textures = DRAWSTUFF_TEXTURE_PATH;
+
+        // create world
+        OdeHelper.initODE2(0);
+        world = OdeHelper.createWorld();
+        space = OdeHelper.createHashSpace(null);
+        space.setLevels(-3, 5);
+        OdeHelper.createPlane(space, 0, 0, 1, 0);    // Add a ground plane.
+
+        contactgroup = OdeHelper.createJointGroup();
+        world.setGravity(0, 0, -1);
+        world.setQuickStepNumIterations(32);
+        world.setContactMaxCorrectingVel(40);
+        world.setMaxAngularSpeed(62.8);
+        world.setERP(0.7);
+        world.setQuickStepW(0.75); // For increased stability.
+
+        world.setAutoDisableFlag(true);
+        world.setAutoDisableLinearThreshold(0.01);
+        world.setAutoDisableAngularThreshold(0.03);
+        world.setAutoDisableTime(0.15f);
+
+        // Generate TriMesh geometries and bodies
+        for (int i = 0; i < HULLS_COUNT; i++) {
+            int hullSize = HULL_SIZES[i];
+            // Vertices
+            int odeVertsCount1 = hullSize * 3 * 2;
+            int odeVertsCount = odeVertsCount1 + 2 * 3;
+            odeVerts[i] = new float[odeVertsCount];
+            for (int j = 0; j < hullSize; j++) {
+                // Bottom layer
+                odeVerts[i][j * 3] = (float) ((HULLS[i][j * 2] - CENTERS[i][0]) * 0.05f);
+                odeVerts[i][j * 3 + 1] = (float) ((HULLS[i][j * 2 + 1] - CENTERS[i][1]) * 0.05f);
+                odeVerts[i][j * 3 + 2] = 0.0f;
+                // Top layer
+                odeVerts[i][(hullSize + j) * 3] = (float) ((HULLS[i][j * 2] - CENTERS[i][0]) * 0.05f);
+                odeVerts[i][(hullSize + j) * 3 + 1] = (float) ((HULLS[i][j * 2 + 1] - CENTERS[i][1]) * 0.05f);
+                odeVerts[i][(hullSize + j) * 3 + 2] = TRIMESH_HEIGHT;
+            }
+            // Center vertex on bottom plane
+            odeVerts[i][odeVertsCount1] = 0.0f;
+            odeVerts[i][odeVertsCount1 + 1] = 0.0f;
+            odeVerts[i][odeVertsCount1 + 2] = 0.0f;
+            // Center vertex on top plane
+            odeVerts[i][odeVertsCount1 + 3] = 0.0f;
+            odeVerts[i][odeVertsCount1 + 3 + 1] = 0.0f;
+            odeVerts[i][odeVertsCount1 + 3 + 2] = TRIMESH_HEIGHT;
+            // Indices
+            int odeIndsCount1 = hullSize * 6;
+            odeIndsCount[i] = odeIndsCount1 * 2;
+            odeInds[i] = new int[odeIndsCount[i]];
+            for (int j = 0; j < hullSize; j++) {
+                // Wall triangles
+                // Wrap around index
+                int n1 = j + 1 < hullSize ? j + 1 : 0;
+                int n2 = hullSize + n1;
+                odeInds[i][j * 6] = j;
+                odeInds[i][j * 6 + 1] = n1;
+                odeInds[i][j * 6 + 2] = hullSize + j;
+                odeInds[i][j * 6 + 3] = hullSize + j;
+                odeInds[i][j * 6 + 4] = n1;
+                odeInds[i][j * 6 + 5] = n2;
+                // Bottom and Top triangles
+                odeInds[i][odeIndsCount1 + j * 6] = j;
+                odeInds[i][odeIndsCount1 + j * 6 + 1] = n1;
+                odeInds[i][odeIndsCount1 + j * 6 + 2] = hullSize * 2;
+                odeInds[i][odeIndsCount1 + j * 6 + 3] = hullSize + j;
+                odeInds[i][odeIndsCount1 + j * 6 + 4] = n2;
+                odeInds[i][odeIndsCount1 + j * 6 + 5] = hullSize * 2 + 1;
+            }
+
+            bodyId[i] = OdeHelper.createBody(world);
+            bodyId[i].setPosition(
+                    BODY_POSITIONS[i][0] * 0.05,
+                    BODY_POSITIONS[i][1] * 0.05,
+                    0.0f);
+
+            DMatrix3 R = new DMatrix3();
+            dRFromAxisAndAngle(R,
+                    1.0f,
+                    1.0f,
+                    1.0f,
+                    0.0f);
+            bodyId[i].setRotation(R);
+
+            RefInt index = new RefInt(0);
+            bodyId[i].setData(index);
+
+            DMass m1 = OdeHelper.createMass();
+            double[] sides = new double[3];
+            sides[0] = 3.0f;
+            sides[1] = 3.0f;
+            sides[2] = 3.0f;
+            final float DENSITY = 1.0f;
+            m1.setBox(DENSITY, sides[0], sides[1], sides[2]);
+
+            bodyId[i].setMass(m1);
+            // Make bodies less bouncy
+            bodyId[i].setLinearDamping(0.1);
+            bodyId[i].setAngularDamping(0.1);
+
+            triMeshDataId[i] = OdeHelper.createTriMeshData();
+            triMeshDataId[i].build(odeVerts[i], odeInds[i]);
+            triMeshDataId[i].preprocess2((1 << DTriMeshData.dTRIDATAPREPROCESS_BUILD.FACE_ANGLES), null);
+
+            triMeshId[i] = OdeHelper.createTriMesh(space, triMeshDataId[i], null, null, null);
+            triMeshId[i].setBody(bodyId[i]);
+        }
+
+        // run simulation
+        dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
+
+        for (int i = 0; i < HULLS_COUNT; i++) {
+            triMeshDataId[i].destroy();
+            triMeshId[i].destroy();
+            bodyId[i].destroy();
+
+            odeVerts[i] = null;
+            odeInds[i] = null;
+        }
+
+        contactgroup.empty();
+        contactgroup.destroy();
+        space.destroy();
+        world.destroy();
+        OdeHelper.closeODE();
+    }
+
+    @Override
+    public void stop() {
+        // Nothing
+    }
+}

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimeshHeightfield.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimeshHeightfield.java
@@ -190,8 +190,8 @@ class DemoTrimeshHeightfield extends dsFunctions {
 		}
 	}
 
-	private static final float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {4.1640f,-5.3079f,1.7600f};
+	private static final float[] hpr = {135.5000f,10.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override

--- a/demo/src/main/java/org/ode4j/demo/DemoTrimeshHeightfield.java
+++ b/demo/src/main/java/org/ode4j/demo/DemoTrimeshHeightfield.java
@@ -27,17 +27,8 @@ package org.ode4j.demo;
 import static org.ode4j.demo.BunnyGeom.IndexCount;
 import static org.ode4j.demo.BunnyGeom.Indices;
 import static org.ode4j.demo.BunnyGeom.Vertices;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawBox;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCapsule;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawConvex;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawCylinder;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawSphere;
-import static org.ode4j.drawstuff.DrawStuff.dsDrawTriangle;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColor;
-import static org.ode4j.drawstuff.DrawStuff.dsSetColorAlpha;
-import static org.ode4j.drawstuff.DrawStuff.dsSetTexture;
-import static org.ode4j.drawstuff.DrawStuff.dsSetViewpoint;
-import static org.ode4j.drawstuff.DrawStuff.dsSimulationLoop;
+import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.DrawStuff.DS_SIMULATION_DEFAULT_HEIGHT;
 import static org.ode4j.ode.DMisc.dRandReal;
 import static org.ode4j.ode.DRotation.dRFromAxisAndAngle;
 import static org.ode4j.ode.OdeConstants.dContactBounce;
@@ -199,8 +190,8 @@ class DemoTrimeshHeightfield extends dsFunctions {
 		}
 	}
 
-	private static float[] xyz = {2.1640f,-1.3079f,1.7600f};
-	private static float[] hpr = {125.5000f,-17.0000f,0.0000f};
+	private static final float[] xyz = {2.1640f,-1.3079f,1.7600f};
+	private static final float[] hpr = {125.5000f,-17.0000f,0.0000f};
 
 	// start simulation - set viewpoint
 	@Override
@@ -634,7 +625,7 @@ class DemoTrimeshHeightfield extends dsFunctions {
 //	    world.setStepThreadingImplementation(threading.dThreadingImplementationGetFunctions(), threading);
 
 		// run simulation
-		dsSimulationLoop (args,640,480,this);
+		dsSimulationLoop(args, DS_SIMULATION_DEFAULT_WIDTH, DS_SIMULATION_DEFAULT_HEIGHT, this);
 
 //	    threading.shutdownProcessing();//dThreadingImplementationShutdownProcessing(threading);
 //	    pool.freeThreadPool();

--- a/demo/src/main/java/org/ode4j/drawstuff/DrawStuff.java
+++ b/demo/src/main/java/org/ode4j/drawstuff/DrawStuff.java
@@ -162,7 +162,7 @@ public class DrawStuff {
 	 * @param args Reserved for future use
 	 */
 	// DS_API
-	void dsInitializeConsole(String[] args) {
+	public static void dsInitializeConsole(String[] args) {
 		get().dsInitializeConsole(args);
 	}
 
@@ -175,7 +175,7 @@ public class DrawStuff {
 	 * The function is to be called only if @fn dsSimulationLoop is not invoked.
 	 */
 	// DS_API
-	void dsFinalizeConsole() {
+	public static void dsFinalizeConsole() {
 		get().dsFinalizeConsole();
 	}
 

--- a/demo/src/main/java/org/ode4j/drawstuff/DrawStuff.java
+++ b/demo/src/main/java/org/ode4j/drawstuff/DrawStuff.java
@@ -152,6 +152,35 @@ public class DrawStuff {
 	  }
 //	} dsFunctions;
 
+	/**
+	 * Initializes output console.
+	 * <p>
+	 * The function performs initialization routines for the application console.
+	 * <p>
+	 * The function is to be called only if @fn dsSimulationLoop is not invoked.
+	 *
+	 * @param args Reserved for future use
+	 */
+	// DS_API
+	void dsInitializeConsole(String[] args) {
+		get().dsInitializeConsole(args);
+	}
+
+
+	/**
+	 * Finalizes output console.
+	 * <p>
+	 * The function performs all the necessary finalization for the application console.
+	 * <p>
+	 * The function is to be called only if @fn dsSimulationLoop is not invoked.
+	 */
+	// DS_API
+	void dsFinalizeConsole() {
+		get().dsFinalizeConsole();
+	}
+
+	public static final int DS_SIMULATION_DEFAULT_WIDTH = 1280;
+	public static final int DS_SIMULATION_DEFAULT_HEIGHT = 720;
 
 	/**
 	 * Does the complete simulation.
@@ -222,10 +251,10 @@ public class DrawStuff {
 	 */
 	//DS_API 
 //	public static  void dsSetViewpoint (float xyz[3], float hpr[3]);
-	public static void dsSetViewpoint (float xyz[], float hpr[]) {
+	public static void dsSetViewpoint (final float[] xyz, final float[] hpr) {
 		get().dsSetViewpoint(xyz, hpr);
 	}
-	public static void dsSetViewpoint (double xyz[], double hpr[]) {
+	public static void dsSetViewpoint (final double[] xyz, final double[] hpr) {
 		get().dsSetViewpoint(toFloat(xyz), toFloat(hpr));
 	}
 

--- a/demo/src/main/java/org/ode4j/drawstuff/internal/DrawStuffApi.java
+++ b/demo/src/main/java/org/ode4j/drawstuff/internal/DrawStuffApi.java
@@ -28,6 +28,10 @@ import org.ode4j.math.DVector3C;
 
 public interface DrawStuffApi {
 
+	void dsInitializeConsole(String[] args);
+
+	void dsFinalizeConsole();
+
 	public abstract void dsSimulationLoop(String[] args, int window_width,
 			int window_height, dsFunctions fn);
 
@@ -69,7 +73,7 @@ public interface DrawStuffApi {
 
 	public abstract void dsDrawLine(final DVector3C pos1, final DVector3C pos2);
 
-	public abstract void dsSetViewpoint(float[] xyz, float[] hpr);
+	public abstract void dsSetViewpoint(final float[] xyz, final float[] hpr);
 
 	public abstract void dsGetViewpoint(float[] xyz, float[] hpr);
 

--- a/demo/src/main/java/org/ode4j/drawstuff/internal/DrawStuffGL.java
+++ b/demo/src/main/java/org/ode4j/drawstuff/internal/DrawStuffGL.java
@@ -1434,13 +1434,13 @@ public class DrawStuffGL extends LwJGL implements DrawStuffApi {
 
 	/*extern */
 	// void dsInitializeConsole(int argc, char **argv)
-	void dsInitializeConsole(String[] args)
+	public void dsInitializeConsole(String[] args)
 	{
 		dsPlatformInitializeConsole();
 	}
 
 	/*extern */
-	void dsFinalizeConsole()
+	public void dsFinalizeConsole()
 	{
 		dsPlatformFinalizeConsole();
 	}
@@ -1504,7 +1504,7 @@ public class DrawStuffGL extends LwJGL implements DrawStuffApi {
 	//extern "C" 
 	//void dsSetViewpoint (float xyz[3], float hpr[3])
 	@Override
-	public void dsSetViewpoint (float[] xyz, float[] hpr)
+	public void dsSetViewpoint (final float[] xyz, final float[] hpr)
 	{
 		if (current_state < 1) dsError ("dsSetViewpoint() called before simulation started");
 		if (xyz!=null) {

--- a/demo/src/main/java/org/ode4j/drawstuff/internal/DrawStuffGL.java
+++ b/demo/src/main/java/org/ode4j/drawstuff/internal/DrawStuffGL.java
@@ -44,6 +44,7 @@ import org.ode4j.math.DVector3;
 import org.ode4j.math.DVector3C;
 
 import static org.ode4j.drawstuff.DrawStuff.*;
+import static org.ode4j.drawstuff.internal.Internal.MOTIONMODE.*;
 
 /**
  *
@@ -1006,18 +1007,18 @@ public class DrawStuffGL extends LwJGL implements DrawStuffApi {
 	void dsMotion (int mode, int deltax, int deltay)
 	{
 		float side = 0.01f * deltax;
-		float fwd = (mode==4) ? (0.01f * deltay) : 0.0f;
+		float fwd = (mode==dsMOTIONMODE_RBUTTONDOWN.v) ? (0.01f * deltay) : 0.0f;
 		float s = (float) Math.sin (view_hpr[0]*DEG_TO_RAD);
 		float c = (float) Math.cos (view_hpr[0]*DEG_TO_RAD);
 
-		if (mode==1) {
+		if (mode==dsMOTIONMODE_LBUTTONDOWN.v) {
 			view_hpr[0] += deltax * 0.5f;
 			view_hpr[1] += deltay * 0.5f;
 		}
 		else {
 			view_xyz[0] += -s*side + c*fwd;
 			view_xyz[1] += c*side + s*fwd;
-			if (mode==2 || mode==5) view_xyz[2] += 0.01f * deltay;
+			if (mode==dsMOTIONMODE_MBUTTONDOWN.v || mode==(dsMOTIONMODE_LBUTTONDOWN.v | dsMOTIONMODE_RBUTTONDOWN.v)) view_xyz[2] += 0.01f * deltay;
 		}
 		wrapCameraAngles();
 	}
@@ -1431,9 +1432,32 @@ public class DrawStuffGL extends LwJGL implements DrawStuffApi {
 		GL11.glDepthRange (0,0.9999);
 	}
 
+	/*extern */
+	// void dsInitializeConsole(int argc, char **argv)
+	void dsInitializeConsole(String[] args)
+	{
+		dsPlatformInitializeConsole();
+	}
 
-	
-	//extern "C" 
+	/*extern */
+	void dsFinalizeConsole()
+	{
+		dsPlatformFinalizeConsole();
+	}
+
+	/*extern */
+	void dsPlatformInitializeConsole()
+	{
+		// Do nothing
+	}
+
+	/*extern */
+	void dsPlatformFinalizeConsole()
+	{
+		// Do nothing
+	}
+
+	/*extern */
 	/**
 	 * If you filter out arguments beforehand, simply set them to "".
 	 * @see org.ode4j.drawstuff.DrawStuff#dsSimulationLoop(String[], int, int, dsFunctions)

--- a/demo/src/main/java/org/ode4j/drawstuff/internal/DrawStuffNull.java
+++ b/demo/src/main/java/org/ode4j/drawstuff/internal/DrawStuffNull.java
@@ -78,6 +78,16 @@ public class DrawStuffNull implements DrawStuffApi {
 	}
 
 	@Override
+	public void dsInitializeConsole(String[] args) {
+		// Nothing
+	}
+
+	@Override
+	public void dsFinalizeConsole()	{
+		// Nothing
+	}
+
+	@Override
 	public void dsSimulationLoop(String[] args, int window_width,
 			int window_height, dsFunctions fn) {
 		// look for flags that apply to us
@@ -194,7 +204,7 @@ public class DrawStuffNull implements DrawStuffApi {
 	}
 
 	@Override
-	public void dsSetViewpoint(float[] xyz, float[] hpr) {
+	public void dsSetViewpoint(final float[] xyz, final float[] hpr) {
 		// Nothing
 	}
 

--- a/demo/src/main/java/org/ode4j/drawstuff/internal/Internal.java
+++ b/demo/src/main/java/org/ode4j/drawstuff/internal/Internal.java
@@ -34,6 +34,9 @@ abstract class Internal {
 
 	// supplied by platform specific code
 
+	abstract void dsPlatformInitializeConsole();
+	abstract void dsPlatformFinalizeConsole();
+
 	abstract void dsPlatformSimLoop (int window_width, int window_height,
 			dsFunctions fn, boolean initial_pause);
 
@@ -43,6 +46,16 @@ abstract class Internal {
 	abstract void dsStartGraphics (int width, int height, dsFunctions fn);
 	abstract void dsDrawFrame (int width, int height, dsFunctions fn, boolean pause);
 	abstract void dsStopGraphics();
+
+	enum MOTIONMODE	{
+		dsMOTIONMODE_LBUTTONDOWN ( 0x00000001),
+		dsMOTIONMODE_MBUTTONDOWN ( 0x00000002),
+		dsMOTIONMODE_RBUTTONDOWN ( 0x00000004);
+		final int v;
+		MOTIONMODE(int v) {
+			this.v = v;
+		}
+	}
 	abstract void dsMotion (int mode, int deltax, int deltay);
 
 	abstract boolean dsGetShadows();


### PR DESCRIPTION
Port updates until 0.16.6 (previous: 0.16.2/.3) ([#147](https://github.com/tzaeschke/ode4j/pull/147)). This includes:
- Fixed porting bug in `dxQuickStepIsland_Stage4LCP_IterationStep`:
    `fc_ptr2P = b2 * CFE__MAX;` was declared `int` and thus overwrote
    the existing variable.
- New box-plane collider
- new DemoTrimeshCollision
- new API method in DPUJoint: `void addTorques (double torque1, double torque2);`
- Cleanup:
    - Lots of typos fixed
    - Demos have new default window size and some a new default view position
    - DemoFeedback has changed parameters.
    - Fix? DxHeightfield.dCollideHeightfieldZone() cleaned up
    - Fix? DLCP swapping updated
- Skipped:
    - quickstep.cpp / dxQuickStepIsland (allowedThreads != 1)
    - threading_impl*, threading_pool*


TODO verify
- Should dxQuickStepIsland_Stage4LCP_IterationStartSingleThread()
- get the same updates as dxQuickStepIsland_Stage4LCP_IterationStart()?
- Multithreading: verify calculateThreadingLimitedThreadCount()
